### PR TITLE
[OK] Fix PDF.js worker selection for older Chrome

### DIFF
--- a/public/assets/pdfjs/pdf.worker.entry.mjs
+++ b/public/assets/pdfjs/pdf.worker.entry.mjs
@@ -1,0 +1,19 @@
+if (typeof Promise.withResolvers !== 'function') {
+  Promise.withResolvers = function () {
+    let resolve;
+    let reject;
+
+    const promise = new Promise((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+
+    return {
+      promise,
+      resolve,
+      reject,
+    };
+  };
+}
+
+import './pdf.worker.min.mjs';

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -16,6 +16,7 @@ import { TranslationPipe } from './i18n/translation.pipe';
 import { Language, TranslationService } from './i18n/translation.service';
 import { APP_AUTHOR, APP_NAME, APP_VERSION } from './app-version';
 import './promise-with-resolvers.polyfill';
+import './array-buffer-transfer.polyfill';
 
 const PDF_WORKER_MODULE_SRC = '/assets/pdfjs/pdf.worker.entry.mjs';
 const PDF_WORKER_TYPE_MODULE = 'module';

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -29,6 +29,13 @@ function supportsModuleWorkers(): boolean {
     return false;
   }
 
+  const promiseConstructor = Promise as PromiseConstructor & {
+    withResolvers?: unknown;
+  };
+  if (typeof promiseConstructor.withResolvers !== 'function') {
+    return false;
+  }
+
   try {
     const tester = new Worker(
       URL.createObjectURL(new Blob(['export {};'], { type: 'application/javascript' })),

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -18,6 +18,8 @@ import { APP_AUTHOR, APP_NAME, APP_VERSION } from './app-version';
 
 const PDF_WORKER_CLASSIC_SRC = '/assets/pdfjs/pdf.worker.min.js';
 const PDF_WORKER_MODULE_SRC = '/assets/pdfjs/pdf.worker.min.mjs';
+const PDF_WORKER_TYPE_CLASSIC = 'classic';
+const PDF_WORKER_TYPE_MODULE = 'module';
 
 function detectModuleWorkerWithResolversSupport(): Promise<boolean> {
   if (
@@ -66,10 +68,12 @@ function detectModuleWorkerWithResolversSupport(): Promise<boolean> {
 }
 
 (pdfjsLib as any).GlobalWorkerOptions.workerSrc = PDF_WORKER_CLASSIC_SRC;
+(pdfjsLib as any).GlobalWorkerOptions.workerType = PDF_WORKER_TYPE_CLASSIC;
 
 void detectModuleWorkerWithResolversSupport().then((supported) => {
   if (supported) {
     (pdfjsLib as any).GlobalWorkerOptions.workerSrc = PDF_WORKER_MODULE_SRC;
+    (pdfjsLib as any).GlobalWorkerOptions.workerType = PDF_WORKER_TYPE_MODULE;
   }
 });
 

--- a/src/app/promise-with-resolvers.polyfill.ts
+++ b/src/app/promise-with-resolvers.polyfill.ts
@@ -1,0 +1,34 @@
+/* Polyfill Promise.withResolvers for browsers that lack it. */
+
+type Resolver<T> = (value: T | PromiseLike<T>) => void;
+type Rejecter = (reason?: unknown) => void;
+
+type PromiseWithResolversResult<T> = {
+  promise: Promise<T>;
+  resolve: Resolver<T>;
+  reject: Rejecter;
+};
+
+type PromiseWithResolversFn = <T>() => PromiseWithResolversResult<T>;
+
+const promiseConstructor = Promise as PromiseConstructor & {
+  withResolvers?: PromiseWithResolversFn;
+};
+
+if (typeof promiseConstructor.withResolvers !== 'function') {
+  promiseConstructor.withResolvers = function <T>() {
+    let resolve!: Resolver<T>;
+    let reject!: Rejecter;
+
+    const promise = new Promise<T>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+
+    return {
+      promise,
+      resolve,
+      reject,
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- detect module worker support at runtime before selecting the PDF.js worker bundle
- keep using the legacy worker when module workers are unavailable to restore compatibility with Chrome 113

## Testing
- npm run build

------
