### PR TITLE
Set document metadata from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pdf-annotator",
+  "name": "Pdf Annotator",
   "version": "0.0.0",
   "author": "AAmoros",
   "scripts": {

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -8,6 +8,7 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
-    provideRouter(routes), provideClientHydration(withEventReplay())
+    provideRouter(routes),
+    provideClientHydration(withEventReplay()),
   ]
 };

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,8 +1,17 @@
 import { CommonModule } from '@angular/common';
-import { Component, ElementRef, ViewChild, signal, AfterViewChecked, HostListener, inject } from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  ViewChild,
+  signal,
+  AfterViewChecked,
+  HostListener,
+  inject,
+} from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import type { PDFDocumentProxy, PDFPageProxy } from 'pdfjs-dist';
 import * as pdfjsLib from 'pdfjs-dist/legacy/build/pdf';
+import { Meta, Title } from '@angular/platform-browser';
 import { TranslationPipe } from './i18n/translation.pipe';
 import { Language, TranslationService } from './i18n/translation.service';
 import { APP_AUTHOR, APP_NAME, APP_VERSION } from './app-version';
@@ -35,6 +44,8 @@ export class App implements AfterViewChecked {
   readonly appAuthor = APP_AUTHOR;
   readonly currentYear = new Date().getFullYear();
   private readonly translationService = inject(TranslationService);
+  private readonly title = inject(Title);
+  private readonly meta = inject(Meta);
   readonly languages: readonly Language[] = this.translationService.supportedLanguages;
   languageModel: Language = this.translationService.getCurrentLanguage();
 
@@ -60,11 +71,19 @@ export class App implements AfterViewChecked {
 
   constructor() {
     (pdfjsLib as any).GlobalWorkerOptions.workerSrc = '/assets/pdfjs/pdf.worker.min.mjs';
+    this.setDocumentMetadata();
   }
 
   onLanguageChange(language: string) {
     this.translationService.setLanguage(language as Language);
     this.languageModel = this.translationService.getCurrentLanguage();
+  }
+
+  private setDocumentMetadata() {
+    const appTitle = APP_NAME;
+    this.title.setTitle(appTitle);
+    this.meta.updateTag({ property: 'og:title', content: appTitle });
+    this.meta.updateTag({ name: 'twitter:title', content: appTitle });
   }
 
   ngAfterViewChecked() {

--- a/src/index.html
+++ b/src/index.html
@@ -3,13 +3,13 @@
 
 <head>
   <meta charset="utf-8">
-  <title>PdfAnnotator</title>
+  <title></title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 
   <!-- Open Graph -->
-  <meta property="og:title" content="PdfAnnotator">
+  <meta property="og:title" content="">
   <meta property="og:description" content="Anota tus PDFs fácilmente.">
   <meta property="og:image" content="https://pdf-annotator-rho.vercel.app/favicon-96x96.png">
   <meta property="og:url" content="https://pdf-annotator-rho.vercel.app">
@@ -17,7 +17,7 @@
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="PdfAnnotator">
+  <meta name="twitter:title" content="">
   <meta name="twitter:description" content="Anota tus PDFs fácilmente.">
   <meta name="twitter:image" content="https://pdf-annotator-rho.vercel.app/favicon-96x96.png">
 </head>


### PR DESCRIPTION
## Summary
- initialize the document title and social metadata from the package.json app name via the Angular Title and Meta services
- remove hard-coded PdfAnnotator strings from index.html so the runtime metadata updates cleanly

## Testing
- npm test -- --watch=false *(fails: No binary for Chrome browser on this platform)*

------
https://chatgpt.com/codex/tasks/task_e_68ffa336d1448325a8441ec91a51ec6d