### PR TITLE
Normalize annotation colors to hex

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -2,7 +2,8 @@
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
   "version": 1,
   "cli": {
-    "packageManager": "npm"
+    "packageManager": "npm",
+    "analytics": false
   },
   "newProjectRoot": "projects",
   "projects": {

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -37,23 +37,64 @@
       <div *ngIf="preview() as p" class="annotation-editor" #previewEditor [style.left.px]="p.x*scale()"
         [style.top.px]="pdfCanvasRef!.nativeElement.height - p.y*scale()" (keydown.enter)="confirmPreview()"
         (keydown.escape)="cancelPreview()">
-        <input type="text" [(ngModel)]="p.value" placeholder="Texto..." />
-        <input type="number" [(ngModel)]="p.size" min="8" max="72" />
-        <input type="color" [(ngModel)]="p.color" />
-        <button (click)="confirmPreview()">✅</button>
-        <button (click)="cancelPreview()">❌</button>
+        <label class="field">
+          <span class="field-label">Texto</span>
+          <input type="text" [(ngModel)]="p.value" placeholder="Texto..." />
+        </label>
+        <label class="field field-small">
+          <span class="field-label">Tamaño</span>
+          <input type="number" [(ngModel)]="p.size" min="8" max="72" />
+        </label>
+        <div class="color-section">
+          <span class="field-label">Color</span>
+          <div class="color-row">
+            <input type="color" [(ngModel)]="p.color" (ngModelChange)="onPreviewColorPicker($event)" />
+            <div class="color-inputs">
+              <input type="text" [ngModel]="previewHexInput()" (ngModelChange)="setPreviewColorFromHex($event)"
+                [ngModelOptions]="{ standalone: true }" placeholder="#5eead4" />
+              <input type="text" [ngModel]="previewRgbInput()" (ngModelChange)="setPreviewColorFromRgb($event)"
+                [ngModelOptions]="{ standalone: true }" placeholder="rgb(94, 234, 212)" />
+            </div>
+          </div>
+          <small class="color-hint">Selecciona un color, escribe un HEX o un RGB. El JSON siempre exportará el color en
+            HEX.</small>
+        </div>
+        <div class="editor-actions">
+          <button (click)="confirmPreview()">✅</button>
+          <button (click)="cancelPreview()">❌</button>
+        </div>
       </div>
 
       <!-- EDITAR ANOTACIÓN -->
       <div *ngIf="editing() as e" class="annotation-editor editing" [style.left.px]="e.coord.x*scale()"
         [style.top.px]="pdfCanvasRef!.nativeElement.height - e.coord.y*scale()" (keydown.enter)="confirmEdit()"
         (keydown.escape)="cancelEdit()">
-        <input type="text" [(ngModel)]="e.coord.value" placeholder="Texto..." />
-        <input type="number" [(ngModel)]="e.coord.size" min="8" max="72" />
-        <input type="color" [(ngModel)]="e.coord.color" />
-        <button (click)="confirmEdit()">✅</button>
-        <button (click)="cancelEdit()">❌</button>
-        <button class="btn-delete" (click)="deleteAnnotation()">🗑️</button>
+        <label class="field">
+          <span class="field-label">Texto</span>
+          <input type="text" [(ngModel)]="e.coord.value" placeholder="Texto..." />
+        </label>
+        <label class="field field-small">
+          <span class="field-label">Tamaño</span>
+          <input type="number" [(ngModel)]="e.coord.size" min="8" max="72" />
+        </label>
+        <div class="color-section">
+          <span class="field-label">Color</span>
+          <div class="color-row">
+            <input type="color" [(ngModel)]="e.coord.color" (ngModelChange)="onEditColorPicker($event)" />
+            <div class="color-inputs">
+              <input type="text" [ngModel]="editHexInput()" (ngModelChange)="setEditColorFromHex($event)"
+                [ngModelOptions]="{ standalone: true }" placeholder="#5eead4" />
+              <input type="text" [ngModel]="editRgbInput()" (ngModelChange)="setEditColorFromRgb($event)"
+                [ngModelOptions]="{ standalone: true }" placeholder="rgb(94, 234, 212)" />
+            </div>
+          </div>
+          <small class="color-hint">Puedes pegar un HEX o un RGB existente para reutilizar colores exactos.</small>
+        </div>
+        <div class="editor-actions">
+          <button (click)="confirmEdit()">✅</button>
+          <button (click)="cancelEdit()">❌</button>
+          <button class="btn-delete" (click)="deleteAnnotation()">🗑️</button>
+        </div>
       </div>
     </div>
   </main>

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -69,6 +69,7 @@
       <div *ngIf="editing() as e" class="annotation-editor editing" [style.left.px]="e.coord.x*scale()"
         [style.top.px]="pdfCanvasRef!.nativeElement.height - e.coord.y*scale()" (keydown.enter)="confirmEdit()"
         (keydown.escape)="cancelEdit()">
+        <span class="editor-badge">Editando</span>
         <label class="field">
           <span class="field-label">Texto</span>
           <input type="text" [(ngModel)]="e.coord.value" placeholder="Texto..." />

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -174,15 +174,16 @@ header .logo {
 .annotation-editor {
   position: absolute;
   z-index: 20;
-  background: rgba(42, 42, 61, 0.95);
-  padding: 12px;
-  border: 1px solid rgba(94, 234, 212, 0.35);
+  background: linear-gradient(180deg, rgba(34, 34, 52, 0.96), rgba(24, 24, 40, 0.96));
+  padding: 14px;
+  border: 1px solid rgba(94, 234, 212, 0.25);
   border-radius: 8px;
   display: flex;
   flex-direction: column;
   gap: 8px;
   min-width: 260px;
-  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.28);
+  backdrop-filter: blur(10px);
 
   input[type="text"],
   input[type="number"] {
@@ -224,8 +225,25 @@ header .logo {
   }
 
   &.editing {
-    background: rgba(94, 234, 212, 0.1);
-    border: 1px solid rgba(94, 234, 212, 0.55);
+    border-color: rgba(94, 234, 212, 0.65);
+    box-shadow:
+      0 18px 36px rgba(0, 0, 0, 0.35),
+      0 0 0 1px rgba(94, 234, 212, 0.25);
+  }
+
+  &.editing::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: 8px;
+    padding: 1px;
+    background: linear-gradient(135deg, rgba(94, 234, 212, 0.45), transparent 70%);
+    -webkit-mask:
+      linear-gradient(#000 0 0) content-box,
+      linear-gradient(#000 0 0);
+    -webkit-mask-composite: xor;
+    mask-composite: exclude;
+    pointer-events: none;
   }
 
   .field {
@@ -275,6 +293,24 @@ header .logo {
     font-size: .7rem;
     color: var(--muted);
     line-height: 1.3;
+  }
+
+  .editor-badge {
+    align-self: flex-start;
+    font-size: .7rem;
+    font-weight: 600;
+    letter-spacing: .08em;
+    text-transform: uppercase;
+    background: rgba(94, 234, 212, 0.2);
+    color: var(--accent);
+    border-radius: 999px;
+    padding: 4px 10px;
+  }
+
+  &.editing .editor-badge {
+    background: var(--accent);
+    color: #061111;
+    box-shadow: 0 4px 12px rgba(94, 234, 212, 0.35);
   }
 
   .color-hint code {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -174,9 +174,9 @@ header .logo {
 .annotation-editor {
   position: absolute;
   z-index: 20;
-  background: #fffbe0;
+  background: rgba(42, 42, 61, 0.95);
   padding: 12px;
-  border: 1px solid #f0c040;
+  border: 1px solid rgba(94, 234, 212, 0.35);
   border-radius: 8px;
   display: flex;
   flex-direction: column;
@@ -187,10 +187,10 @@ header .logo {
   input[type="text"],
   input[type="number"] {
     border-radius: 4px;
-    border: 1px solid #d8b45c;
+    border: 1px solid rgba(94, 234, 212, 0.25);
     padding: 6px;
-    background: #fff;
-    color: #2f2f2f;
+    background: rgba(30, 30, 47, 0.9);
+    color: var(--text);
     font-size: .9rem;
   }
 
@@ -201,10 +201,10 @@ header .logo {
   input[type="color"] {
     width: 44px;
     height: 36px;
-    border: 1px solid #d8b45c;
+    border: 1px solid rgba(94, 234, 212, 0.35);
     border-radius: 6px;
     padding: 0;
-    background: #fff;
+    background: transparent;
     cursor: pointer;
   }
 
@@ -214,8 +214,8 @@ header .logo {
     border-radius: 6px;
     padding: 6px 10px;
     font-size: .9rem;
-    background: #f0c040;
-    color: #2f2f2f;
+    background: var(--accent);
+    color: #0b1f1f;
     transition: transform .1s ease;
   }
 
@@ -224,8 +224,8 @@ header .logo {
   }
 
   &.editing {
-    background: #fff0e0;
-    border: 1px solid #f0a040;
+    background: rgba(94, 234, 212, 0.1);
+    border: 1px solid rgba(94, 234, 212, 0.55);
   }
 
   .field {
@@ -243,7 +243,7 @@ header .logo {
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: .05em;
-    color: #a86c00;
+    color: var(--accent);
   }
 
   .color-section {
@@ -273,12 +273,12 @@ header .logo {
 
   .color-hint {
     font-size: .7rem;
-    color: #8c6d2e;
+    color: var(--muted);
     line-height: 1.3;
   }
 
   .color-hint code {
-    background: rgba(0, 0, 0, 0.05);
+    background: rgba(94, 234, 212, 0.1);
     padding: 0 4px;
     border-radius: 4px;
   }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -175,40 +175,129 @@ header .logo {
   position: absolute;
   z-index: 20;
   background: #fffbe0;
-  padding: 6px;
+  padding: 12px;
   border: 1px solid #f0c040;
-  border-radius: 6px;
+  border-radius: 8px;
   display: flex;
-  gap: 4px;
-  flex-wrap: wrap;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 260px;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.2);
 
   input[type="text"],
-  input[type="number"],
-  input[type="color"] {
+  input[type="number"] {
     border-radius: 4px;
-    border: 1px solid #ccc;
-    padding: 2px 4px;
+    border: 1px solid #d8b45c;
+    padding: 6px;
+    background: #fff;
+    color: #2f2f2f;
+    font-size: .9rem;
+  }
+
+  input[type="number"] {
+    width: 100%;
+  }
+
+  input[type="color"] {
+    width: 44px;
+    height: 36px;
+    border: 1px solid #d8b45c;
+    border-radius: 6px;
+    padding: 0;
+    background: #fff;
+    cursor: pointer;
   }
 
   button {
     cursor: pointer;
     border: none;
-    border-radius: 4px;
-    padding: 4px 6px;
+    border-radius: 6px;
+    padding: 6px 10px;
+    font-size: .9rem;
+    background: #f0c040;
+    color: #2f2f2f;
+    transition: transform .1s ease;
+  }
+
+  button:hover {
+    transform: translateY(-1px);
   }
 
   &.editing {
     background: #fff0e0;
     border: 1px solid #f0a040;
   }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .field-small {
+    max-width: 120px;
+  }
+
+  .field-label {
+    font-size: .7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: .05em;
+    color: #a86c00;
+  }
+
+  .color-section {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .color-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+  }
+
+  .color-inputs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    min-width: 200px;
+  }
+
+  .color-inputs input[type="text"] {
+    flex: 1 1 120px;
+    font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  }
+
+  .color-hint {
+    font-size: .7rem;
+    color: #8c6d2e;
+    line-height: 1.3;
+  }
+
+  .color-hint code {
+    background: rgba(0, 0, 0, 0.05);
+    padding: 0 4px;
+    border-radius: 4px;
+  }
+
+  .editor-actions {
+    display: flex;
+    gap: 6px;
+    justify-content: flex-end;
+  }
 }
 
 .btn-delete {
   background: var(--danger);
   color: #fff;
-  padding: 4px 8px;
+  padding: 6px 10px;
   border-radius: 6px;
   cursor: pointer;
+  border: none;
+  font-size: .9rem;
 }
 
 .btn-delete:hover {


### PR DESCRIPTION
## Summary
- normalize annotation colors so stored values are always hexadecimal strings
- convert rgb values to hex when editing existing annotations to keep JSON consistent

## Testing
- npm run lint *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68ff80b9ead083258b70c178aa849825