### PR TITLE
feat: add annotation type controls and value overrides

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -78,6 +78,29 @@
           <input type="text" [(ngModel)]="p.field.mapField"
             [placeholder]="'annotation.fields.text.placeholder' | t" />
         </label>
+        <label class="field">
+          <span class="field-label">{{ 'annotation.fields.type.label' | t }}</span>
+          <select [(ngModel)]="p.field.type">
+            <option value="text">{{ 'annotation.fields.type.options.text' | t }}</option>
+            <option value="check">{{ 'annotation.fields.type.options.check' | t }}</option>
+            <option value="radio">{{ 'annotation.fields.type.options.radio' | t }}</option>
+            <option value="number">{{ 'annotation.fields.type.options.number' | t }}</option>
+          </select>
+        </label>
+        <label class="field">
+          <span class="field-label">{{ 'annotation.fields.value.label' | t }}</span>
+          <input type="text" [(ngModel)]="p.field.value"
+            [placeholder]="'annotation.fields.value.placeholder' | t" />
+        </label>
+        <label class="field field-small" *ngIf="p.field.type === 'number'">
+          <span class="field-label">{{ 'annotation.fields.number.decimals.label' | t }}</span>
+          <input type="number" [(ngModel)]="p.field.decimals" min="0" />
+        </label>
+        <label class="field field-small" *ngIf="p.field.type === 'number'">
+          <span class="field-label">{{ 'annotation.fields.number.appender.label' | t }}</span>
+          <input type="text" [(ngModel)]="p.field.appender"
+            [placeholder]="'annotation.fields.number.appender.placeholder' | t" />
+        </label>
         <label class="field field-small">
           <span class="field-label">{{ 'annotation.fields.size.label' | t }}</span>
           <input type="number" [(ngModel)]="p.field.fontSize" min="8" max="72" />
@@ -110,6 +133,29 @@
           <span class="field-label">{{ 'annotation.fields.text.label' | t }}</span>
           <input type="text" [(ngModel)]="e.field.mapField"
             [placeholder]="'annotation.fields.text.placeholder' | t" />
+        </label>
+        <label class="field">
+          <span class="field-label">{{ 'annotation.fields.type.label' | t }}</span>
+          <select [(ngModel)]="e.field.type">
+            <option value="text">{{ 'annotation.fields.type.options.text' | t }}</option>
+            <option value="check">{{ 'annotation.fields.type.options.check' | t }}</option>
+            <option value="radio">{{ 'annotation.fields.type.options.radio' | t }}</option>
+            <option value="number">{{ 'annotation.fields.type.options.number' | t }}</option>
+          </select>
+        </label>
+        <label class="field">
+          <span class="field-label">{{ 'annotation.fields.value.label' | t }}</span>
+          <input type="text" [(ngModel)]="e.field.value"
+            [placeholder]="'annotation.fields.value.placeholder' | t" />
+        </label>
+        <label class="field field-small" *ngIf="e.field.type === 'number'">
+          <span class="field-label">{{ 'annotation.fields.number.decimals.label' | t }}</span>
+          <input type="number" [(ngModel)]="e.field.decimals" min="0" />
+        </label>
+        <label class="field field-small" *ngIf="e.field.type === 'number'">
+          <span class="field-label">{{ 'annotation.fields.number.appender.label' | t }}</span>
+          <input type="text" [(ngModel)]="e.field.appender"
+            [placeholder]="'annotation.fields.number.appender.placeholder' | t" />
         </label>
         <label class="field field-small">
           <span class="field-label">{{ 'annotation.fields.size.label' | t }}</span>

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -177,21 +177,27 @@ export class App implements AfterViewChecked {
 
   ngAfterViewChecked() {
     if (this.preview()) {
-      const previewEl = this.previewEditorRef?.nativeElement;
-      if (previewEl) {
-        const input = previewEl.querySelector('input[type="text"]') as HTMLInputElement | null;
-        input?.focus();
-      }
+      this.focusEditorIfNeeded(this.previewEditorRef?.nativeElement ?? null);
       return;
     }
 
     if (this.editing()) {
-      const editEl = this.editEditorRef?.nativeElement;
-      if (editEl) {
-        const input = editEl.querySelector('input[type="text"]') as HTMLInputElement | null;
-        input?.focus();
-      }
+      this.focusEditorIfNeeded(this.editEditorRef?.nativeElement ?? null);
     }
+  }
+
+  private focusEditorIfNeeded(editorEl: HTMLElement | null) {
+    if (!editorEl) {
+      return;
+    }
+
+    const activeElement = this.document?.activeElement as HTMLElement | null;
+    if (activeElement && editorEl.contains(activeElement)) {
+      return;
+    }
+
+    const focusTarget = editorEl.querySelector<HTMLElement>('input, select, textarea, button');
+    focusTarget?.focus();
   }
 
   onEditorKeydown(event: KeyboardEvent, mode: 'preview' | 'edit') {

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -686,7 +686,10 @@ export class App implements AfterViewChecked {
       const numeric = this.toFiniteNumber(baseText);
       if (numeric !== null) {
         const decimals = this.normalizeFieldDecimals(field.decimals);
-        const formatted = decimals !== undefined ? numeric.toFixed(decimals) : baseText;
+        const formatted =
+          decimals !== undefined
+            ? this.formatNumberWithTruncation(numeric, decimals)
+            : baseText;
         const appender = this.sanitizeOptionalAppender(field.appender) ?? '';
         return `${formatted}${appender}`;
       }
@@ -1392,6 +1395,12 @@ export class App implements AfterViewChecked {
     }
 
     return null;
+  }
+
+  private formatNumberWithTruncation(value: number, decimals: number): string {
+    const factor = 10 ** decimals;
+    const truncated = Math.trunc(value * factor) / factor;
+    return truncated.toFixed(decimals);
   }
 
   private normalizeFieldText(value: unknown): string | null {

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -61,12 +61,18 @@ if (supportsModuleWorkers()) {
   workerOptions.workerType = undefined;
 }
 
+type FieldType = 'text' | 'check' | 'radio' | 'number';
+
 type PageField = {
   x: number;
   y: number;
   mapField: string;
   fontSize: number;
   color: string;
+  type: FieldType;
+  value?: string;
+  appender?: string;
+  decimals?: number | null;
 };
 
 type PageAnnotations = { num: number; fields: PageField[] };
@@ -305,6 +311,10 @@ export class App implements AfterViewChecked {
         mapField: '',
         fontSize: 14,
         color: defaultColor,
+        type: 'text',
+        value: '',
+        appender: '',
+        decimals: null,
       },
     });
     this.updatePreviewColorState(defaultColor);
@@ -468,14 +478,11 @@ export class App implements AfterViewChecked {
 
   confirmPreview() {
     const p = this.preview();
-    if (!p || !p.field.mapField.trim()) {
+    if (!p || !this.fieldHasRenderableContent(p.field)) {
       this.preview.set(null);
       return;
     }
-    const normalizedField: PageField = {
-      ...p.field,
-      color: this.normalizeColor(p.field.color),
-    };
+    const normalizedField = this.prepareFieldForStorage(p.field);
     this.coords.update((pages) => this.addFieldToPages(p.page, normalizedField, pages));
     this.syncCoordsTextModel();
     this.preview.set(null);
@@ -487,28 +494,28 @@ export class App implements AfterViewChecked {
   }
 
   startEditing(pageIndex: number, fieldIndex: number, field: PageField) {
-    const normalized: PageField = { ...field, color: this.normalizeColor(field.color) };
-    if (normalized.color !== field.color) {
+    const sanitized = this.prepareFieldForStorage(field);
+    if (this.fieldRequiresStorageUpdate(field, sanitized)) {
       this.coords.update((pages) =>
-        this.updateFieldInPages(pageIndex, fieldIndex, normalized, pages)
+        this.updateFieldInPages(pageIndex, fieldIndex, sanitized, pages)
       );
       this.syncCoordsTextModel();
     }
-    this.editing.set({ pageIndex, fieldIndex, field: { ...normalized } });
-    this.updateEditingColorState(normalized.color);
+    const formField = this.prepareFieldForForm(sanitized);
+    this.editing.set({ pageIndex, fieldIndex, field: formField });
+    this.updateEditingColorState(formField.color);
     this.preview.set(null);
   }
 
   confirmEdit() {
     const e = this.editing();
     if (!e) return;
-    const normalized: PageField = {
-      ...e.field,
-      color: this.normalizeColor(e.field.color),
-    };
-    this.coords.update((pages) =>
-      this.updateFieldInPages(e.pageIndex, e.fieldIndex, normalized, pages)
-    );
+    if (!this.fieldHasRenderableContent(e.field)) {
+      this.editing.set(null);
+      return;
+    }
+    const normalized = this.prepareFieldForStorage(e.field);
+    this.coords.update((pages) => this.updateFieldInPages(e.pageIndex, e.fieldIndex, normalized, pages));
     this.syncCoordsTextModel();
     this.editing.set(null);
     this.redrawAllForPage();
@@ -541,6 +548,145 @@ export class App implements AfterViewChecked {
     this.syncCoordsTextModel();
     this.editing.set(null);
     this.redrawAllForPage();
+  }
+
+  private fieldHasRenderableContent(field: PageField): boolean {
+    const valueText = typeof field.value === 'string' ? field.value.trim() : '';
+    if (valueText) {
+      return true;
+    }
+
+    const type = this.normalizeFieldType(field.type);
+    if (type === 'check' || type === 'radio') {
+      return true;
+    }
+
+    return field.mapField.trim().length > 0;
+  }
+
+  private fieldRequiresStorageUpdate(original: PageField, sanitized: PageField): boolean {
+    const originalValue = (original as { value?: unknown }).value;
+    const originalAppender = (original as { appender?: unknown }).appender;
+    const originalDecimals = (original as { decimals?: unknown }).decimals;
+    const originalType = (original as { type?: unknown }).type;
+
+    return (
+      original.x !== sanitized.x ||
+      original.y !== sanitized.y ||
+      original.mapField !== sanitized.mapField ||
+      original.fontSize !== sanitized.fontSize ||
+      original.color !== sanitized.color ||
+      originalType !== sanitized.type ||
+      originalValue !== sanitized.value ||
+      originalAppender !== sanitized.appender ||
+      originalDecimals !== sanitized.decimals
+    );
+  }
+
+  private prepareFieldForStorage(field: PageField): PageField {
+    const type = this.normalizeFieldType(field.type);
+    const base: PageField = {
+      x: field.x,
+      y: field.y,
+      mapField: typeof field.mapField === 'string' ? field.mapField : '',
+      fontSize: field.fontSize,
+      color: this.normalizeColor(field.color),
+      type,
+    };
+
+    const value = this.sanitizeTextPreservingSpacing(field.value);
+    if (value !== undefined) {
+      base.value = value;
+    }
+
+    if (type === 'number') {
+      const decimals = this.normalizeFieldDecimals(field.decimals);
+      if (decimals !== undefined) {
+        base.decimals = decimals;
+      }
+      const appender = this.sanitizeOptionalAppender(field.appender);
+      if (appender !== undefined) {
+        base.appender = appender;
+      }
+    }
+
+    return base;
+  }
+
+  private prepareFieldForForm(field: PageField): PageField {
+    const decimals =
+      typeof field.decimals === 'number' && Number.isFinite(field.decimals)
+        ? Math.max(0, Math.round(field.decimals))
+        : null;
+
+    return {
+      ...field,
+      value: typeof field.value === 'string' ? field.value : '',
+      appender: typeof field.appender === 'string' ? field.appender : '',
+      decimals,
+    };
+  }
+
+  private normalizeFieldType(value: unknown): FieldType {
+    if (typeof value === 'string') {
+      const normalized = value.toLowerCase();
+      if (normalized === 'check' || normalized === 'radio' || normalized === 'number' || normalized === 'text') {
+        return normalized as FieldType;
+      }
+    }
+    return 'text';
+  }
+
+  private sanitizeTextPreservingSpacing(value: unknown): string | undefined {
+    if (typeof value !== 'string') {
+      return undefined;
+    }
+    return value.trim() ? value : undefined;
+  }
+
+  private sanitizeOptionalAppender(value: unknown): string | undefined {
+    if (typeof value !== 'string') {
+      return undefined;
+    }
+    return value.trim() ? value : undefined;
+  }
+
+  private normalizeFieldDecimals(value: unknown): number | undefined {
+    if (value === null || value === undefined || value === '') {
+      return undefined;
+    }
+    const parsed = this.toFiniteNumber(value);
+    if (parsed === null || parsed < 0) {
+      return undefined;
+    }
+    return Math.round(parsed);
+  }
+
+  private getFieldRenderValue(field: PageField): string {
+    const override =
+      typeof field.value === 'string' && field.value.trim() ? field.value : undefined;
+    if (override !== undefined) {
+      return override;
+    }
+
+    const type = this.normalizeFieldType(field.type);
+    if (type === 'check' || type === 'radio') {
+      return 'X';
+    }
+
+    const baseText = typeof field.mapField === 'string' ? field.mapField : '';
+
+    if (type === 'number') {
+      const numeric = this.toFiniteNumber(baseText);
+      if (numeric !== null) {
+        const decimals = this.normalizeFieldDecimals(field.decimals);
+        const formatted = decimals !== undefined ? numeric.toFixed(decimals) : baseText;
+        const appender = this.sanitizeOptionalAppender(field.appender) ?? '';
+        return `${formatted}${appender}`;
+      }
+    }
+
+    return baseText;
   }
 
   private addFieldToPages(
@@ -618,7 +764,7 @@ export class App implements AfterViewChecked {
 
           const el = document.createElement('div');
           el.className = 'annotation';
-          el.textContent = field.mapField;
+          el.textContent = this.getFieldRenderValue(field);
           el.style.left = `${left}px`;
           el.style.top = `${top - field.fontSize * scale}px`;
           el.style.fontSize = `${field.fontSize * scale}px`;
@@ -916,7 +1062,7 @@ export class App implements AfterViewChecked {
           const g = parseInt(hex.substring(2, 4), 16) / 255;
           const b = parseInt(hex.substring(4, 6), 16) / 255;
 
-          page.drawText(field.mapField, {
+          page.drawText(this.getFieldRenderValue(field), {
             x: field.x,
             y: field.y,
             size: field.fontSize,
@@ -1135,14 +1281,35 @@ export class App implements AfterViewChecked {
           continue;
         }
 
-        const { x, y, mapField, fontSize, color, value } = rawField as Record<string, unknown>;
+        const {
+          x,
+          y,
+          mapField,
+          fontSize,
+          color,
+          value,
+          type,
+          decimals,
+          appender,
+        } = rawField as Record<string, unknown>;
 
+        const normalizedType = this.normalizeFieldType(type);
+        const normalizedValue = this.normalizeFieldText(value);
         const normalizedMapField =
-          this.normalizeFieldText(mapField) ?? this.normalizeFieldText(value);
+          this.normalizeFieldText(mapField) ?? normalizedValue;
         const normalizedX = this.toFiniteNumber(x);
         const normalizedY = this.toFiniteNumber(y);
 
-        if (normalizedMapField === null || normalizedX === null || normalizedY === null) {
+        if (normalizedX === null || normalizedY === null) {
+          continue;
+        }
+
+        if (
+          normalizedMapField === null &&
+          normalizedValue === null &&
+          normalizedType !== 'check' &&
+          normalizedType !== 'radio'
+        ) {
           continue;
         }
 
@@ -1153,13 +1320,29 @@ export class App implements AfterViewChecked {
         const normalizedField: PageField = {
           x: Math.round(normalizedX * 100) / 100,
           y: Math.round(normalizedY * 100) / 100,
-          mapField: normalizedMapField,
+          mapField: normalizedMapField ?? '',
           fontSize:
             normalizedFontSize && normalizedFontSize > 0
               ? Math.round(normalizedFontSize * 100) / 100
               : 14,
           color: this.normalizeColor(normalizedColor),
+          type: normalizedType,
         };
+
+        if (normalizedValue !== null) {
+          normalizedField.value = normalizedValue;
+        }
+
+        if (normalizedType === 'number') {
+          const normalizedDecimals = this.normalizeFieldDecimals(decimals);
+          if (normalizedDecimals !== undefined) {
+            normalizedField.decimals = normalizedDecimals;
+          }
+          const normalizedAppender = this.sanitizeOptionalAppender(appender);
+          if (normalizedAppender !== undefined) {
+            normalizedField.appender = normalizedAppender;
+          }
+        }
 
         fields.push(normalizedField);
       }
@@ -1206,6 +1389,16 @@ export class App implements AfterViewChecked {
   }
 
   private normalizeFieldText(value: unknown): string | null {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        const normalized = this.normalizeFieldText(item);
+        if (normalized !== null) {
+          return normalized;
+        }
+      }
+      return null;
+    }
+
     let source: string | null = null;
 
     if (typeof value === 'string') {

--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -28,18 +28,40 @@
     "jsonHint": "Enganxa les coordenades o importa-les des d'un fitxer JSON amb el mateix format que l'exportat."
   },
   "annotation": {
-    "fields": {
-      "text": {
-        "label": "Text",
-        "placeholder": "Text..."
-      },
-      "size": {
-        "label": "Mida"
-      },
-      "color": {
-        "label": "Color"
+  "fields": {
+    "text": {
+      "label": "Text",
+      "placeholder": "Text..."
+    },
+    "size": {
+      "label": "Mida"
+    },
+    "color": {
+      "label": "Color"
+    },
+    "type": {
+      "label": "Tipus",
+      "options": {
+        "text": "Text",
+        "check": "Casella",
+        "radio": "Botó d'opció",
+        "number": "Nombre"
       }
     },
+    "value": {
+      "label": "Valor fix",
+      "placeholder": "Valor opcional..."
+    },
+    "number": {
+      "decimals": {
+        "label": "Decimals"
+      },
+      "appender": {
+        "label": "Sufix",
+        "placeholder": "Ex.: %"
+      }
+    }
+  },
     "color": {
       "hintPreview": "Selecciona un color, escriu un HEX o un RGB. El JSON sempre exportarà el color en HEX.",
       "hintEdit": "Pots enganxar un HEX o un RGB existent per reutilitzar colors exactes.",

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -28,18 +28,40 @@
     "jsonHint": "Paste coordinates or import them from a JSON file following the same format as the exported data."
   },
   "annotation": {
-    "fields": {
-      "text": {
-        "label": "Text",
-        "placeholder": "Text..."
-      },
-      "size": {
-        "label": "Size"
-      },
-      "color": {
-        "label": "Color"
+  "fields": {
+    "text": {
+      "label": "Text",
+      "placeholder": "Text..."
+    },
+    "size": {
+      "label": "Size"
+    },
+    "color": {
+      "label": "Color"
+    },
+    "type": {
+      "label": "Type",
+      "options": {
+        "text": "Text",
+        "check": "Checkbox",
+        "radio": "Radio button",
+        "number": "Number"
       }
     },
+    "value": {
+      "label": "Value override",
+      "placeholder": "Optional fixed value..."
+    },
+    "number": {
+      "decimals": {
+        "label": "Decimals"
+      },
+      "appender": {
+        "label": "Suffix",
+        "placeholder": "E.g. %"
+      }
+    }
+  },
     "color": {
       "hintPreview": "Pick a color, type a HEX or an RGB value. The JSON will always export the color in HEX.",
       "hintEdit": "Paste an existing HEX or RGB value to reuse exact colors.",

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -28,18 +28,40 @@
     "jsonHint": "Pega las coordenadas o impórtalas desde un JSON con el mismo formato que el archivo exportado."
   },
   "annotation": {
-    "fields": {
-      "text": {
-        "label": "Texto",
-        "placeholder": "Texto..."
-      },
-      "size": {
-        "label": "Tamaño"
-      },
-      "color": {
-        "label": "Color"
+  "fields": {
+    "text": {
+      "label": "Texto",
+      "placeholder": "Texto..."
+    },
+    "size": {
+      "label": "Tamaño"
+    },
+    "color": {
+      "label": "Color"
+    },
+    "type": {
+      "label": "Tipo",
+      "options": {
+        "text": "Texto",
+        "check": "Casilla",
+        "radio": "Botón de opción",
+        "number": "Número"
       }
     },
+    "value": {
+      "label": "Valor fijo",
+      "placeholder": "Valor opcional..."
+    },
+    "number": {
+      "decimals": {
+        "label": "Decimales"
+      },
+      "appender": {
+        "label": "Sufijo",
+        "placeholder": "Ej.: %"
+      }
+    }
+  },
     "color": {
       "hintPreview": "Selecciona un color, escribe un HEX o un RGB. El JSON siempre exportará el color en HEX.",
       "hintEdit": "Puedes pegar un HEX o un RGB existente para reutilizar colores exactos.",

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -290,7 +290,8 @@ header .logo {
   backdrop-filter: blur(10px);
 
   input[type="text"],
-  input[type="number"] {
+  input[type="number"],
+  select {
     border-radius: 4px;
     border: 1px solid rgba(94, 234, 212, 0.25);
     padding: 6px;
@@ -300,6 +301,10 @@ header .logo {
   }
 
   input[type="number"] {
+    width: 100%;
+  }
+
+  select {
     width: 100%;
   }
 


### PR DESCRIPTION
## Summary
- extend annotation data to track type, optional value overrides, and number formatting before rendering and export
- update the creation/editing panels with type selectors plus value, decimal, and suffix inputs styled to match the rest of the editor
- translate the new labels across the supported locales

## Testing
- npm run i18n:check
- npm run build

------
