### PR TITLE
Add script to download remote font fallbacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "serve:ssr:pdf-annotator": "node dist/pdf-annotator/server/server.mjs",
-    "i18n:check": "node scripts/check-translations.mjs"
+    "i18n:check": "node scripts/check-translations.mjs",
+    "fonts:download": "node scripts/download-font-fallbacks.mjs"
   },
   "prettier": {
     "printWidth": 100,

--- a/scripts/download-font-fallbacks.mjs
+++ b/scripts/download-font-fallbacks.mjs
@@ -1,0 +1,289 @@
+#!/usr/bin/env node
+import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = path.resolve(__dirname, '..');
+const DEFAULT_OUTPUT_DIR = path.join(ROOT_DIR, 'public', 'fonts');
+const REMOTE_FALLBACK_PATH = path.join(
+  ROOT_DIR,
+  'src',
+  'app',
+  'config',
+  'fonts',
+  'font-remote-fallbacks.json'
+);
+
+const HELP_MESSAGE = `Usage: node scripts/download-font-fallbacks.mjs [options]
+
+Downloads the remote fallback font files declared in
+src/app/config/fonts/font-remote-fallbacks.json.
+
+Options:
+  --font <id>          Download the fallback files for a specific font. May be repeated.
+  --fonts <ids>        Comma separated list of font identifiers to download.
+  --output <dir>       Directory where the font folders will be created (default: public/fonts).
+  --force              Overwrite files even if they already exist.
+  --dry-run            Show the actions that would be performed without downloading files.
+  --help               Show this help message.
+`;
+
+let remoteFallbackMapCache = null;
+
+async function loadRemoteFallbackMap() {
+  if (remoteFallbackMapCache) {
+    return remoteFallbackMapCache;
+  }
+  const raw = await readFile(REMOTE_FALLBACK_PATH, 'utf8');
+  const parsed = JSON.parse(raw);
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error('Remote fallback map is not a valid object.');
+  }
+  remoteFallbackMapCache = parsed;
+  return remoteFallbackMapCache;
+}
+
+function parseArgs(argv) {
+  const options = {
+    fonts: new Set(),
+    outputDir: DEFAULT_OUTPUT_DIR,
+    force: false,
+    dryRun: false,
+    help: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    switch (token) {
+      case '--help':
+      case '-h':
+        options.help = true;
+        break;
+      case '--force':
+        options.force = true;
+        break;
+      case '--dry-run':
+        options.dryRun = true;
+        break;
+      case '--font':
+        {
+          const value = argv[i + 1];
+          if (!value) {
+            throw new Error('Missing value for --font');
+          }
+          options.fonts.add(value.trim());
+          i += 1;
+        }
+        break;
+      case '--fonts':
+        {
+          const value = argv[i + 1];
+          if (!value) {
+            throw new Error('Missing value for --fonts');
+          }
+          value
+            .split(',')
+            .map((part) => part.trim())
+            .filter(Boolean)
+            .forEach((id) => options.fonts.add(id));
+          i += 1;
+        }
+        break;
+      case '--output':
+        {
+          const value = argv[i + 1];
+          if (!value) {
+            throw new Error('Missing value for --output');
+          }
+          options.outputDir = path.resolve(ROOT_DIR, value);
+          i += 1;
+        }
+        break;
+      default:
+        if (token.startsWith('-')) {
+          throw new Error(`Unknown option: ${token}`);
+        }
+        options.fonts.add(token);
+        break;
+    }
+  }
+
+  return options;
+}
+
+async function fileExists(filePath) {
+  try {
+    await access(filePath, fsConstants.F_OK);
+    return true;
+  } catch (error) {
+    if (error && (error.code === 'ENOENT' || error.code === 'ENOTDIR')) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function normaliseFontId(value) {
+  return value.trim().toLowerCase();
+}
+
+function selectFonts(requested, fallbackMap) {
+  const requestedIds = Array.from(requested)
+    .map(normaliseFontId)
+    .filter(Boolean);
+
+  if (!requestedIds.length) {
+    return Object.keys(fallbackMap).sort();
+  }
+
+  const available = new Set(Object.keys(fallbackMap).map(normaliseFontId));
+  const valid = [];
+  for (const id of requestedIds) {
+    if (available.has(id)) {
+      valid.push(id);
+    } else {
+      console.warn(`Ignoring unknown font id: ${id}`);
+    }
+  }
+  return valid;
+}
+
+function getFileNameFromUrl(url) {
+  try {
+    const parsed = new URL(url);
+    const pathname = parsed.pathname;
+    const lastSegment = pathname?.split('/')?.filter(Boolean).pop();
+    if (lastSegment) {
+      return lastSegment;
+    }
+  } catch (error) {
+    // fall through to basename heuristic
+  }
+
+  const sanitized = url.split('?')[0] ?? url;
+  return path.basename(sanitized);
+}
+
+async function downloadToFile(url, filePath, { force, dryRun }) {
+  const alreadyExists = await fileExists(filePath);
+
+  if (dryRun) {
+    if (alreadyExists && !force) {
+      console.log(`[dry-run] Would keep existing file: ${filePath}`);
+      return 'dry-run';
+    }
+    console.log(`[dry-run] Would download ${url} -> ${filePath}`);
+    return 'dry-run';
+  }
+
+  if (!force && alreadyExists) {
+    console.log(`Skipping existing file: ${filePath}`);
+    return 'skipped';
+  }
+
+  await mkdir(path.dirname(filePath), { recursive: true });
+
+  const response = await fetch(url, {
+    headers: {
+      'User-Agent': 'pdf-annotator-font-fetcher/1.0 (+https://github.com/AlvaroMaxter/pdf-annotator)',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to download ${url} (${response.status} ${response.statusText})`);
+  }
+
+  const arrayBuffer = await response.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+  await writeFile(filePath, buffer);
+  console.log(`Downloaded ${url} -> ${filePath}`);
+  return 'downloaded';
+}
+
+async function downloadFont(fontId, urls, options) {
+  if (!Array.isArray(urls) || !urls.length) {
+    console.warn(`No fallback URLs declared for font '${fontId}'.`);
+    return { fontId, downloaded: 0, skipped: 0, dryRun: 0 };
+  }
+
+  let downloaded = 0;
+  let skipped = 0;
+  let dryRun = 0;
+
+  for (const rawUrl of urls) {
+    const url = typeof rawUrl === 'string' ? rawUrl.trim() : '';
+    if (!url) {
+      continue;
+    }
+    const fileName = getFileNameFromUrl(url);
+    if (!fileName) {
+      console.warn(`Unable to determine filename for ${url}; skipping.`);
+      skipped += 1;
+      continue;
+    }
+    const targetPath = path.join(options.outputDir, fontId, fileName);
+    const result = await downloadToFile(url, targetPath, options);
+    if (result === 'downloaded') {
+      downloaded += 1;
+    } else if (result === 'dry-run') {
+      dryRun += 1;
+    } else {
+      skipped += 1;
+    }
+  }
+
+  return { fontId, downloaded, skipped, dryRun };
+}
+
+async function main() {
+  let options;
+  try {
+    options = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    console.error(error.message || error);
+    process.exitCode = 1;
+    console.log('\n' + HELP_MESSAGE.trim());
+    return;
+  }
+
+  if (options.help) {
+    console.log(HELP_MESSAGE.trim());
+    return;
+  }
+
+  const fallbackMap = await loadRemoteFallbackMap();
+  const selectedFonts = selectFonts(options.fonts, fallbackMap);
+  if (!selectedFonts.length) {
+    console.log('Nothing to do.');
+    return;
+  }
+
+  console.log(`Downloading fallback fonts to ${options.outputDir}`);
+
+  const summaries = [];
+  for (const fontId of selectedFonts) {
+    const urls =
+      fallbackMap[fontId] ?? fallbackMap[normaliseFontId(fontId)] ?? fallbackMap[fontId.toLowerCase()];
+    const summary = await downloadFont(normaliseFontId(fontId), urls, options);
+    summaries.push(summary);
+  }
+
+  const totalDownloaded = summaries.reduce((acc, item) => acc + item.downloaded, 0);
+  const totalSkipped = summaries.reduce((acc, item) => acc + item.skipped, 0);
+  const totalDryRun = summaries.reduce((acc, item) => acc + item.dryRun, 0);
+
+  if (options.dryRun) {
+    console.log(
+      `\nSummary: would download ${totalDryRun} file(s); skipped ${totalSkipped} existing file(s).`
+    );
+  } else {
+    console.log(`\nSummary: downloaded ${totalDownloaded} file(s), skipped ${totalSkipped} file(s).`);
+  }
+}
+
+main().catch((error) => {
+  console.error('Failed to download fallback fonts:', error);
+  process.exit(1);
+});

--- a/src/app/config/fonts/font-registry.json
+++ b/src/app/config/fonts/font-registry.json
@@ -3,288 +3,252 @@
     "id": "roboto",
     "label": "Roboto",
     "pdf": [
-      "/fonts/roboto/Roboto-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/apache/roboto/static/Roboto-Regular.ttf"
+      "/fonts/roboto/Roboto-Regular.ttf"
     ]
   },
   {
     "id": "poppins",
     "label": "Poppins",
     "pdf": [
-      "/fonts/poppins/Poppins-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/poppins/static/Poppins-Regular.ttf"
+      "/fonts/poppins/Poppins-Regular.ttf"
     ]
   },
   {
     "id": "inter",
     "label": "Inter",
     "pdf": [
-      "/fonts/inter/Inter-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/inter/static/Inter-Regular.ttf"
+      "/fonts/inter/Inter-Regular.ttf"
     ]
   },
   {
     "id": "montserrat",
     "label": "Montserrat",
     "pdf": [
-      "/fonts/montserrat/Montserrat-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/montserrat/static/Montserrat-Regular.ttf"
+      "/fonts/montserrat/Montserrat-Regular.ttf"
     ]
   },
   {
     "id": "lato",
     "label": "Lato",
     "pdf": [
-      "/fonts/lato/Lato-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/lato/static/Lato-Regular.ttf"
+      "/fonts/lato/Lato-Regular.ttf"
     ]
   },
   {
     "id": "nunito",
     "label": "Nunito",
     "pdf": [
-      "/fonts/nunito/Nunito-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/nunito/static/Nunito-Regular.ttf"
+      "/fonts/nunito/Nunito-Regular.ttf"
     ]
   },
   {
     "id": "open-sans",
     "label": "Open Sans",
     "pdf": [
-      "/fonts/open-sans/OpenSans-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/apache/opensans/static/OpenSans-Regular.ttf"
+      "/fonts/open-sans/OpenSans-Regular.ttf"
     ]
   },
   {
     "id": "manrope",
     "label": "Manrope",
     "pdf": [
-      "/fonts/manrope/Manrope-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/manrope/static/Manrope-Regular.ttf"
+      "/fonts/manrope/Manrope-Regular.ttf"
     ]
   },
   {
     "id": "fira-code",
     "label": "Fira Code",
     "pdf": [
-      "/fonts/fira-code/FiraCode-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/firacode/static/FiraCode-Regular.ttf"
+      "/fonts/fira-code/FiraCode-Regular.ttf"
     ]
   },
   {
     "id": "jetbrains-mono",
     "label": "JetBrains Mono",
     "pdf": [
-      "/fonts/jetbrains-mono/JetBrainsMono-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/jetbrainsmono/static/JetBrainsMono-Regular.ttf"
+      "/fonts/jetbrains-mono/JetBrainsMono-Regular.ttf"
     ]
   },
   {
     "id": "playfair-display",
     "label": "Playfair Display",
     "pdf": [
-      "/fonts/playfair-display/PlayfairDisplay-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/playfairdisplay/static/PlayfairDisplay-Regular.ttf"
+      "/fonts/playfair-display/PlayfairDisplay-Regular.ttf"
     ]
   },
   {
     "id": "merriweather",
     "label": "Merriweather",
     "pdf": [
-      "/fonts/merriweather/Merriweather-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/merriweather/static/Merriweather-Regular.ttf"
+      "/fonts/merriweather/Merriweather-Regular.ttf"
     ]
   },
   {
     "id": "source-serif-4",
     "label": "Source Serif 4",
     "pdf": [
-      "/fonts/source-serif-4/SourceSerif4-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/sourceserif4/static/SourceSerif4-Regular.ttf"
+      "/fonts/source-serif-4/SourceSerif4-Regular.ttf"
     ]
   },
   {
     "id": "raleway",
     "label": "Raleway",
     "pdf": [
-      "/fonts/raleway/Raleway-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/raleway/static/Raleway-Regular.ttf"
+      "/fonts/raleway/Raleway-Regular.ttf"
     ]
   },
   {
     "id": "oswald",
     "label": "Oswald",
     "pdf": [
-      "/fonts/oswald/Oswald-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/oswald/static/Oswald-Regular.ttf"
+      "/fonts/oswald/Oswald-Regular.ttf"
     ]
   },
   {
     "id": "work-sans",
     "label": "Work Sans",
     "pdf": [
-      "/fonts/work-sans/WorkSans-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/worksans/static/WorkSans-Regular.ttf"
+      "/fonts/work-sans/WorkSans-Regular.ttf"
     ]
   },
   {
     "id": "dm-sans",
     "label": "DM Sans",
     "pdf": [
-      "/fonts/dm-sans/DMSans-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/dmsans/static/DMSans-Regular.ttf"
+      "/fonts/dm-sans/DMSans-Regular.ttf"
     ]
   },
   {
     "id": "dm-serif-display",
     "label": "DM Serif Display",
     "pdf": [
-      "/fonts/dm-serif-display/DMSerifDisplay-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/dmserifdisplay/static/DMSerifDisplay-Regular.ttf"
+      "/fonts/dm-serif-display/DMSerifDisplay-Regular.ttf"
     ]
   },
   {
     "id": "noto-sans-jp",
     "label": "Noto Sans JP",
     "pdf": [
-      "/fonts/noto-sans-jp/NotoSansJP-Regular.otf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/notosansjp/NotoSansJP-Regular.otf"
+      "/fonts/noto-sans-jp/NotoSansJP-Regular.otf"
     ]
   },
   {
     "id": "noto-serif-display",
     "label": "Noto Serif Display",
     "pdf": [
-      "/fonts/noto-serif-display/NotoSerifDisplay-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/notoserifdisplay/static/NotoSerifDisplay-Regular.ttf"
+      "/fonts/noto-serif-display/NotoSerifDisplay-Regular.ttf"
     ]
   },
   {
     "id": "cabin",
     "label": "Cabin",
     "pdf": [
-      "/fonts/cabin/Cabin-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/cabin/static/Cabin-Regular.ttf"
+      "/fonts/cabin/Cabin-Regular.ttf"
     ]
   },
   {
     "id": "karla",
     "label": "Karla",
     "pdf": [
-      "/fonts/karla/Karla-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/karla/static/Karla-Regular.ttf"
+      "/fonts/karla/Karla-Regular.ttf"
     ]
   },
   {
     "id": "space-grotesk",
     "label": "Space Grotesk",
     "pdf": [
-      "/fonts/space-grotesk/SpaceGrotesk-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/spacegrotesk/static/SpaceGrotesk-Regular.ttf"
+      "/fonts/space-grotesk/SpaceGrotesk-Regular.ttf"
     ]
   },
   {
     "id": "sora",
     "label": "Sora",
     "pdf": [
-      "/fonts/sora/Sora-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/sora/static/Sora-Regular.ttf"
+      "/fonts/sora/Sora-Regular.ttf"
     ]
   },
   {
     "id": "bitter",
     "label": "Bitter",
     "pdf": [
-      "/fonts/bitter/Bitter-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/bitter/static/Bitter-Regular.ttf"
+      "/fonts/bitter/Bitter-Regular.ttf"
     ]
   },
   {
     "id": "archivo",
     "label": "Archivo",
     "pdf": [
-      "/fonts/archivo/Archivo-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/archivo/static/Archivo-Regular.ttf"
+      "/fonts/archivo/Archivo-Regular.ttf"
     ]
   },
   {
     "id": "heebo",
     "label": "Heebo",
     "pdf": [
-      "/fonts/heebo/Heebo-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/heebo/static/Heebo-Regular.ttf"
+      "/fonts/heebo/Heebo-Regular.ttf"
     ]
   },
   {
     "id": "crimson-pro",
     "label": "Crimson Pro",
     "pdf": [
-      "/fonts/crimson-pro/CrimsonPro-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/crimsonpro/static/CrimsonPro-Regular.ttf"
+      "/fonts/crimson-pro/CrimsonPro-Regular.ttf"
     ]
   },
   {
     "id": "ibm-plex-sans",
     "label": "IBM Plex Sans",
     "pdf": [
-      "/fonts/ibm-plex-sans/IBMPlexSans-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/ibmplexsans/static/IBMPlexSans-Regular.ttf"
+      "/fonts/ibm-plex-sans/IBMPlexSans-Regular.ttf"
     ]
   },
   {
     "id": "ibm-plex-serif",
     "label": "IBM Plex Serif",
     "pdf": [
-      "/fonts/ibm-plex-serif/IBMPlexSerif-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/ibmplexserif/static/IBMPlexSerif-Regular.ttf"
+      "/fonts/ibm-plex-serif/IBMPlexSerif-Regular.ttf"
     ]
   },
   {
     "id": "ibm-plex-mono",
     "label": "IBM Plex Mono",
     "pdf": [
-      "/fonts/ibm-plex-mono/IBMPlexMono-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/ibmplexmono/static/IBMPlexMono-Regular.ttf"
+      "/fonts/ibm-plex-mono/IBMPlexMono-Regular.ttf"
     ]
   },
   {
     "id": "urbanist",
     "label": "Urbanist",
     "pdf": [
-      "/fonts/urbanist/Urbanist-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/urbanist/static/Urbanist-Regular.ttf"
+      "/fonts/urbanist/Urbanist-Regular.ttf"
     ]
   },
   {
     "id": "sofia-sans",
     "label": "Sofia Sans",
     "pdf": [
-      "/fonts/sofia-sans/SofiaSans-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/sofiasans/static/SofiaSans-Regular.ttf"
+      "/fonts/sofia-sans/SofiaSans-Regular.ttf"
     ]
   },
   {
     "id": "asap",
     "label": "Asap",
     "pdf": [
-      "/fonts/asap/Asap-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/asap/static/Asap-Regular.ttf"
+      "/fonts/asap/Asap-Regular.ttf"
     ]
   },
   {
     "id": "quicksand",
     "label": "Quicksand",
     "pdf": [
-      "/fonts/quicksand/Quicksand-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/quicksand/static/Quicksand-Regular.ttf"
+      "/fonts/quicksand/Quicksand-Regular.ttf"
     ]
   },
   {
     "id": "zilla-slab",
     "label": "Zilla Slab",
     "pdf": [
-      "/fonts/zilla-slab/ZillaSlab-Regular.ttf",
-      "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/zillaslab/static/ZillaSlab-Regular.ttf"
+      "/fonts/zilla-slab/ZillaSlab-Regular.ttf"
     ]
   }
 ]

--- a/src/app/config/fonts/font-remote-fallbacks.json
+++ b/src/app/config/fonts/font-remote-fallbacks.json
@@ -1,0 +1,110 @@
+{
+  "roboto": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/apache/roboto/static/Roboto-Regular.ttf"
+  ],
+  "poppins": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/poppins/static/Poppins-Regular.ttf"
+  ],
+  "inter": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/inter/static/Inter-Regular.ttf"
+  ],
+  "montserrat": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/montserrat/static/Montserrat-Regular.ttf"
+  ],
+  "lato": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/lato/static/Lato-Regular.ttf"
+  ],
+  "nunito": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/nunito/static/Nunito-Regular.ttf"
+  ],
+  "open-sans": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/apache/opensans/static/OpenSans-Regular.ttf"
+  ],
+  "manrope": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/manrope/static/Manrope-Regular.ttf"
+  ],
+  "fira-code": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/firacode/static/FiraCode-Regular.ttf"
+  ],
+  "jetbrains-mono": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/jetbrainsmono/static/JetBrainsMono-Regular.ttf"
+  ],
+  "playfair-display": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/playfairdisplay/static/PlayfairDisplay-Regular.ttf"
+  ],
+  "merriweather": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/merriweather/static/Merriweather-Regular.ttf"
+  ],
+  "source-serif-4": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/sourceserif4/static/SourceSerif4-Regular.ttf"
+  ],
+  "raleway": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/raleway/static/Raleway-Regular.ttf"
+  ],
+  "oswald": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/oswald/static/Oswald-Regular.ttf"
+  ],
+  "work-sans": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/worksans/static/WorkSans-Regular.ttf"
+  ],
+  "dm-sans": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/dmsans/static/DMSans-Regular.ttf"
+  ],
+  "dm-serif-display": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/dmserifdisplay/static/DMSerifDisplay-Regular.ttf"
+  ],
+  "noto-sans-jp": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/notosansjp/NotoSansJP-Regular.otf"
+  ],
+  "noto-serif-display": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/notoserifdisplay/static/NotoSerifDisplay-Regular.ttf"
+  ],
+  "cabin": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/cabin/static/Cabin-Regular.ttf"
+  ],
+  "karla": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/karla/static/Karla-Regular.ttf"
+  ],
+  "space-grotesk": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/spacegrotesk/static/SpaceGrotesk-Regular.ttf"
+  ],
+  "sora": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/sora/static/Sora-Regular.ttf"
+  ],
+  "bitter": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/bitter/static/Bitter-Regular.ttf"
+  ],
+  "archivo": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/archivo/static/Archivo-Regular.ttf"
+  ],
+  "heebo": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/heebo/static/Heebo-Regular.ttf"
+  ],
+  "crimson-pro": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/crimsonpro/static/CrimsonPro-Regular.ttf"
+  ],
+  "ibm-plex-sans": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/ibmplexsans/static/IBMPlexSans-Regular.ttf"
+  ],
+  "ibm-plex-serif": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/ibmplexserif/static/IBMPlexSerif-Regular.ttf"
+  ],
+  "ibm-plex-mono": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/ibmplexmono/static/IBMPlexMono-Regular.ttf"
+  ],
+  "urbanist": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/urbanist/static/Urbanist-Regular.ttf"
+  ],
+  "sofia-sans": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/sofiasans/static/SofiaSans-Regular.ttf"
+  ],
+  "asap": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/asap/static/Asap-Regular.ttf"
+  ],
+  "quicksand": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/quicksand/static/Quicksand-Regular.ttf"
+  ],
+  "zilla-slab": [
+    "https://cdn.jsdelivr.net/gh/google/fonts@main/ofl/zillaslab/static/ZillaSlab-Regular.ttf"
+  ]
+}


### PR DESCRIPTION
## Summary
- move remote fallback URLs into a reusable JSON keymap consumed by the font options helper
- add a CLI utility and npm script to download fallback font files based on that keymap
- update font option generation to reference the shared map for remote PDF sources

## Testing
- npm run build
- node scripts/download-font-fallbacks.mjs --dry-run --font roboto

------
https://chatgpt.com/codex/tasks/task_e_690252e03594832586adb3e973f772bb