### PR TITLE
Disable Express X-Powered-By header

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -10,6 +10,9 @@ import { join } from 'node:path';
 const browserDistFolder = join(import.meta.dirname, '../browser');
 
 const app = express();
+
+// Disable the X-Powered-By header to avoid leaking framework details.
+app.disable('x-powered-by');
 const angularApp = new AngularNodeAppEngine();
 
 /**


### PR DESCRIPTION
## Summary
- disable the Express X-Powered-By response header to avoid framework disclosure warnings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ff7cdd6748832586cb4523412592c7