### PR TITLE
Align keyboard behavior for annotation modals

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -35,8 +35,8 @@
 
       <!-- NUEVA ANOTACIÓN -->
       <div *ngIf="preview() as p" class="annotation-editor" #previewEditor [style.left.px]="p.x*scale()"
-        [style.top.px]="pdfCanvasRef!.nativeElement.height - p.y*scale()" (keydown.enter)="confirmPreview()"
-        (keydown.escape)="cancelPreview()">
+        [style.top.px]="pdfCanvasRef!.nativeElement.height - p.y*scale()"
+        (keydown)="onEditorKeydown($event, 'preview')">
         <label class="field">
           <span class="field-label">Texto</span>
           <input type="text" [(ngModel)]="p.value" placeholder="Texto..." />
@@ -66,9 +66,9 @@
       </div>
 
       <!-- EDITAR ANOTACIÓN -->
-      <div *ngIf="editing() as e" class="annotation-editor editing" [style.left.px]="e.coord.x*scale()"
-        [style.top.px]="pdfCanvasRef!.nativeElement.height - e.coord.y*scale()" (keydown.enter)="confirmEdit()"
-        (keydown.escape)="cancelEdit()">
+      <div *ngIf="editing() as e" class="annotation-editor editing" #editEditor [style.left.px]="e.coord.x*scale()"
+        [style.top.px]="pdfCanvasRef!.nativeElement.height - e.coord.y*scale()"
+        (keydown)="onEditorKeydown($event, 'edit')">
         <span class="editor-badge">Editando</span>
         <label class="field">
           <span class="field-label">Texto</span>

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -46,17 +46,45 @@ export class App implements AfterViewChecked {
   annotationsLayerRef?: ElementRef<HTMLDivElement>;
 
   @ViewChild('previewEditor') previewEditorRef?: ElementRef<HTMLDivElement>;
+  @ViewChild('editEditor') editEditorRef?: ElementRef<HTMLDivElement>;
 
   constructor() {
     (pdfjsLib as any).GlobalWorkerOptions.workerSrc = '/assets/pdfjs/pdf.worker.min.mjs';
   }
 
   ngAfterViewChecked() {
-    const previewEl = this.previewEditorRef?.nativeElement;
-    if (previewEl) {
-      const input = previewEl.querySelector('input[type="text"]') as HTMLInputElement;
-      if (input) {
-        input.focus();
+    if (this.preview()) {
+      const previewEl = this.previewEditorRef?.nativeElement;
+      if (previewEl) {
+        const input = previewEl.querySelector('input[type="text"]') as HTMLInputElement | null;
+        input?.focus();
+      }
+      return;
+    }
+
+    if (this.editing()) {
+      const editEl = this.editEditorRef?.nativeElement;
+      if (editEl) {
+        const input = editEl.querySelector('input[type="text"]') as HTMLInputElement | null;
+        input?.focus();
+      }
+    }
+  }
+
+  onEditorKeydown(event: KeyboardEvent, mode: 'preview' | 'edit') {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      if (mode === 'preview') {
+        this.confirmPreview();
+      } else {
+        this.confirmEdit();
+      }
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      if (mode === 'preview') {
+        this.cancelPreview();
+      } else {
+        this.cancelEdit();
       }
     }
   }

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -72,20 +72,28 @@ export class App implements AfterViewChecked {
   }
 
   onEditorKeydown(event: KeyboardEvent, mode: 'preview' | 'edit') {
-    if (event.key === 'Enter') {
+    const triggerAction = (action: 'confirm' | 'cancel') => {
       event.preventDefault();
-      if (mode === 'preview') {
-        this.confirmPreview();
-      } else {
-        this.confirmEdit();
-      }
-    } else if (event.key === 'Escape') {
-      event.preventDefault();
-      if (mode === 'preview') {
-        this.cancelPreview();
-      } else {
-        this.cancelEdit();
-      }
+      this.invokeEditorAction(mode, action);
+    };
+
+    switch (event.key) {
+      case 'Enter':
+        triggerAction('confirm');
+        break;
+      case 'Escape':
+        triggerAction('cancel');
+        break;
+      default:
+        break;
+    }
+  }
+
+  private invokeEditorAction(mode: 'preview' | 'edit', action: 'confirm' | 'cancel') {
+    if (mode === 'preview') {
+      action === 'confirm' ? this.confirmPreview() : this.cancelPreview();
+    } else {
+      action === 'confirm' ? this.confirmEdit() : this.cancelEdit();
     }
   }
 

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -71,6 +71,15 @@ export class App implements AfterViewChecked {
     }
   }
 
+  private isTextEntryElement(element: Element | null): boolean {
+    if (!element) return false;
+    if (element instanceof HTMLInputElement) return true;
+    if (element instanceof HTMLTextAreaElement) return true;
+    if (element instanceof HTMLSelectElement) return true;
+    const htmlEl = element as HTMLElement;
+    return Boolean(htmlEl?.isContentEditable);
+  }
+
   onEditorKeydown(event: KeyboardEvent, mode: 'preview' | 'edit') {
     if (event.key === 'Enter') {
       event.preventDefault();
@@ -86,6 +95,13 @@ export class App implements AfterViewChecked {
       } else {
         this.cancelEdit();
       }
+    } else if (
+      mode === 'edit' &&
+      (event.key === 'Delete' || event.key === 'Backspace') &&
+      !this.isTextEntryElement(document.activeElement)
+    ) {
+      event.preventDefault();
+      this.deleteAnnotation();
     }
   }
 

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -71,15 +71,6 @@ export class App implements AfterViewChecked {
     }
   }
 
-  private isTextEntryElement(element: Element | null): boolean {
-    if (!element) return false;
-    if (element instanceof HTMLInputElement) return true;
-    if (element instanceof HTMLTextAreaElement) return true;
-    if (element instanceof HTMLSelectElement) return true;
-    const htmlEl = element as HTMLElement;
-    return Boolean(htmlEl?.isContentEditable);
-  }
-
   onEditorKeydown(event: KeyboardEvent, mode: 'preview' | 'edit') {
     if (event.key === 'Enter') {
       event.preventDefault();
@@ -95,13 +86,6 @@ export class App implements AfterViewChecked {
       } else {
         this.cancelEdit();
       }
-    } else if (
-      mode === 'edit' &&
-      (event.key === 'Delete' || event.key === 'Backspace') &&
-      !this.isTextEntryElement(document.activeElement)
-    ) {
-      event.preventDefault();
-      this.deleteAnnotation();
     }
   }
 

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, ElementRef, ViewChild, signal, AfterViewChecked } from '@angular/core';
+import { Component, ElementRef, ViewChild, signal, AfterViewChecked, HostListener } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import type { PDFDocumentProxy, PDFPageProxy } from 'pdfjs-dist';
 import * as pdfjsLib from 'pdfjs-dist/legacy/build/pdf';
@@ -362,6 +362,22 @@ export class App implements AfterViewChecked {
 
   cancelEdit() {
     this.editing.set(null);
+  }
+
+  @HostListener('document:mousedown', ['$event'])
+  onDocumentMouseDown(event: MouseEvent) {
+    const editState = this.editing();
+    if (!editState) return;
+
+    const modal = this.editEditorRef?.nativeElement;
+    if (!modal) return;
+
+    const target = event.target as Node | null;
+    if (target && modal.contains(target)) {
+      return;
+    }
+
+    this.cancelEdit();
   }
 
   deleteAnnotation() {


### PR DESCRIPTION
## Summary
- unify handling of keyboard shortcuts for creating and editing annotation modals
- focus the active modal input when previewing or editing annotations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ff8ed034f48325b9f36ec57a2896e4