### PR TITLE
Add support for importing annotation coordinates from JSON

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -5,6 +5,13 @@
     <input type="file" accept="application/pdf" (change)="onFileSelected($event)" class="input-file" />
 
     <div class="controls">
+      <input
+        #coordsFileInput
+        type="file"
+        accept="application/json"
+        (change)="onCoordsFileSelected($event)"
+        hidden
+      />
       <button class="btn" (click)="prevPage()" [disabled]="!pdfDoc || pageIndex()===1">◀
         {{ 'controls.prev' | t }}</button>
       <span
@@ -18,6 +25,7 @@
 
       <button class="btn danger" (click)="clearAll()" [disabled]="!coords().length">{{ 'controls.clear' | t }}</button>
       <button class="btn" (click)="copyJSON()" [disabled]="!coords().length">{{ 'controls.copyJson' | t }}</button>
+      <button class="btn" (click)="triggerImportCoords()" [disabled]="!pdfDoc">{{ 'controls.importJson' | t }}</button>
       <button class="btn" (click)="downloadJSON()"
         [disabled]="!coords().length">{{ 'controls.downloadJson' | t }}</button>
       <button class="btn" (click)="downloadAnnotatedPDF()"

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -25,7 +25,6 @@
 
       <button class="btn danger" (click)="clearAll()" [disabled]="!coords().length">{{ 'controls.clear' | t }}</button>
       <button class="btn" (click)="copyJSON()" [disabled]="!coords().length">{{ 'controls.copyJson' | t }}</button>
-      <button class="btn" (click)="triggerImportCoords()" [disabled]="!pdfDoc">{{ 'controls.importJson' | t }}</button>
       <button class="btn" (click)="downloadJSON()"
         [disabled]="!coords().length">{{ 'controls.downloadJson' | t }}</button>
       <button class="btn" (click)="downloadAnnotatedPDF()"
@@ -45,7 +44,21 @@
   <!-- LATERAL SIDEBAR -->
   <aside class="sidebar">
     <h4>{{ 'sidebar.title' | t }}</h4>
-    <pre class="json">{{ coords() | json }}</pre>
+    <div class="sidebar-actions">
+      <button type="button" class="btn" (click)="triggerImportCoords()" [disabled]="!pdfDoc">
+        {{ 'sidebar.importJsonFile' | t }}
+      </button>
+      <button type="button" class="btn" (click)="applyCoordsText()">
+        {{ 'sidebar.applyJson' | t }}
+      </button>
+    </div>
+    <textarea
+      class="json-editor"
+      [(ngModel)]="coordsTextModel"
+      [placeholder]="'sidebar.jsonPlaceholder' | t"
+      spellcheck="false"
+    ></textarea>
+    <small class="sidebar-hint">{{ 'sidebar.jsonHint' | t }}</small>
   </aside>
 
   <!-- VISOR PDF -->

--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -16,6 +16,7 @@
     "zoomLabel": "Zoom",
     "clear": "Esborrar",
     "copyJson": "Copiar JSON",
+    "importJson": "Importar JSON",
     "downloadJson": "Descarregar JSON",
     "downloadPdf": "Descarregar PDF"
   },

--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -21,7 +21,11 @@
     "downloadPdf": "Descarregar PDF"
   },
   "sidebar": {
-    "title": "Anotacions (JSON)"
+    "title": "Anotacions (JSON)",
+    "importJsonFile": "Importa des d'un fitxer",
+    "applyJson": "Aplica el JSON",
+    "jsonPlaceholder": "Enganxa o edita aquí les coordenades de les anotacions...",
+    "jsonHint": "Enganxa les coordenades o importa-les des d'un fitxer JSON amb el mateix format que l'exportat."
   },
   "annotation": {
     "fields": {

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -21,7 +21,11 @@
     "downloadPdf": "Download PDF"
   },
   "sidebar": {
-    "title": "Annotations (JSON)"
+    "title": "Annotations (JSON)",
+    "importJsonFile": "Import from file",
+    "applyJson": "Apply JSON",
+    "jsonPlaceholder": "Paste or edit annotation coordinates here...",
+    "jsonHint": "Paste coordinates or import them from a JSON file following the same format as the exported data."
   },
   "annotation": {
     "fields": {

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -16,6 +16,7 @@
     "zoomLabel": "Zoom",
     "clear": "Clear",
     "copyJson": "Copy JSON",
+    "importJson": "Import JSON",
     "downloadJson": "Download JSON",
     "downloadPdf": "Download PDF"
   },

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -16,6 +16,7 @@
     "zoomLabel": "Zoom",
     "clear": "Limpiar",
     "copyJson": "Copiar JSON",
+    "importJson": "Importar JSON",
     "downloadJson": "Descargar JSON",
     "downloadPdf": "Descargar PDF"
   },

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -21,7 +21,11 @@
     "downloadPdf": "Descargar PDF"
   },
   "sidebar": {
-    "title": "Anotaciones (JSON)"
+    "title": "Anotaciones (JSON)",
+    "importJsonFile": "Importar desde archivo",
+    "applyJson": "Aplicar JSON",
+    "jsonPlaceholder": "Pega o edita aquí las coordenadas de anotaciones...",
+    "jsonHint": "Pega las coordenadas o impórtalas desde un JSON con el mismo formato que el archivo exportado."
   },
   "annotation": {
     "fields": {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -126,12 +126,38 @@ header .logo {
     color: var(--accent);
   }
 
-  .json {
-    font-family: monospace;
-    font-size: .85rem;
-    white-space: pre-wrap;
-    word-break: break-word;
+  .sidebar-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 8px;
+  }
+
+  .json-editor {
+    width: 100%;
+    min-height: 220px;
+    border-radius: 8px;
+    border: 1px solid #444;
+    background: #1d1d2a;
     color: var(--text);
+    padding: 10px;
+    font-family: 'Fira Code', monospace;
+    font-size: 0.85rem;
+    resize: vertical;
+  }
+
+  .json-editor:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 2px rgba(94, 234, 212, 0.15);
+  }
+
+  .sidebar-hint {
+    display: block;
+    margin-top: 8px;
+    font-size: 0.75rem;
+    color: var(--muted);
+    line-height: 1.4;
   }
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated control to load annotation coordinates from a JSON file
- validate and normalize imported annotations before updating the canvas
- add localization strings for the new import action

## Testing
- npm run i18n:check

------
https://chatgpt.com/codex/tasks/task_e_68ffd9e98bf483259d670c87e7404ce3