### PR TITLE
feat: add font selection for annotations

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -82,6 +82,15 @@
           <span class="field-label">{{ 'annotation.fields.size.label' | t }}</span>
           <input type="number" [(ngModel)]="p.field.fontSize" min="8" max="72" />
         </label>
+        <label class="field">
+          <span class="field-label">{{ 'annotation.fields.font.label' | t }}</span>
+          <select [(ngModel)]="p.field.fontType">
+            <option *ngFor="let option of fontOptions" [ngValue]="option.cssDeclaration"
+              [style.fontFamily]="option.fontFamilyValue">
+              {{ option.labelKey | t }}
+            </option>
+          </select>
+        </label>
         <div class="color-section">
           <span class="field-label">{{ 'annotation.fields.color.label' | t }}</span>
           <div class="color-row">
@@ -114,6 +123,15 @@
         <label class="field field-small">
           <span class="field-label">{{ 'annotation.fields.size.label' | t }}</span>
           <input type="number" [(ngModel)]="e.field.fontSize" min="8" max="72" />
+        </label>
+        <label class="field">
+          <span class="field-label">{{ 'annotation.fields.font.label' | t }}</span>
+          <select [(ngModel)]="e.field.fontType">
+            <option *ngFor="let option of fontOptions" [ngValue]="option.cssDeclaration"
+              [style.fontFamily]="option.fontFamilyValue">
+              {{ option.labelKey | t }}
+            </option>
+          </select>
         </label>
         <div class="color-section">
           <span class="field-label">{{ 'annotation.fields.color.label' | t }}</span>

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -11,7 +11,6 @@ import {
 import { FormsModule } from '@angular/forms';
 import type { PDFDocumentProxy, PDFPageProxy } from 'pdfjs-dist';
 import * as pdfjsLib from 'pdfjs-dist/legacy/build/pdf';
-import type { PDFFont } from 'pdf-lib';
 import { Meta, Title } from '@angular/platform-browser';
 import { TranslationPipe } from './i18n/translation.pipe';
 import { Language, TranslationService } from './i18n/translation.service';
@@ -957,7 +956,7 @@ export class App implements AfterViewChecked {
       }
 
       this.rememberPdfBytes(usedBytes, 3);
-      const fontCache = new Map<PdfFontKey, PDFFont>();
+      const fontCache = new Map<PdfFontKey, unknown>();
       const loadFont = async (fontKey: PdfFontKey) => {
         if (!fontCache.has(fontKey)) {
           const embedded = await pdf.embedFont(StandardFonts[fontKey]);

--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -36,6 +36,14 @@
       "size": {
         "label": "Mida"
       },
+      "font": {
+        "label": "Tipus de lletra",
+        "options": {
+          "sans": "Sans-serif (Helvetica / Arial)",
+          "serif": "Serif (Times New Roman)",
+          "mono": "Monoespaiada (Courier New)"
+        }
+      },
       "color": {
         "label": "Color"
       }

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -36,6 +36,14 @@
       "size": {
         "label": "Size"
       },
+      "font": {
+        "label": "Font",
+        "options": {
+          "sans": "Sans-serif (Helvetica / Arial)",
+          "serif": "Serif (Times New Roman)",
+          "mono": "Monospace (Courier New)"
+        }
+      },
       "color": {
         "label": "Color"
       }

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -36,6 +36,14 @@
       "size": {
         "label": "Tamaño"
       },
+      "font": {
+        "label": "Fuente",
+        "options": {
+          "sans": "Sans-serif (Helvetica / Arial)",
+          "serif": "Serif (Times New Roman)",
+          "mono": "Monoespaciada (Courier New)"
+        }
+      },
       "color": {
         "label": "Color"
       }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -290,7 +290,8 @@ header .logo {
   backdrop-filter: blur(10px);
 
   input[type="text"],
-  input[type="number"] {
+  input[type="number"],
+  select {
     border-radius: 4px;
     border: 1px solid rgba(94, 234, 212, 0.25);
     padding: 6px;
@@ -299,7 +300,8 @@ header .logo {
     font-size: .9rem;
   }
 
-  input[type="number"] {
+  input[type="number"],
+  select {
     width: 100%;
   }
 


### PR DESCRIPTION
## Summary
- add a font selector to the annotation preview and edit dialogs
- persist the chosen font in annotation data with a sensible default
- embed the corresponding font when rendering the annotated PDF and update translations/styles

## Testing
- npm run i18n:check

------
