### PR TITLE
fix: replace deprecated json import assert

### DIFF
--- a/src/app/app-version.ts
+++ b/src/app/app-version.ts
@@ -1,4 +1,4 @@
-import packageJson from '../../package.json' assert { type: 'json' };
+import packageJson from '../../package.json' with { type: 'json' };
 
 type PackageAuthor = string | { name?: string } | undefined;
 


### PR DESCRIPTION
## Summary
- replace deprecated `assert` import attribute when loading package.json

## Testing
- npm run lint *(fails: script not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6901e5af26c083258cb0188d12a153f9