### PR TITLE
feat: add i18n support with translation guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,11 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build",
+    "build": "npm run i18n:check && ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
-    "serve:ssr:pdf-annotator": "node dist/pdf-annotator/server/server.mjs"
+    "serve:ssr:pdf-annotator": "node dist/pdf-annotator/server/server.mjs",
+    "i18n:check": "node scripts/check-translations.mjs"
   },
   "prettier": {
     "printWidth": 100,

--- a/scripts/check-translations.mjs
+++ b/scripts/check-translations.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+import { readFile, readdir } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const translationsDir = path.resolve(__dirname, '../src/app/i18n/translations');
+const baseLanguage = 'es-ES';
+
+async function readJson(filePath) {
+  const raw = await readFile(filePath, 'utf8');
+  return JSON.parse(raw);
+}
+
+function getValue(dictionary, key) {
+  return key.split('.').reduce((value, segment) => {
+    if (value && typeof value === 'object' && segment in value) {
+      return value[segment];
+    }
+    return undefined;
+  }, dictionary);
+}
+
+function collectStringKeys(dictionary, prefix = '') {
+  return Object.entries(dictionary).flatMap(([key, value]) => {
+    const composedKey = prefix ? `${prefix}.${key}` : key;
+    if (typeof value === 'string') {
+      return [composedKey];
+    }
+    if (value && typeof value === 'object') {
+      return collectStringKeys(value, composedKey);
+    }
+    return [];
+  });
+}
+
+async function main() {
+  const files = await readdir(translationsDir);
+  const languages = files
+    .filter((file) => file.endsWith('.json'))
+    .map((file) => path.basename(file, '.json'))
+    .sort();
+
+  if (!languages.includes(baseLanguage)) {
+    console.error(`Base language file "${baseLanguage}.json" was not found in ${translationsDir}.`);
+    process.exit(1);
+  }
+
+  const basePath = path.join(translationsDir, `${baseLanguage}.json`);
+  const baseDictionary = await readJson(basePath);
+  const baseKeys = new Set(collectStringKeys(baseDictionary));
+
+  let hasErrors = false;
+
+  for (const language of languages.filter((lang) => lang !== baseLanguage)) {
+    const languagePath = path.join(translationsDir, `${language}.json`);
+    const dictionary = await readJson(languagePath);
+    const missingKeys = [];
+    const emptyKeys = [];
+
+    for (const key of baseKeys) {
+      const value = getValue(dictionary, key);
+      if (typeof value !== 'string') {
+        missingKeys.push(key);
+      } else if (!value.trim()) {
+        emptyKeys.push(key);
+      }
+    }
+
+    if (missingKeys.length || emptyKeys.length) {
+      hasErrors = true;
+      if (missingKeys.length) {
+        console.error(`\n[${language}] Missing translations:`);
+        missingKeys.forEach((key) => console.error(`  - ${key}`));
+      }
+      if (emptyKeys.length) {
+        console.error(`\n[${language}] Empty translations:`);
+        emptyKeys.forEach((key) => console.error(`  - ${key}`));
+      }
+    }
+  }
+
+  if (hasErrors) {
+    console.error('\nTranslation files are inconsistent. Please update the missing entries.');
+    process.exit(1);
+  }
+
+  console.log(`Translation check passed. ${baseKeys.size} keys validated.`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,27 +1,37 @@
 <div class="app">
   <!-- HEADER -->
   <header class="header">
-    <div class="logo">PDF Annotator</div>
+    <div class="logo">{{ 'app.title' | t }}</div>
     <input type="file" accept="application/pdf" (change)="onFileSelected($event)" class="input-file" />
 
     <div class="controls">
-      <button class="btn" (click)="prevPage()" [disabled]="!pdfDoc || pageIndex()===1">◀ Prev</button>
-      <span class="page-indicator">Page {{ pageIndex() }} / {{ pageCount || 0 }}</span>
-      <button class="btn" (click)="nextPage()" [disabled]="!pdfDoc || pageIndex()===pageCount">Next ▶</button>
+      <button class="btn" (click)="prevPage()" [disabled]="!pdfDoc || pageIndex()===1">◀ {{ 'controls.prev' | t }}</button>
+      <span class="page-indicator">{{ 'controls.pageIndicator' | t : { current: pageIndex(), total: pageCount || 0 } }}</span>
+      <button class="btn" (click)="nextPage()" [disabled]="!pdfDoc || pageIndex()===pageCount">{{ 'controls.next' | t }} ▶</button>
 
       <button class="btn" (click)="zoomOut()" [disabled]="!pdfDoc">−</button>
-      <span class="page-indicator">Zoom {{ scale() | number:'1.0-2' }}×</span>
+      <span class="page-indicator">{{ 'controls.zoomLabel' | t }} {{ scale() | number:'1.0-2' }}×</span>
       <button class="btn" (click)="zoomIn()" [disabled]="!pdfDoc">+</button>
 
-      <button class="btn danger" (click)="clearAll()" [disabled]="!coords().length">Clear</button>
-      <button class="btn" (click)="copyJSON()" [disabled]="!coords().length">Copy JSON</button>
-      <button class="btn" (click)="downloadJSON()" [disabled]="!coords().length">Download JSON</button>
+      <button class="btn danger" (click)="clearAll()" [disabled]="!coords().length">{{ 'controls.clear' | t }}</button>
+      <button class="btn" (click)="copyJSON()" [disabled]="!coords().length">{{ 'controls.copyJson' | t }}</button>
+      <button class="btn" (click)="downloadJSON()" [disabled]="!coords().length">{{ 'controls.downloadJson' | t }}</button>
+    </div>
+
+    <div class="language-selector">
+      <label for="language-select">{{ 'app.languageLabel' | t }}</label>
+      <select id="language-select"
+        [(ngModel)]="languageModel"
+        (ngModelChange)="onLanguageChange($event)"
+        [attr.aria-label]="'app.languageAriaLabel' | t">
+        <option *ngFor="let lang of languages" [value]="lang">{{ ('app.languages.' + lang) | t }}</option>
+      </select>
     </div>
   </header>
 
   <!-- LATERAL SIDEBAR -->
   <aside class="sidebar">
-    <h4>Anotaciones (JSON)</h4>
+    <h4>{{ 'sidebar.title' | t }}</h4>
     <pre class="json">{{ coords() | json }}</pre>
   </aside>
 
@@ -38,26 +48,25 @@
         [style.top.px]="pdfCanvasRef!.nativeElement.height - p.y*scale()"
         (keydown)="onEditorKeydown($event, 'preview')">
         <label class="field">
-          <span class="field-label">Texto</span>
-          <input type="text" [(ngModel)]="p.value" placeholder="Texto..." />
+          <span class="field-label">{{ 'annotation.fields.text.label' | t }}</span>
+          <input type="text" [(ngModel)]="p.value" [placeholder]="'annotation.fields.text.placeholder' | t" />
         </label>
         <label class="field field-small">
-          <span class="field-label">Tamaño</span>
+          <span class="field-label">{{ 'annotation.fields.size.label' | t }}</span>
           <input type="number" [(ngModel)]="p.size" min="8" max="72" />
         </label>
         <div class="color-section">
-          <span class="field-label">Color</span>
+          <span class="field-label">{{ 'annotation.fields.color.label' | t }}</span>
           <div class="color-row">
             <input type="color" [(ngModel)]="p.color" (ngModelChange)="onPreviewColorPicker($event)" />
             <div class="color-inputs">
               <input type="text" [ngModel]="previewHexInput()" (ngModelChange)="setPreviewColorFromHex($event)"
-                [ngModelOptions]="{ standalone: true }" placeholder="#5eead4" />
+                [ngModelOptions]="{ standalone: true }" [placeholder]="'annotation.color.hexPlaceholder' | t" />
               <input type="text" [ngModel]="previewRgbInput()" (ngModelChange)="setPreviewColorFromRgb($event)"
-                [ngModelOptions]="{ standalone: true }" placeholder="rgb(94, 234, 212)" />
+                [ngModelOptions]="{ standalone: true }" [placeholder]="'annotation.color.rgbPlaceholder' | t" />
             </div>
           </div>
-          <small class="color-hint">Selecciona un color, escribe un HEX o un RGB. El JSON siempre exportará el color en
-            HEX.</small>
+          <small class="color-hint">{{ 'annotation.color.hintPreview' | t }}</small>
         </div>
         <div class="editor-actions">
           <button (click)="confirmPreview()">✅</button>
@@ -69,27 +78,27 @@
       <div *ngIf="editing() as e" class="annotation-editor editing" #editEditor [style.left.px]="e.coord.x*scale()"
         [style.top.px]="pdfCanvasRef!.nativeElement.height - e.coord.y*scale()"
         (keydown)="onEditorKeydown($event, 'edit')">
-        <span class="editor-badge">Editando</span>
+        <span class="editor-badge">{{ 'annotation.editingBadge' | t }}</span>
         <label class="field">
-          <span class="field-label">Texto</span>
-          <input type="text" [(ngModel)]="e.coord.value" placeholder="Texto..." />
+          <span class="field-label">{{ 'annotation.fields.text.label' | t }}</span>
+          <input type="text" [(ngModel)]="e.coord.value" [placeholder]="'annotation.fields.text.placeholder' | t" />
         </label>
         <label class="field field-small">
-          <span class="field-label">Tamaño</span>
+          <span class="field-label">{{ 'annotation.fields.size.label' | t }}</span>
           <input type="number" [(ngModel)]="e.coord.size" min="8" max="72" />
         </label>
         <div class="color-section">
-          <span class="field-label">Color</span>
+          <span class="field-label">{{ 'annotation.fields.color.label' | t }}</span>
           <div class="color-row">
             <input type="color" [(ngModel)]="e.coord.color" (ngModelChange)="onEditColorPicker($event)" />
             <div class="color-inputs">
               <input type="text" [ngModel]="editHexInput()" (ngModelChange)="setEditColorFromHex($event)"
-                [ngModelOptions]="{ standalone: true }" placeholder="#5eead4" />
+                [ngModelOptions]="{ standalone: true }" [placeholder]="'annotation.color.hexPlaceholder' | t" />
               <input type="text" [ngModel]="editRgbInput()" (ngModelChange)="setEditColorFromRgb($event)"
-                [ngModelOptions]="{ standalone: true }" placeholder="rgb(94, 234, 212)" />
+                [ngModelOptions]="{ standalone: true }" [placeholder]="'annotation.color.rgbPlaceholder' | t" />
             </div>
           </div>
-          <small class="color-hint">Puedes pegar un HEX o un RGB existente para reutilizar colores exactos.</small>
+          <small class="color-hint">{{ 'annotation.color.hintEdit' | t }}</small>
         </div>
         <div class="editor-actions">
           <button (click)="confirmEdit()">✅</button>
@@ -101,7 +110,6 @@
   </main>
 
   <main class="viewer empty" *ngIf="!pdfDoc">
-    <p class="empty-text">Sube un PDF y haz click donde quieras añadir anotaciones. Edítalas en la vista previa antes de
-      confirmar ✅.</p>
+    <p class="empty-text">{{ 'viewer.emptyMessage' | t }}</p>
   </main>
 </div>

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { App } from './app';
+import { TranslationService } from './i18n/translation.service';
 
 describe('App', () => {
   beforeEach(async () => {
@@ -14,10 +15,11 @@ describe('App', () => {
     expect(app).toBeTruthy();
   });
 
-  it('should render title', () => {
+  it('should render the localized title', () => {
     const fixture = TestBed.createComponent(App);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, pdf-annotator');
+    const translation = TestBed.inject(TranslationService);
+    expect(compiled.querySelector('.logo')?.textContent?.trim()).toBe(translation.translate('app.title'));
   });
 });

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,8 +1,10 @@
 import { CommonModule } from '@angular/common';
-import { Component, ElementRef, ViewChild, signal, AfterViewChecked, HostListener } from '@angular/core';
+import { Component, ElementRef, ViewChild, signal, AfterViewChecked, HostListener, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import type { PDFDocumentProxy, PDFPageProxy } from 'pdfjs-dist';
 import * as pdfjsLib from 'pdfjs-dist/legacy/build/pdf';
+import { TranslationPipe } from './i18n/translation.pipe';
+import { Language, TranslationService } from './i18n/translation.service';
 
 (pdfjsLib as any).GlobalWorkerOptions.workerSrc = '/assets/pdfjs/pdf.worker.min.js';
 
@@ -13,7 +15,7 @@ type EditState = { index: number; coord: Coord } | null;
   selector: 'app-root',
   standalone: true,
   templateUrl: './app.html',
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, TranslationPipe],
   styleUrls: ['./app.scss'],
 })
 export class App implements AfterViewChecked {
@@ -27,6 +29,9 @@ export class App implements AfterViewChecked {
   previewRgbInput = signal('rgb(0, 0, 0)');
   editHexInput = signal('#000000');
   editRgbInput = signal('rgb(0, 0, 0)');
+  private readonly translationService = inject(TranslationService);
+  readonly languages: readonly Language[] = this.translationService.supportedLanguages;
+  languageModel: Language = this.translationService.getCurrentLanguage();
 
   private dragInfo: {
     index: number;
@@ -50,6 +55,11 @@ export class App implements AfterViewChecked {
 
   constructor() {
     (pdfjsLib as any).GlobalWorkerOptions.workerSrc = '/assets/pdfjs/pdf.worker.min.mjs';
+  }
+
+  onLanguageChange(language: string) {
+    this.translationService.setLanguage(language as Language);
+    this.languageModel = this.translationService.getCurrentLanguage();
   }
 
   ngAfterViewChecked() {

--- a/src/app/i18n/translation.pipe.ts
+++ b/src/app/i18n/translation.pipe.ts
@@ -1,0 +1,16 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+import { TranslationService } from './translation.service';
+
+@Pipe({
+  name: 't',
+  standalone: true,
+  pure: false,
+})
+export class TranslationPipe implements PipeTransform {
+  constructor(private readonly translation: TranslationService) {}
+
+  transform(key: string, params?: Record<string, unknown>): string {
+    return this.translation.translate(key, params);
+  }
+}

--- a/src/app/i18n/translation.service.ts
+++ b/src/app/i18n/translation.service.ts
@@ -1,0 +1,60 @@
+import { Injectable, computed, signal } from '@angular/core';
+
+import ca from './translations/ca.json';
+import en from './translations/en.json';
+import es from './translations/es-ES.json';
+
+export const LANGUAGES = ['es-ES', 'en', 'ca'] as const;
+export type Language = (typeof LANGUAGES)[number];
+
+type TranslationRecord = typeof es;
+
+const TRANSLATIONS: Record<Language, TranslationRecord> = {
+  'es-ES': es,
+  en,
+  ca,
+};
+
+@Injectable({ providedIn: 'root' })
+export class TranslationService {
+  private readonly languageSignal = signal<Language>('es-ES');
+
+  readonly language = computed(() => this.languageSignal());
+  readonly supportedLanguages: readonly Language[] = LANGUAGES;
+
+  translate(key: string, params?: Record<string, unknown>): string {
+    const dictionary = TRANSLATIONS[this.languageSignal()];
+    const template = this.resolve(dictionary, key);
+    if (typeof template !== 'string') {
+      return key;
+    }
+    if (!params) {
+      return template;
+    }
+
+    return template.replace(/\{\{\s*(\w+)\s*\}\}/g, (_, param: string) => {
+      const value = params[param];
+      return value === undefined || value === null ? '' : String(value);
+    });
+  }
+
+  setLanguage(language: Language) {
+    if (!TRANSLATIONS[language]) {
+      throw new Error(`Unsupported language: ${language}`);
+    }
+    this.languageSignal.set(language);
+  }
+
+  getCurrentLanguage(): Language {
+    return this.languageSignal();
+  }
+
+  private resolve(dictionary: Record<string, unknown>, key: string): unknown {
+    return key.split('.').reduce<unknown>((value, segment) => {
+      if (value && typeof value === 'object' && segment in (value as Record<string, unknown>)) {
+        return (value as Record<string, unknown>)[segment];
+      }
+      return undefined;
+    }, dictionary);
+  }
+}

--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -1,0 +1,48 @@
+{
+  "app": {
+    "title": "PDF Annotator",
+    "languageLabel": "Idioma",
+    "languageAriaLabel": "Selecciona l'idioma de l'aplicació",
+    "languages": {
+      "es-ES": "Espanyol",
+      "en": "Anglès",
+      "ca": "Català"
+    }
+  },
+  "controls": {
+    "prev": "Anterior",
+    "next": "Següent",
+    "pageIndicator": "Pàgina {{current}} / {{total}}",
+    "zoomLabel": "Zoom",
+    "clear": "Esborrar",
+    "copyJson": "Copiar JSON",
+    "downloadJson": "Descarregar JSON"
+  },
+  "sidebar": {
+    "title": "Anotacions (JSON)"
+  },
+  "annotation": {
+    "fields": {
+      "text": {
+        "label": "Text",
+        "placeholder": "Text..."
+      },
+      "size": {
+        "label": "Mida"
+      },
+      "color": {
+        "label": "Color"
+      }
+    },
+    "color": {
+      "hintPreview": "Selecciona un color, escriu un HEX o un RGB. El JSON sempre exportarà el color en HEX.",
+      "hintEdit": "Pots enganxar un HEX o un RGB existent per reutilitzar colors exactes.",
+      "hexPlaceholder": "#5eead4",
+      "rgbPlaceholder": "rgb(94, 234, 212)"
+    },
+    "editingBadge": "Editant"
+  },
+  "viewer": {
+    "emptyMessage": "Puja un PDF i fes clic on vulguis afegir anotacions. Edita-les a la previsualització abans de confirmar ✅."
+  }
+}

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -1,0 +1,48 @@
+{
+  "app": {
+    "title": "PDF Annotator",
+    "languageLabel": "Language",
+    "languageAriaLabel": "Select the application language",
+    "languages": {
+      "es-ES": "Spanish",
+      "en": "English",
+      "ca": "Catalan"
+    }
+  },
+  "controls": {
+    "prev": "Prev",
+    "next": "Next",
+    "pageIndicator": "Page {{current}} / {{total}}",
+    "zoomLabel": "Zoom",
+    "clear": "Clear",
+    "copyJson": "Copy JSON",
+    "downloadJson": "Download JSON"
+  },
+  "sidebar": {
+    "title": "Annotations (JSON)"
+  },
+  "annotation": {
+    "fields": {
+      "text": {
+        "label": "Text",
+        "placeholder": "Text..."
+      },
+      "size": {
+        "label": "Size"
+      },
+      "color": {
+        "label": "Color"
+      }
+    },
+    "color": {
+      "hintPreview": "Pick a color, type a HEX or an RGB value. The JSON will always export the color in HEX.",
+      "hintEdit": "Paste an existing HEX or RGB value to reuse exact colors.",
+      "hexPlaceholder": "#5eead4",
+      "rgbPlaceholder": "rgb(94, 234, 212)"
+    },
+    "editingBadge": "Editing"
+  },
+  "viewer": {
+    "emptyMessage": "Upload a PDF and click anywhere to add annotations. Edit them in the preview before confirming ✅."
+  }
+}

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -1,0 +1,48 @@
+{
+  "app": {
+    "title": "PDF Annotator",
+    "languageLabel": "Idioma",
+    "languageAriaLabel": "Selecciona el idioma de la aplicación",
+    "languages": {
+      "es-ES": "Español",
+      "en": "Inglés",
+      "ca": "Catalán"
+    }
+  },
+  "controls": {
+    "prev": "Anterior",
+    "next": "Siguiente",
+    "pageIndicator": "Página {{current}} / {{total}}",
+    "zoomLabel": "Zoom",
+    "clear": "Limpiar",
+    "copyJson": "Copiar JSON",
+    "downloadJson": "Descargar JSON"
+  },
+  "sidebar": {
+    "title": "Anotaciones (JSON)"
+  },
+  "annotation": {
+    "fields": {
+      "text": {
+        "label": "Texto",
+        "placeholder": "Texto..."
+      },
+      "size": {
+        "label": "Tamaño"
+      },
+      "color": {
+        "label": "Color"
+      }
+    },
+    "color": {
+      "hintPreview": "Selecciona un color, escribe un HEX o un RGB. El JSON siempre exportará el color en HEX.",
+      "hintEdit": "Puedes pegar un HEX o un RGB existente para reutilizar colores exactos.",
+      "hexPlaceholder": "#5eead4",
+      "rgbPlaceholder": "rgb(94, 234, 212)"
+    },
+    "editingBadge": "Editando"
+  },
+  "viewer": {
+    "emptyMessage": "Sube un PDF y haz click donde quieras añadir anotaciones. Edítalas en la vista previa antes de confirmar ✅."
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -46,6 +46,26 @@ header .logo {
   color: var(--accent);
 }
 
+.language-selector {
+  margin-left: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.language-selector label {
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.language-selector select {
+  background: var(--panel);
+  color: var(--text);
+  border-radius: 8px;
+  border: 1px solid #444;
+  padding: 6px 10px;
+}
+
 .input-file {
   background: var(--panel);
   color: var(--text);


### PR DESCRIPTION
## Summary
- add JSON-based translations and a translation pipe to localize the PDF annotator UI in Spanish, English, and Catalan
- expose a language selector and wire the component to the translation service
- introduce an i18n consistency check that runs before builds to keep locales in sync

## Testing
- npm run i18n:check
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ff9703fa0c832584f2f54a673e1185