### PR TITLE
Clear annotations when loading a new PDF

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -121,6 +121,9 @@ export class App implements AfterViewChecked {
     this.pdfDoc = await loadingTask.promise;
 
     this.pageIndex.set(1);
+    this.clearAll();
+    this.preview.set(null);
+    this.editing.set(null);
     await this.render();
   }
 


### PR DESCRIPTION
## Summary
- clear any existing annotations whenever a new PDF is selected
- reset preview and editing state after loading the new document

## Testing
- npm run lint *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68ff9c56e8108325be469a42f5ea1ad8