### PR TITLE
Add keyboard shortcuts to confirm or cancel annotation editors

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -35,7 +35,8 @@
 
       <!-- NUEVA ANOTACIÓN -->
       <div *ngIf="preview() as p" class="annotation-editor" #previewEditor [style.left.px]="p.x*scale()"
-        [style.top.px]="pdfCanvasRef!.nativeElement.height - p.y*scale()">
+        [style.top.px]="pdfCanvasRef!.nativeElement.height - p.y*scale()" (keydown.enter)="confirmPreview()"
+        (keydown.escape)="cancelPreview()">
         <input type="text" [(ngModel)]="p.value" placeholder="Texto..." />
         <input type="number" [(ngModel)]="p.size" min="8" max="72" />
         <input type="color" [(ngModel)]="p.color" />
@@ -45,7 +46,8 @@
 
       <!-- EDITAR ANOTACIÓN -->
       <div *ngIf="editing() as e" class="annotation-editor editing" [style.left.px]="e.coord.x*scale()"
-        [style.top.px]="pdfCanvasRef!.nativeElement.height - e.coord.y*scale()">
+        [style.top.px]="pdfCanvasRef!.nativeElement.height - e.coord.y*scale()" (keydown.enter)="confirmEdit()"
+        (keydown.escape)="cancelEdit()">
         <input type="text" [(ngModel)]="e.coord.value" placeholder="Texto..." />
         <input type="number" [(ngModel)]="e.coord.size" min="8" max="72" />
         <input type="color" [(ngModel)]="e.coord.color" />


### PR DESCRIPTION
## Summary
- allow confirming new annotations with the Enter key
- allow cancelling annotation editors with the Escape key

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68ff7ef8dc188325822f415209545f1c