### PR TITLE
Add draggable annotations to the PDF viewer

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -158,17 +158,22 @@ header .logo {
 .annotation {
   position: absolute;
   pointer-events: auto;
-  cursor: text;
+  cursor: grab;
   background: rgba(255, 255, 255, 0.15);
   padding: 2px 4px;
   border-radius: 4px;
   white-space: nowrap;
   transition: .2s;
+  user-select: none;
 }
 
 .annotation:hover {
   background: rgba(94, 234, 212, 0.25);
   border: 1px dashed var(--accent);
+}
+
+.annotation.dragging {
+  cursor: grabbing;
 }
 
 .annotation-editor {


### PR DESCRIPTION
## Summary
- allow annotations to be repositioned by dragging and persist their updated coordinates
- refactor annotation rendering to track global indices while keeping editing functionality
- adjust annotation styling to reflect draggable behavior

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68ff80d93d608325a436affd4dcd2cfa