### PR TITLE
Add configurable JSON export templates

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -44,6 +44,187 @@
   <!-- LATERAL SIDEBAR -->
   <aside class="sidebar">
     <h4>{{ 'sidebar.title' | t }}</h4>
+    <section class="json-configurator">
+      <label class="json-configurator__select">
+        <span>{{ 'jsonConfig.selectLabel' | t }}</span>
+        <select
+          [ngModel]="selectedConfigId()"
+          (ngModelChange)="onJsonConfigChange($event)"
+          [ngModelOptions]="{ standalone: true }"
+          [attr.aria-label]="'jsonConfig.selectAriaLabel' | t"
+        >
+          <option *ngFor="let config of jsonConfigs()" [value]="config.id">
+            {{ config.name }}<ng-container *ngIf="config.version"> · {{ config.version }}</ng-container>
+          </option>
+        </select>
+      </label>
+
+      <div class="json-configurator__actions">
+        <button type="button" class="btn" (click)="createJsonConfigFromCurrent()">
+          {{ 'jsonConfig.actions.duplicate' | t }}
+        </button>
+        <button
+          type="button"
+          class="btn danger"
+          (click)="deleteSelectedJsonConfig()"
+          [disabled]="isDefaultConfigSelected()"
+        >
+          {{ 'jsonConfig.actions.delete' | t }}
+        </button>
+        <button type="button" class="btn" (click)="exportSelectedJsonConfig()">
+          {{ 'jsonConfig.actions.export' | t }}
+        </button>
+        <button type="button" class="btn" (click)="triggerImportConfig()">
+          {{ 'jsonConfig.actions.import' | t }}
+        </button>
+        <input
+          #configFileInput
+          type="file"
+          accept="application/json"
+          (change)="onConfigFileSelected($event)"
+          hidden
+        />
+      </div>
+
+      <ng-container *ngIf="editingConfig(); else defaultConfigNotice">
+        <div class="json-configurator__editor">
+          <div class="json-configurator__row">
+            <label>
+              <span>{{ 'jsonConfig.edit.name' | t }}</span>
+              <input
+                type="text"
+                [ngModel]="editingConfig()?.name || ''"
+                (ngModelChange)="updateEditingConfigField('name', $event)"
+                [ngModelOptions]="{ standalone: true }"
+              />
+            </label>
+            <label>
+              <span>{{ 'jsonConfig.edit.version' | t }}</span>
+              <input
+                type="text"
+                [ngModel]="editingConfig()?.version || ''"
+                (ngModelChange)="updateEditingConfigField('version', $event)"
+                [ngModelOptions]="{ standalone: true }"
+              />
+            </label>
+          </div>
+
+          <div class="json-configurator__row">
+            <label>
+              <span>{{ 'jsonConfig.edit.root' | t }}</span>
+              <select
+                [ngModel]="editingConfig()?.root || 'object'"
+                (ngModelChange)="updateEditingConfigField('root', $event)"
+                [ngModelOptions]="{ standalone: true }"
+              >
+                <option value="object">{{ 'jsonConfig.edit.rootOptions.object' | t }}</option>
+                <option value="array">{{ 'jsonConfig.edit.rootOptions.array' | t }}</option>
+              </select>
+            </label>
+            <label>
+              <span>{{ 'jsonConfig.edit.pagesKey' | t }}</span>
+              <input
+                type="text"
+                [ngModel]="editingConfig()?.pagesKey || ''"
+                (ngModelChange)="updateEditingConfigField('pagesKey', $event)"
+                [ngModelOptions]="{ standalone: true }"
+              />
+            </label>
+          </div>
+
+          <div class="json-configurator__row">
+            <label>
+              <span>{{ 'jsonConfig.edit.pageNumberKey' | t }}</span>
+              <input
+                type="text"
+                [ngModel]="editingConfig()?.pageNumberKey || ''"
+                (ngModelChange)="updateEditingConfigField('pageNumberKey', $event)"
+                [ngModelOptions]="{ standalone: true }"
+              />
+            </label>
+            <label>
+              <span>{{ 'jsonConfig.edit.fieldsKey' | t }}</span>
+              <input
+                type="text"
+                [ngModel]="editingConfig()?.fieldsKey || ''"
+                (ngModelChange)="updateEditingConfigField('fieldsKey', $event)"
+                [ngModelOptions]="{ standalone: true }"
+              />
+            </label>
+          </div>
+
+          <div class="json-configurator__grid">
+            <label>
+              <span>{{ 'jsonConfig.edit.fieldKeys.mapField' | t }}</span>
+              <input
+                type="text"
+                [ngModel]="editingConfig()?.fieldKeys?.mapField || ''"
+                (ngModelChange)="updateEditingConfigField('fieldKeys.mapField', $event)"
+                [ngModelOptions]="{ standalone: true }"
+              />
+            </label>
+            <label>
+              <span>{{ 'jsonConfig.edit.fieldKeys.x' | t }}</span>
+              <input
+                type="text"
+                [ngModel]="editingConfig()?.fieldKeys?.x || ''"
+                (ngModelChange)="updateEditingConfigField('fieldKeys.x', $event)"
+                [ngModelOptions]="{ standalone: true }"
+              />
+            </label>
+            <label>
+              <span>{{ 'jsonConfig.edit.fieldKeys.y' | t }}</span>
+              <input
+                type="text"
+                [ngModel]="editingConfig()?.fieldKeys?.y || ''"
+                (ngModelChange)="updateEditingConfigField('fieldKeys.y', $event)"
+                [ngModelOptions]="{ standalone: true }"
+              />
+            </label>
+            <label>
+              <span>{{ 'jsonConfig.edit.fieldKeys.fontSize' | t }}</span>
+              <input
+                type="text"
+                [ngModel]="editingConfig()?.fieldKeys?.fontSize || ''"
+                (ngModelChange)="updateEditingConfigField('fieldKeys.fontSize', $event)"
+                [ngModelOptions]="{ standalone: true }"
+              />
+            </label>
+            <label>
+              <span>{{ 'jsonConfig.edit.fieldKeys.color' | t }}</span>
+              <input
+                type="text"
+                [ngModel]="editingConfig()?.fieldKeys?.color || ''"
+                (ngModelChange)="updateEditingConfigField('fieldKeys.color', $event)"
+                [ngModelOptions]="{ standalone: true }"
+              />
+            </label>
+          </div>
+
+          <div class="json-configurator__editor-actions">
+            <button
+              type="button"
+              class="btn"
+              (click)="saveEditingConfig()"
+              [disabled]="!editingConfigDirty()"
+            >
+              {{ 'jsonConfig.edit.save' | t }}
+            </button>
+            <button
+              type="button"
+              class="btn"
+              (click)="resetEditingConfig()"
+              [disabled]="!editingConfigDirty()"
+            >
+              {{ 'jsonConfig.edit.reset' | t }}
+            </button>
+          </div>
+        </div>
+      </ng-container>
+      <ng-template #defaultConfigNotice>
+        <p class="json-configurator__info">{{ 'jsonConfig.defaultInfo' | t }}</p>
+      </ng-template>
+    </section>
     <div class="sidebar-actions">
       <button type="button" class="btn" (click)="triggerImportCoords()" [disabled]="!pdfDoc">
         {{ 'sidebar.importJsonFile' | t }}

--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -27,6 +27,43 @@
     "jsonPlaceholder": "Enganxa o edita aquí les coordenades de les anotacions...",
     "jsonHint": "Enganxa les coordenades o importa-les des d'un fitxer JSON amb el mateix format que l'exportat."
   },
+  "jsonConfig": {
+    "selectLabel": "Format JSON",
+    "selectAriaLabel": "Selecciona la plantilla d'exportació JSON",
+    "actions": {
+      "duplicate": "Duplicar configuració",
+      "delete": "Suprimeix",
+      "export": "Exporta la configuració",
+      "import": "Importa la configuració"
+    },
+    "edit": {
+      "name": "Nom visible",
+      "version": "Etiqueta de versió",
+      "root": "Tipus d'arrel",
+      "rootOptions": {
+        "object": "Objecte amb col·lecció",
+        "array": "Array de pàgines"
+      },
+      "pagesKey": "Clau de la col·lecció de pàgines",
+      "pageNumberKey": "Clau del número de pàgina",
+      "fieldsKey": "Clau dels camps",
+      "fieldKeys": {
+        "mapField": "Clau del nom del camp",
+        "x": "Clau de la coordenada X",
+        "y": "Clau de la coordenada Y",
+        "fontSize": "Clau de la mida de lletra",
+        "color": "Clau del color"
+      },
+      "save": "Desa la configuració",
+      "reset": "Descarta els canvis"
+    },
+    "defaultInfo": "La configuració «Predeterminada V1» manté el format original del JSON.",
+    "newName": "Configuració personalitzada",
+    "importSuccess": "S'ha importat la configuració «{{ name }}».",
+    "importError": "No s'ha pogut importar la configuració JSON. Revisa el format.",
+    "validationError": "Comprova que tots els camps de la configuració tinguin un valor vàlid.",
+    "deleteConfirm": "Segur que vols eliminar la configuració «{{ name }}»?"
+  },
   "annotation": {
     "fields": {
       "text": {

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -27,6 +27,43 @@
     "jsonPlaceholder": "Paste or edit annotation coordinates here...",
     "jsonHint": "Paste coordinates or import them from a JSON file following the same format as the exported data."
   },
+  "jsonConfig": {
+    "selectLabel": "JSON format",
+    "selectAriaLabel": "Select the JSON export template",
+    "actions": {
+      "duplicate": "Duplicate configuration",
+      "delete": "Delete",
+      "export": "Export configuration",
+      "import": "Import configuration"
+    },
+    "edit": {
+      "name": "Display name",
+      "version": "Version label",
+      "root": "Root type",
+      "rootOptions": {
+        "object": "Object with collection",
+        "array": "Array of pages"
+      },
+      "pagesKey": "Pages collection key",
+      "pageNumberKey": "Page number key",
+      "fieldsKey": "Fields key",
+      "fieldKeys": {
+        "mapField": "Field name key",
+        "x": "X coordinate key",
+        "y": "Y coordinate key",
+        "fontSize": "Font size key",
+        "color": "Color key"
+      },
+      "save": "Save configuration",
+      "reset": "Discard changes"
+    },
+    "defaultInfo": "The “Predeterminada V1” configuration keeps the original JSON format.",
+    "newName": "Custom configuration",
+    "importSuccess": "Configuration “{{ name }}” imported successfully.",
+    "importError": "The JSON configuration could not be imported. Check the format.",
+    "validationError": "Make sure every configuration field has a valid value.",
+    "deleteConfirm": "Are you sure you want to delete the configuration “{{ name }}”?"
+  },
   "annotation": {
     "fields": {
       "text": {

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -27,6 +27,43 @@
     "jsonPlaceholder": "Pega o edita aquí las coordenadas de anotaciones...",
     "jsonHint": "Pega las coordenadas o impórtalas desde un JSON con el mismo formato que el archivo exportado."
   },
+  "jsonConfig": {
+    "selectLabel": "Formato de JSON",
+    "selectAriaLabel": "Selecciona la plantilla de exportación de JSON",
+    "actions": {
+      "duplicate": "Duplicar configuración",
+      "delete": "Eliminar",
+      "export": "Exportar configuración",
+      "import": "Importar configuración"
+    },
+    "edit": {
+      "name": "Nombre visible",
+      "version": "Etiqueta de versión",
+      "root": "Tipo de raíz",
+      "rootOptions": {
+        "object": "Objeto con colección",
+        "array": "Array de páginas"
+      },
+      "pagesKey": "Clave de la colección de páginas",
+      "pageNumberKey": "Clave del número de página",
+      "fieldsKey": "Clave de los campos",
+      "fieldKeys": {
+        "mapField": "Clave del nombre del campo",
+        "x": "Clave de la coordenada X",
+        "y": "Clave de la coordenada Y",
+        "fontSize": "Clave del tamaño de fuente",
+        "color": "Clave del color"
+      },
+      "save": "Guardar configuración",
+      "reset": "Descartar cambios"
+    },
+    "defaultInfo": "La configuración «Predeterminada V1» mantiene el formato original del JSON.",
+    "newName": "Configuración personalizada",
+    "importSuccess": "Se importó la configuración «{{ name }}».",
+    "importError": "No se pudo importar la configuración JSON. Revisa el formato.",
+    "validationError": "Revisa que todos los campos de la configuración tengan un valor válido.",
+    "deleteConfirm": "¿Seguro que deseas eliminar la configuración «{{ name }}»?"
+  },
   "annotation": {
     "fields": {
       "text": {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -133,6 +133,107 @@ header .logo {
     margin-bottom: 8px;
   }
 
+  .json-configurator {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin-bottom: 12px;
+    padding: 10px;
+    border-radius: 10px;
+    border: 1px solid rgba(94, 234, 212, 0.15);
+    background: rgba(17, 17, 28, 0.65);
+
+    &__select {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      font-size: 0.8rem;
+      color: var(--muted);
+
+      select {
+        background: #1d1d2a;
+        color: var(--text);
+        border: 1px solid #3c3c52;
+        border-radius: 6px;
+        padding: 6px 10px;
+      }
+    }
+
+    &__actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    &__editor {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    &__row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+
+      label {
+        flex: 1 1 160px;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        font-size: 0.75rem;
+        color: var(--muted);
+
+        input,
+        select {
+          background: #1d1d2a;
+          border: 1px solid #3c3c52;
+          border-radius: 6px;
+          padding: 6px 10px;
+          color: var(--text);
+          font-size: 0.85rem;
+        }
+      }
+    }
+
+    &__grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 10px;
+
+      label {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        font-size: 0.75rem;
+        color: var(--muted);
+
+        input {
+          background: #1d1d2a;
+          border: 1px solid #3c3c52;
+          border-radius: 6px;
+          padding: 6px 10px;
+          color: var(--text);
+          font-size: 0.85rem;
+        }
+      }
+    }
+
+    &__editor-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      justify-content: flex-end;
+    }
+
+    &__info {
+      margin: 0;
+      font-size: 0.8rem;
+      color: var(--muted);
+      line-height: 1.4;
+    }
+  }
+
   .json-editor {
     width: 100%;
     min-height: 220px;


### PR DESCRIPTION
## Summary
- add a configurable JSON template system with persistence, import/export, and schema-aware normalization
- expose a sidebar UI to select, duplicate, edit, delete, import, and export JSON templates with dedicated styling
- translate new controls and helper text into Spanish, English, and Catalan

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6900b9ef5ec88325916e68155887e95f