### PR TITLE
Add undo/redo support for annotation history

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -23,6 +23,8 @@
       <span class="page-indicator">{{ 'controls.zoomLabel' | t }} {{ scale() | number:'1.0-2' }}×</span>
       <button class="btn" (click)="zoomIn()" [disabled]="!pdfDoc">+</button>
 
+      <button class="btn" (click)="undo()" [disabled]="!canUndo()">{{ 'controls.undo' | t }}</button>
+      <button class="btn" (click)="redo()" [disabled]="!canRedo()">{{ 'controls.redo' | t }}</button>
       <button class="btn danger" (click)="clearAll()" [disabled]="!coords().length">{{ 'controls.clear' | t }}</button>
       <button class="btn" (click)="copyJSON()" [disabled]="!coords().length">{{ 'controls.copyJson' | t }}</button>
       <button class="btn" (click)="downloadJSON()"

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -951,7 +951,7 @@ export class App implements AfterViewChecked {
     const newX = +(boundedLeft / scale).toFixed(2);
     const newY = +((pdfCanvas.height - (boundedTop + fontSizePx)) / scale).toFixed(2);
 
-    if (this.applyCoordsChange(() =>
+    const changed = this.applyCoordsChange(() =>
       this.coords.update((pages) =>
         pages.map((page, idx) => {
           if (idx !== pageIndex) {
@@ -966,10 +966,13 @@ export class App implements AfterViewChecked {
           return { ...page, fields: updatedFields };
         })
       )
-    )) {
+    );
+
+    if (changed) {
       this.syncCoordsTextModel();
-      this.redrawAllForPage();
     }
+
+    this.redrawAllForPage();
   }
 
   async prevPage() {

--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -14,6 +14,8 @@
     "next": "Següent",
     "pageIndicator": "Pàgina {{current}} / {{total}}",
     "zoomLabel": "Zoom",
+    "undo": "Desfer",
+    "redo": "Refer",
     "clear": "Esborrar",
     "copyJson": "Copiar JSON",
     "importJson": "Importar JSON",

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -14,6 +14,8 @@
     "next": "Next",
     "pageIndicator": "Page {{current}} / {{total}}",
     "zoomLabel": "Zoom",
+    "undo": "Undo",
+    "redo": "Redo",
     "clear": "Clear",
     "copyJson": "Copy JSON",
     "importJson": "Import JSON",

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -14,6 +14,8 @@
     "next": "Siguiente",
     "pageIndicator": "Página {{current}} / {{total}}",
     "zoomLabel": "Zoom",
+    "undo": "Deshacer",
+    "redo": "Rehacer",
     "clear": "Limpiar",
     "copyJson": "Copiar JSON",
     "importJson": "Importar JSON",


### PR DESCRIPTION
## Summary
- add undo and redo stacks to preserve annotation changes and reset them appropriately when loading new PDFs
- expose undo/redo actions in the toolbar and translate their labels across supported languages
- ensure coordinate mutations and imports funnel through the history helper to keep JSON text and rendering in sync

## Testing
- npm run i18n:check
- npm run build

------
