### PR TITLE
Add internal i18n support with language selector

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -2,7 +2,8 @@
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
   "version": 1,
   "cli": {
-    "packageManager": "npm"
+    "packageManager": "npm",
+    "analytics": false
   },
   "newProjectRoot": "projects",
   "projects": {

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,27 +1,39 @@
 <div class="app">
   <!-- HEADER -->
   <header class="header">
-    <div class="logo">PDF Annotator</div>
+    <div class="logo">{{ 'header.title' | translate }}</div>
     <input type="file" accept="application/pdf" (change)="onFileSelected($event)" class="input-file" />
 
     <div class="controls">
-      <button class="btn" (click)="prevPage()" [disabled]="!pdfDoc || pageIndex()===1">◀ Prev</button>
-      <span class="page-indicator">Page {{ pageIndex() }} / {{ pageCount || 0 }}</span>
-      <button class="btn" (click)="nextPage()" [disabled]="!pdfDoc || pageIndex()===pageCount">Next ▶</button>
+      <button class="btn" (click)="prevPage()" [disabled]="!pdfDoc || pageIndex()===1">
+        <span aria-hidden="true" class="btn-icon">◀</span>
+        {{ 'header.actions.prev' | translate }}
+      </button>
+      <span class="page-indicator">{{ 'header.pageIndicator' | translate: { index: pageIndex(), count: pageCount || 0 } }}</span>
+      <button class="btn" (click)="nextPage()" [disabled]="!pdfDoc || pageIndex()===pageCount">
+        {{ 'header.actions.next' | translate }}
+        <span aria-hidden="true" class="btn-icon">▶</span>
+      </button>
 
       <button class="btn" (click)="zoomOut()" [disabled]="!pdfDoc">−</button>
-      <span class="page-indicator">Zoom {{ scale() | number:'1.0-2' }}×</span>
+      <span class="page-indicator">{{ 'header.zoomIndicator' | translate: { value: (scale() | number:'1.0-2') } }}</span>
       <button class="btn" (click)="zoomIn()" [disabled]="!pdfDoc">+</button>
 
-      <button class="btn danger" (click)="clearAll()" [disabled]="!coords().length">Clear</button>
-      <button class="btn" (click)="copyJSON()" [disabled]="!coords().length">Copy JSON</button>
-      <button class="btn" (click)="downloadJSON()" [disabled]="!coords().length">Download JSON</button>
+      <button class="btn danger" (click)="clearAll()" [disabled]="!coords().length">{{ 'actions.clear' | translate }}</button>
+      <button class="btn" (click)="copyJSON()" [disabled]="!coords().length">{{ 'actions.copy' | translate }}</button>
+      <button class="btn" (click)="downloadJSON()" [disabled]="!coords().length">{{ 'actions.download' | translate }}</button>
+    </div>
+    <div class="language-picker">
+      <label class="visually-hidden" for="language-select">{{ 'header.languageLabel' | translate }}</label>
+      <select id="language-select" class="lang-select" [value]="activeLang()" (change)="switchLanguage($any($event.target).value)">
+        <option *ngFor="let lang of languageOptions" [value]="lang.code">{{ ('lang.' + lang.code) | translate }}</option>
+      </select>
     </div>
   </header>
 
   <!-- LATERAL SIDEBAR -->
   <aside class="sidebar">
-    <h4>Anotaciones (JSON)</h4>
+    <h4>{{ 'sidebar.title' | translate }}</h4>
     <pre class="json">{{ coords() | json }}</pre>
   </aside>
 
@@ -37,7 +49,7 @@
       <div *ngIf="preview() as p" class="annotation-editor" #previewEditor [style.left.px]="p.x*scale()"
         [style.top.px]="pdfCanvasRef!.nativeElement.height - p.y*scale()" (keydown.enter)="confirmPreview()"
         (keydown.escape)="cancelPreview()">
-        <input type="text" [(ngModel)]="p.value" placeholder="Texto..." />
+        <input type="text" [(ngModel)]="p.value" [placeholder]="'annotation.placeholder' | translate" />
         <input type="number" [(ngModel)]="p.size" min="8" max="72" />
         <input type="color" [(ngModel)]="p.color" />
         <button (click)="confirmPreview()">✅</button>
@@ -48,7 +60,7 @@
       <div *ngIf="editing() as e" class="annotation-editor editing" [style.left.px]="e.coord.x*scale()"
         [style.top.px]="pdfCanvasRef!.nativeElement.height - e.coord.y*scale()" (keydown.enter)="confirmEdit()"
         (keydown.escape)="cancelEdit()">
-        <input type="text" [(ngModel)]="e.coord.value" placeholder="Texto..." />
+        <input type="text" [(ngModel)]="e.coord.value" [placeholder]="'annotation.placeholder' | translate" />
         <input type="number" [(ngModel)]="e.coord.size" min="8" max="72" />
         <input type="color" [(ngModel)]="e.coord.color" />
         <button (click)="confirmEdit()">✅</button>
@@ -59,7 +71,6 @@
   </main>
 
   <main class="viewer empty" *ngIf="!pdfDoc">
-    <p class="empty-text">Sube un PDF y haz click donde quieras añadir anotaciones. Edítalas en la vista previa antes de
-      confirmar ✅.</p>
+    <p class="empty-text">{{ 'viewer.empty' | translate }}</p>
   </main>
 </div>

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -17,7 +17,11 @@ describe('App', () => {
   it('should render title', () => {
     const fixture = TestBed.createComponent(App);
     fixture.detectChanges();
+    const component = fixture.componentInstance;
+    component.switchLanguage('es');
+    fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, pdf-annotator');
+    const logoText = compiled.querySelector('.logo')?.textContent?.trim();
+    expect(logoText).toBe('Anotador de PDF');
   });
 });

--- a/src/app/i18n.service.ts
+++ b/src/app/i18n.service.ts
@@ -1,0 +1,130 @@
+import { Injectable, Signal, signal } from '@angular/core';
+
+export type LanguageCode = 'es' | 'en';
+export type TranslationParams = Record<string, unknown>;
+
+export interface LanguageOption {
+  code: LanguageCode;
+  label: string;
+}
+
+const LANGUAGE_LABELS: Record<LanguageCode, string> = {
+  es: 'Español',
+  en: 'English',
+};
+
+const TRANSLATIONS: Record<LanguageCode, Record<string, unknown>> = {
+  en: {
+    header: {
+      title: 'PDF Annotator',
+      actions: { prev: 'Prev', next: 'Next' },
+      pageIndicator: 'Page {{index}} / {{count}}',
+      zoomIndicator: 'Zoom {{ value }}×',
+      languageLabel: 'Select language',
+    },
+    actions: {
+      clear: 'Clear',
+      copy: 'Copy JSON',
+      download: 'Download JSON',
+      downloadFilename: 'annotations.json',
+    },
+    lang: {
+      es: 'Español',
+      en: 'English',
+    },
+    sidebar: {
+      title: 'Annotations (JSON)',
+    },
+    annotation: {
+      placeholder: 'Text...',
+    },
+    viewer: {
+      empty:
+        'Upload a PDF and click anywhere to add annotations. Edit them in the preview before confirming ✅.',
+    },
+  },
+  es: {
+    header: {
+      title: 'Anotador de PDF',
+      actions: { prev: 'Anterior', next: 'Siguiente' },
+      pageIndicator: 'Página {{index}} / {{count}}',
+      zoomIndicator: 'Zoom {{ value }}×',
+      languageLabel: 'Seleccionar idioma',
+    },
+    actions: {
+      clear: 'Limpiar',
+      copy: 'Copiar JSON',
+      download: 'Descargar JSON',
+      downloadFilename: 'anotaciones.json',
+    },
+    lang: {
+      es: 'Español',
+      en: 'Inglés',
+    },
+    sidebar: {
+      title: 'Anotaciones (JSON)',
+    },
+    annotation: {
+      placeholder: 'Texto...',
+    },
+    viewer: {
+      empty:
+        'Sube un PDF y haz clic donde quieras añadir anotaciones. Edítalas en la vista previa antes de confirmar ✅.',
+    },
+  },
+};
+
+const FALLBACK_LANG: LanguageCode = 'en';
+
+@Injectable({ providedIn: 'root' })
+export class I18nService {
+  readonly languageOptions: LanguageOption[] = Object.entries(LANGUAGE_LABELS).map(([code, label]) => ({
+    code: code as LanguageCode,
+    label,
+  }));
+
+  private readonly lang = signal<LanguageCode>('es');
+
+  readonly currentLang: Signal<LanguageCode> = this.lang.asReadonly();
+
+  setLanguage(lang: string) {
+    const normalized = lang.toLowerCase();
+    if (Object.prototype.hasOwnProperty.call(TRANSLATIONS, normalized)) {
+      this.lang.set(normalized as LanguageCode);
+    }
+  }
+
+  translate(key: string, params?: TranslationParams): string {
+    const lang = this.lang();
+    const value = this.resolveValue(key, lang) ?? this.resolveValue(key, FALLBACK_LANG);
+    if (typeof value !== 'string') {
+      return key;
+    }
+    if (!params) {
+      return value;
+    }
+    return value.replace(/{{\s*(\w+)\s*}}/g, (match, paramKey) => {
+      if (Object.prototype.hasOwnProperty.call(params, paramKey)) {
+        const paramValue = params[paramKey];
+        return paramValue !== undefined && paramValue !== null ? String(paramValue) : '';
+      }
+      return match;
+    });
+  }
+
+  getLanguageLabel(lang: LanguageCode): string {
+    return LANGUAGE_LABELS[lang];
+  }
+
+  private resolveValue(path: string, lang: LanguageCode): unknown {
+    const segments = path.split('.');
+    let current: unknown = TRANSLATIONS[lang];
+    for (const segment of segments) {
+      if (typeof current !== 'object' || current === null) {
+        return undefined;
+      }
+      current = (current as Record<string, unknown>)[segment];
+    }
+    return current;
+  }
+}

--- a/src/app/i18n.service.ts
+++ b/src/app/i18n.service.ts
@@ -1,6 +1,9 @@
 import { Injectable, Signal, signal } from '@angular/core';
+import { caTranslations } from './translations/ca';
+import { enTranslations } from './translations/en';
+import { esTranslations } from './translations/es';
 
-export type LanguageCode = 'es' | 'en';
+export type LanguageCode = 'es' | 'en' | 'ca';
 export type TranslationParams = Record<string, unknown>;
 
 export interface LanguageOption {
@@ -11,67 +14,13 @@ export interface LanguageOption {
 const LANGUAGE_LABELS: Record<LanguageCode, string> = {
   es: 'Español',
   en: 'English',
+  ca: 'Català',
 };
 
 const TRANSLATIONS: Record<LanguageCode, Record<string, unknown>> = {
-  en: {
-    header: {
-      title: 'PDF Annotator',
-      actions: { prev: 'Prev', next: 'Next' },
-      pageIndicator: 'Page {{index}} / {{count}}',
-      zoomIndicator: 'Zoom {{ value }}×',
-      languageLabel: 'Select language',
-    },
-    actions: {
-      clear: 'Clear',
-      copy: 'Copy JSON',
-      download: 'Download JSON',
-      downloadFilename: 'annotations.json',
-    },
-    lang: {
-      es: 'Español',
-      en: 'English',
-    },
-    sidebar: {
-      title: 'Annotations (JSON)',
-    },
-    annotation: {
-      placeholder: 'Text...',
-    },
-    viewer: {
-      empty:
-        'Upload a PDF and click anywhere to add annotations. Edit them in the preview before confirming ✅.',
-    },
-  },
-  es: {
-    header: {
-      title: 'Anotador de PDF',
-      actions: { prev: 'Anterior', next: 'Siguiente' },
-      pageIndicator: 'Página {{index}} / {{count}}',
-      zoomIndicator: 'Zoom {{ value }}×',
-      languageLabel: 'Seleccionar idioma',
-    },
-    actions: {
-      clear: 'Limpiar',
-      copy: 'Copiar JSON',
-      download: 'Descargar JSON',
-      downloadFilename: 'anotaciones.json',
-    },
-    lang: {
-      es: 'Español',
-      en: 'Inglés',
-    },
-    sidebar: {
-      title: 'Anotaciones (JSON)',
-    },
-    annotation: {
-      placeholder: 'Texto...',
-    },
-    viewer: {
-      empty:
-        'Sube un PDF y haz clic donde quieras añadir anotaciones. Edítalas en la vista previa antes de confirmar ✅.',
-    },
-  },
+  en: enTranslations,
+  es: esTranslations,
+  ca: caTranslations,
 };
 
 const FALLBACK_LANG: LanguageCode = 'en';

--- a/src/app/translate.pipe.ts
+++ b/src/app/translate.pipe.ts
@@ -1,0 +1,18 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { I18nService, TranslationParams } from './i18n.service';
+
+@Pipe({
+  name: 'translate',
+  standalone: true,
+  pure: false,
+})
+export class TranslatePipe implements PipeTransform {
+  constructor(private readonly i18n: I18nService) {}
+
+  transform(key: string, params?: TranslationParams): string {
+    if (!key) {
+      return '';
+    }
+    return this.i18n.translate(key, params);
+  }
+}

--- a/src/app/translations/ca.ts
+++ b/src/app/translations/ca.ts
@@ -1,0 +1,30 @@
+export const caTranslations = {
+  header: {
+    title: 'Anotador de PDF',
+    actions: { prev: 'Anterior', next: 'Següent' },
+    pageIndicator: 'Pàgina {{index}} / {{count}}',
+    zoomIndicator: 'Zoom {{ value }}×',
+    languageLabel: "Selecciona l'idioma",
+  },
+  actions: {
+    clear: 'Netejar',
+    copy: 'Copiar JSON',
+    download: 'Descarregar JSON',
+    downloadFilename: 'anotacions.json',
+  },
+  lang: {
+    es: 'Castellà',
+    en: 'Anglès',
+    ca: 'Català',
+  },
+  sidebar: {
+    title: 'Anotacions (JSON)',
+  },
+  annotation: {
+    placeholder: 'Text...',
+  },
+  viewer: {
+    empty:
+      'Puja un PDF i fes clic a qualsevol lloc per afegir anotacions. Edita-les a la previsualització abans de confirmar ✅.',
+  },
+} as const;

--- a/src/app/translations/en.ts
+++ b/src/app/translations/en.ts
@@ -1,0 +1,30 @@
+export const enTranslations = {
+  header: {
+    title: 'PDF Annotator',
+    actions: { prev: 'Prev', next: 'Next' },
+    pageIndicator: 'Page {{index}} / {{count}}',
+    zoomIndicator: 'Zoom {{ value }}×',
+    languageLabel: 'Select language',
+  },
+  actions: {
+    clear: 'Clear',
+    copy: 'Copy JSON',
+    download: 'Download JSON',
+    downloadFilename: 'annotations.json',
+  },
+  lang: {
+    es: 'Spanish',
+    en: 'English',
+    ca: 'Catalan',
+  },
+  sidebar: {
+    title: 'Annotations (JSON)',
+  },
+  annotation: {
+    placeholder: 'Text...',
+  },
+  viewer: {
+    empty:
+      'Upload a PDF and click anywhere to add annotations. Edit them in the preview before confirming ✅.',
+  },
+} as const;

--- a/src/app/translations/es.ts
+++ b/src/app/translations/es.ts
@@ -1,0 +1,30 @@
+export const esTranslations = {
+  header: {
+    title: 'Anotador de PDF',
+    actions: { prev: 'Anterior', next: 'Siguiente' },
+    pageIndicator: 'Página {{index}} / {{count}}',
+    zoomIndicator: 'Zoom {{ value }}×',
+    languageLabel: 'Seleccionar idioma',
+  },
+  actions: {
+    clear: 'Limpiar',
+    copy: 'Copiar JSON',
+    download: 'Descargar JSON',
+    downloadFilename: 'anotaciones.json',
+  },
+  lang: {
+    es: 'Español',
+    en: 'Inglés',
+    ca: 'Catalán',
+  },
+  sidebar: {
+    title: 'Anotaciones (JSON)',
+  },
+  annotation: {
+    placeholder: 'Texto...',
+  },
+  viewer: {
+    empty:
+      'Sube un PDF y haz clic donde quieras añadir anotaciones. Edítalas en la vista previa antes de confirmar ✅.',
+  },
+} as const;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -46,6 +46,36 @@ header .logo {
   color: var(--accent);
 }
 
+.language-picker {
+  margin-left: auto;
+}
+
+.lang-select {
+  background: var(--panel);
+  color: var(--text);
+  border-radius: 8px;
+  border: 1px solid #444;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+
+.lang-select:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .input-file {
   background: var(--panel);
   color: var(--text);
@@ -70,6 +100,8 @@ header .logo {
   padding: 6px 10px;
   cursor: pointer;
   transition: .2s;
+  display: inline-flex;
+  align-items: center;
 }
 
 .btn:hover {
@@ -84,6 +116,11 @@ header .logo {
 
 .btn.danger:hover {
   opacity: 0.8;
+}
+
+.btn-icon {
+  margin: 0 4px;
+  display: inline-block;
 }
 
 .page-indicator {


### PR DESCRIPTION
## Summary
- add a lightweight i18n service and translate pipe to provide English and Spanish strings
- replace hardcoded UI copy with translation keys and expose a language selector with matching styles
- refresh the unit test and CLI config so the suite exercises the localized title without analytics prompts

## Testing
- npm run test -- --watch=false --browsers=ChromeHeadless *(fails: ChromeHeadless binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ff8500a7a88325a78f6f22f1d1b33f