### PR TITLE
Fix annotated PDF download parsing error

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -2,7 +2,8 @@
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
   "version": 1,
   "cli": {
-    "packageManager": "npm"
+    "packageManager": "npm",
+    "analytics": false
   },
   "newProjectRoot": "projects",
   "projects": {

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -23,7 +23,7 @@ export class App implements AfterViewChecked {
   coords = signal<Coord[]>([]);
   preview = signal<Coord | null>(null);
   editing = signal<EditState>(null);
-  private originalPdfData?: ArrayBuffer;
+  private originalPdfData?: Uint8Array;
 
   @ViewChild('pdfCanvas', { static: false }) pdfCanvasRef?: ElementRef<HTMLCanvasElement>;
   @ViewChild('overlayCanvas', { static: false }) overlayCanvasRef?: ElementRef<HTMLCanvasElement>;
@@ -53,7 +53,7 @@ export class App implements AfterViewChecked {
     if (!file) return;
 
     const buf = await file.arrayBuffer();
-    this.originalPdfData = buf.slice(0);
+    this.originalPdfData = new Uint8Array(buf);
 
     const loadingTask = pdfjsLib.getDocument({ data: buf });
     this.pdfDoc = await loadingTask.promise;
@@ -259,7 +259,7 @@ export class App implements AfterViewChecked {
       });
     }
 
-    const pdfBytes = await pdf.save();
+    const pdfBytes = await pdf.save({ useObjectStreams: false });
     const blob = new Blob([new Uint8Array(pdfBytes)], { type: 'application/pdf' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');


### PR DESCRIPTION
## Summary
- keep the original PDF bytes as a Uint8Array so pdf-lib loads consistent data for annotation export
- save annotated PDFs without object streams to avoid invalid-object parsing errors in pdf.js
- disable Angular CLI analytics to prevent interactive prompts during tooling runs

## Testing
- npm run test -- --watch=false *(fails: Angular bundler cannot resolve the dynamic pdf-lib import during unit tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ff81a737e0832591c24640d35cb13c