### PR TITLE
Add overlay guides and configurable snapping controls

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -214,7 +214,11 @@
   </aside>
 
   <!-- VISOR PDF -->
-  <main class="viewer" *ngIf="pdfDoc as _">
+  <main
+    class="viewer"
+    *ngIf="pdfDoc as _"
+    [class.viewer--guides-enabled]="guidesFeatureEnabled()"
+  >
     <div class="canvas-container">
       <canvas #pdfCanvas></canvas>
       <canvas #overlayCanvas></canvas>

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -273,8 +273,8 @@
     <!-- VISOR PDF -->
     <main class="viewer" *ngIf="pdfDoc as _">
       <div class="canvas-container">
-        <canvas #pdfCanvas></canvas>
-        <canvas #overlayCanvas></canvas>
+        <canvas #pdfCanvas class="canvas canvas--pdf"></canvas>
+        <canvas #overlayCanvas class="canvas canvas--overlay"></canvas>
         <div #annotationsLayer class="annotations-layer"></div>
         <div class="hitbox" (click)="onHitboxClick($event)"></div>
 

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -59,6 +59,130 @@
       spellcheck="false"
     ></textarea>
     <small class="sidebar-hint">{{ 'sidebar.jsonHint' | t }}</small>
+
+    <div class="sidebar-divider"></div>
+
+    <section class="guides-panel" *ngIf="guideSettings() as guides">
+      <h5>{{ 'guides.title' | t }}</h5>
+      <div class="guides-toggles">
+        <label>
+          <input
+            type="checkbox"
+            [checked]="guides.showGrid"
+            (change)="toggleGuideSetting('showGrid', $event.target.checked)"
+          />
+          <span>{{ 'guides.showGrid' | t }}</span>
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            [checked]="guides.showRulers"
+            (change)="toggleGuideSetting('showRulers', $event.target.checked)"
+          />
+          <span>{{ 'guides.showRulers' | t }}</span>
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            [checked]="guides.showAlignment"
+            (change)="toggleGuideSetting('showAlignment', $event.target.checked)"
+          />
+          <span>{{ 'guides.showAlignment' | t }}</span>
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            [checked]="guides.snapToGrid"
+            (change)="toggleGuideSetting('snapToGrid', $event.target.checked)"
+          />
+          <span>{{ 'guides.snapGrid' | t }}</span>
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            [checked]="guides.snapToMargins"
+            (change)="toggleGuideSetting('snapToMargins', $event.target.checked)"
+          />
+          <span>{{ 'guides.snapMargins' | t }}</span>
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            [checked]="guides.snapToCenters"
+            (change)="toggleGuideSetting('snapToCenters', $event.target.checked)"
+          />
+          <span>{{ 'guides.snapCenters' | t }}</span>
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            [checked]="guides.snapToCustom"
+            (change)="toggleGuideSetting('snapToCustom', $event.target.checked)"
+          />
+          <span>{{ 'guides.snapCustom' | t }}</span>
+        </label>
+      </div>
+
+      <div class="guides-inputs">
+        <label>
+          <span>{{ 'guides.gridSize' | t }}</span>
+          <input
+            type="number"
+            min="0.5"
+            step="0.5"
+            [ngModel]="guides.gridSize"
+            (ngModelChange)="updateGuideNumber('gridSize', $event)"
+            [ngModelOptions]="{ standalone: true }"
+          />
+        </label>
+        <label>
+          <span>{{ 'guides.marginSize' | t }}</span>
+          <input
+            type="number"
+            min="0"
+            step="1"
+            [ngModel]="guides.marginSize"
+            (ngModelChange)="updateGuideNumber('marginSize', $event)"
+            [ngModelOptions]="{ standalone: true }"
+          />
+        </label>
+        <label>
+          <span>{{ 'guides.tolerance' | t }}</span>
+          <input
+            type="number"
+            min="0"
+            step="1"
+            [ngModel]="guides.snapTolerance"
+            (ngModelChange)="updateGuideNumber('snapTolerance', $event)"
+            [ngModelOptions]="{ standalone: true }"
+          />
+        </label>
+      </div>
+
+      <div class="guides-custom">
+        <label>
+          <span>{{ 'guides.customX' | t }}</span>
+          <input
+            type="text"
+            [ngModel]="snapPointsXText()"
+            (ngModelChange)="onSnapPointsInput('x', $event)"
+            [ngModelOptions]="{ standalone: true }"
+            [placeholder]="'guides.customPlaceholder' | t"
+          />
+        </label>
+        <label>
+          <span>{{ 'guides.customY' | t }}</span>
+          <input
+            type="text"
+            [ngModel]="snapPointsYText()"
+            (ngModelChange)="onSnapPointsInput('y', $event)"
+            [ngModelOptions]="{ standalone: true }"
+            [placeholder]="'guides.customPlaceholder' | t"
+          />
+        </label>
+        <small class="guides-hint">{{ 'guides.customHint' | t }}</small>
+      </div>
+    </section>
   </aside>
 
   <!-- VISOR PDF -->

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -62,7 +62,20 @@
 
     <div class="sidebar-divider"></div>
 
-    <section class="guides-panel" *ngIf="guideSettings() as guides">
+    <section class="advanced-panel">
+      <h5>{{ 'sidebar.advancedTitle' | t }}</h5>
+      <label>
+        <input
+          type="checkbox"
+          [checked]="guidesFeatureEnabled()"
+          (change)="toggleGuidesFeature($event.target.checked)"
+        />
+        <span>{{ 'guides.enableFeature' | t }}</span>
+      </label>
+      <small class="advanced-hint">{{ 'sidebar.advancedHint' | t }}</small>
+    </section>
+
+    <section class="guides-panel" *ngIf="guidesFeatureEnabled() && guideSettings() as guides">
       <h5>{{ 'guides.title' | t }}</h5>
       <div class="guides-toggles">
         <label>

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -234,6 +234,23 @@
                 </label>
               </div>
 
+              <div class="guides-mode" role="radiogroup"
+                [attr.aria-label]="'guides.coordinateMode.label' | t">
+                <span class="guides-mode__label">{{ 'guides.coordinateMode.label' | t }}</span>
+                <div class="guides-mode__options">
+                  <label>
+                    <input type="radio" name="coordinateMode" [checked]="!guides.usePdfCoordinates"
+                      (change)="setCoordinateMode('canvas')" />
+                    <span>{{ 'guides.coordinateMode.canvas' | t }}</span>
+                  </label>
+                  <label>
+                    <input type="radio" name="coordinateMode" [checked]="guides.usePdfCoordinates"
+                      (change)="setCoordinateMode('pdf')" />
+                    <span>{{ 'guides.coordinateMode.pdf' | t }}</span>
+                  </label>
+                </div>
+              </div>
+
               <div class="guides-inputs">
                 <label>
                   <span>{{ 'guides.gridSize' | t }}</span>
@@ -260,11 +277,11 @@
                     [ngModelOptions]="{ standalone: true }" [placeholder]="'guides.customPlaceholder' | t" />
                 </label>
                 <label>
-                  <span>{{ 'guides.customY' | t }}</span>
+                  <span>{{ (guides.usePdfCoordinates ? 'guides.customY.pdf' : 'guides.customY.canvas') | t }}</span>
                   <input type="text" [ngModel]="snapPointsYText()" (ngModelChange)="onSnapPointsInput('y', $event)"
                     [ngModelOptions]="{ standalone: true }" [placeholder]="'guides.customPlaceholder' | t" />
                 </label>
-                <small class="guides-hint">{{ 'guides.customHint' | t }}</small>
+                <small class="guides-hint">{{ (guides.usePdfCoordinates ? 'guides.customHint.pdf' : 'guides.customHint.canvas') | t }}</small>
               </div>
             </section>
           </div>

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -60,141 +60,156 @@
     ></textarea>
     <small class="sidebar-hint">{{ 'sidebar.jsonHint' | t }}</small>
 
-    <div class="sidebar-divider"></div>
+    <section
+      class="advanced-panel"
+      [class.open]="advancedOptionsOpen()"
+      [class.active]="guidesFeatureEnabled()"
+    >
+      <button
+        type="button"
+        class="advanced-toggle"
+        (click)="toggleAdvancedOptions(!advancedOptionsOpen())"
+        [attr.aria-expanded]="advancedOptionsOpen()"
+      >
+        <span>{{ 'sidebar.advancedTitle' | t }}</span>
+        <span class="advanced-icon" aria-hidden="true">▾</span>
+      </button>
 
-    <section class="advanced-panel">
-      <h5>{{ 'sidebar.advancedTitle' | t }}</h5>
-      <label>
-        <input
-          type="checkbox"
-          [checked]="guidesFeatureEnabled()"
-          (change)="toggleGuidesFeature($event.target.checked)"
-        />
-        <span>{{ 'guides.enableFeature' | t }}</span>
-      </label>
-      <small class="advanced-hint">{{ 'sidebar.advancedHint' | t }}</small>
-    </section>
+      <ng-container *ngIf="advancedOptionsOpen()">
+        <div class="sidebar-divider"></div>
 
-    <section class="guides-panel" *ngIf="guidesFeatureEnabled() && guideSettings() as guides">
-      <h5>{{ 'guides.title' | t }}</h5>
-      <div class="guides-toggles">
-        <label>
+        <label class="advanced-checkbox">
           <input
             type="checkbox"
-            [checked]="guides.showGrid"
-            (change)="toggleGuideSetting('showGrid', $event.target.checked)"
+            [checked]="guidesFeatureEnabled()"
+            (change)="toggleGuidesFeature($event.target.checked)"
           />
-          <span>{{ 'guides.showGrid' | t }}</span>
+          <span>{{ 'guides.enableFeature' | t }}</span>
         </label>
-        <label>
-          <input
-            type="checkbox"
-            [checked]="guides.showRulers"
-            (change)="toggleGuideSetting('showRulers', $event.target.checked)"
-          />
-          <span>{{ 'guides.showRulers' | t }}</span>
-        </label>
-        <label>
-          <input
-            type="checkbox"
-            [checked]="guides.showAlignment"
-            (change)="toggleGuideSetting('showAlignment', $event.target.checked)"
-          />
-          <span>{{ 'guides.showAlignment' | t }}</span>
-        </label>
-        <label>
-          <input
-            type="checkbox"
-            [checked]="guides.snapToGrid"
-            (change)="toggleGuideSetting('snapToGrid', $event.target.checked)"
-          />
-          <span>{{ 'guides.snapGrid' | t }}</span>
-        </label>
-        <label>
-          <input
-            type="checkbox"
-            [checked]="guides.snapToMargins"
-            (change)="toggleGuideSetting('snapToMargins', $event.target.checked)"
-          />
-          <span>{{ 'guides.snapMargins' | t }}</span>
-        </label>
-        <label>
-          <input
-            type="checkbox"
-            [checked]="guides.snapToCenters"
-            (change)="toggleGuideSetting('snapToCenters', $event.target.checked)"
-          />
-          <span>{{ 'guides.snapCenters' | t }}</span>
-        </label>
-        <label>
-          <input
-            type="checkbox"
-            [checked]="guides.snapToCustom"
-            (change)="toggleGuideSetting('snapToCustom', $event.target.checked)"
-          />
-          <span>{{ 'guides.snapCustom' | t }}</span>
-        </label>
-      </div>
+        <small class="advanced-hint">{{ 'sidebar.advancedHint' | t }}</small>
 
-      <div class="guides-inputs">
-        <label>
-          <span>{{ 'guides.gridSize' | t }}</span>
-          <input
-            type="number"
-            min="0.5"
-            step="0.5"
-            [ngModel]="guides.gridSize"
-            (ngModelChange)="updateGuideNumber('gridSize', $event)"
-            [ngModelOptions]="{ standalone: true }"
-          />
-        </label>
-        <label>
-          <span>{{ 'guides.marginSize' | t }}</span>
-          <input
-            type="number"
-            min="0"
-            step="1"
-            [ngModel]="guides.marginSize"
-            (ngModelChange)="updateGuideNumber('marginSize', $event)"
-            [ngModelOptions]="{ standalone: true }"
-          />
-        </label>
-        <label>
-          <span>{{ 'guides.tolerance' | t }}</span>
-          <input
-            type="number"
-            min="0"
-            step="1"
-            [ngModel]="guides.snapTolerance"
-            (ngModelChange)="updateGuideNumber('snapTolerance', $event)"
-            [ngModelOptions]="{ standalone: true }"
-          />
-        </label>
-      </div>
+        <section class="guides-panel" *ngIf="guidesFeatureEnabled() && guideSettings() as guides">
+          <h5>{{ 'guides.title' | t }}</h5>
+          <div class="guides-toggles">
+            <label>
+              <input
+                type="checkbox"
+                [checked]="guides.showGrid"
+                (change)="toggleGuideSetting('showGrid', $event.target.checked)"
+              />
+              <span>{{ 'guides.showGrid' | t }}</span>
+            </label>
+            <label>
+              <input
+                type="checkbox"
+                [checked]="guides.showRulers"
+                (change)="toggleGuideSetting('showRulers', $event.target.checked)"
+              />
+              <span>{{ 'guides.showRulers' | t }}</span>
+            </label>
+            <label>
+              <input
+                type="checkbox"
+                [checked]="guides.showAlignment"
+                (change)="toggleGuideSetting('showAlignment', $event.target.checked)"
+              />
+              <span>{{ 'guides.showAlignment' | t }}</span>
+            </label>
+            <label>
+              <input
+                type="checkbox"
+                [checked]="guides.snapToGrid"
+                (change)="toggleGuideSetting('snapToGrid', $event.target.checked)"
+              />
+              <span>{{ 'guides.snapGrid' | t }}</span>
+            </label>
+            <label>
+              <input
+                type="checkbox"
+                [checked]="guides.snapToMargins"
+                (change)="toggleGuideSetting('snapToMargins', $event.target.checked)"
+              />
+              <span>{{ 'guides.snapMargins' | t }}</span>
+            </label>
+            <label>
+              <input
+                type="checkbox"
+                [checked]="guides.snapToCenters"
+                (change)="toggleGuideSetting('snapToCenters', $event.target.checked)"
+              />
+              <span>{{ 'guides.snapCenters' | t }}</span>
+            </label>
+            <label>
+              <input
+                type="checkbox"
+                [checked]="guides.snapToCustom"
+                (change)="toggleGuideSetting('snapToCustom', $event.target.checked)"
+              />
+              <span>{{ 'guides.snapCustom' | t }}</span>
+            </label>
+          </div>
 
-      <div class="guides-custom">
-        <label>
-          <span>{{ 'guides.customX' | t }}</span>
-          <input
-            type="text"
-            [ngModel]="snapPointsXText()"
-            (ngModelChange)="onSnapPointsInput('x', $event)"
-            [ngModelOptions]="{ standalone: true }"
-            [placeholder]="'guides.customPlaceholder' | t"
-          />
-        </label>
-        <label>
-          <span>{{ 'guides.customY' | t }}</span>
-          <input
-            type="text"
-            [ngModel]="snapPointsYText()"
-            (ngModelChange)="onSnapPointsInput('y', $event)"
-            [ngModelOptions]="{ standalone: true }"
-            [placeholder]="'guides.customPlaceholder' | t"
-          />
-        </label>
-        <small class="guides-hint">{{ 'guides.customHint' | t }}</small>
-      </div>
+          <div class="guides-inputs">
+            <label>
+              <span>{{ 'guides.gridSize' | t }}</span>
+              <input
+                type="number"
+                min="0.5"
+                step="0.5"
+                [ngModel]="guides.gridSize"
+                (ngModelChange)="updateGuideNumber('gridSize', $event)"
+                [ngModelOptions]="{ standalone: true }"
+              />
+            </label>
+            <label>
+              <span>{{ 'guides.marginSize' | t }}</span>
+              <input
+                type="number"
+                min="0"
+                step="1"
+                [ngModel]="guides.marginSize"
+                (ngModelChange)="updateGuideNumber('marginSize', $event)"
+                [ngModelOptions]="{ standalone: true }"
+              />
+            </label>
+            <label>
+              <span>{{ 'guides.tolerance' | t }}</span>
+              <input
+                type="number"
+                min="0"
+                step="1"
+                [ngModel]="guides.snapTolerance"
+                (ngModelChange)="updateGuideNumber('snapTolerance', $event)"
+                [ngModelOptions]="{ standalone: true }"
+              />
+            </label>
+          </div>
+
+          <div class="guides-custom">
+            <label>
+              <span>{{ 'guides.customX' | t }}</span>
+              <input
+                type="text"
+                [ngModel]="snapPointsXText()"
+                (ngModelChange)="onSnapPointsInput('x', $event)"
+                [ngModelOptions]="{ standalone: true }"
+                [placeholder]="'guides.customPlaceholder' | t"
+              />
+            </label>
+            <label>
+              <span>{{ 'guides.customY' | t }}</span>
+              <input
+                type="text"
+                [ngModel]="snapPointsYText()"
+                (ngModelChange)="onSnapPointsInput('y', $event)"
+                [ngModelOptions]="{ standalone: true }"
+                [placeholder]="'guides.customPlaceholder' | t"
+              />
+            </label>
+            <small class="guides-hint">{{ 'guides.customHint' | t }}</small>
+          </div>
+        </section>
+      </ng-container>
     </section>
   </aside>
 

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -184,88 +184,90 @@
         </button>
 
         <ng-container *ngIf="advancedOptionsOpen()">
-          <div class="sidebar-divider"></div>
+          <div class="advanced-content">
+            <div class="sidebar-divider"></div>
 
-          <label class="advanced-checkbox">
-            <input type="checkbox" [checked]="guidesFeatureEnabled()"
-              (change)="toggleGuidesFeature($event.target.checked)" />
-            <span>{{ 'guides.enableFeature' | t }}</span>
-          </label>
-          <small class="advanced-hint">{{ 'sidebar.advancedHint' | t }}</small>
+            <label class="advanced-checkbox">
+              <input type="checkbox" [checked]="guidesFeatureEnabled()"
+                (change)="toggleGuidesFeature($event.target.checked)" />
+              <span>{{ 'guides.enableFeature' | t }}</span>
+            </label>
+            <small class="advanced-hint">{{ 'sidebar.advancedHint' | t }}</small>
 
-          <section class="guides-panel" *ngIf="guidesFeatureEnabled() && guideSettings() as guides">
-            <h5>{{ 'guides.title' | t }}</h5>
-            <div class="guides-toggles">
-              <label>
-                <input type="checkbox" [checked]="guides.showGrid"
-                  (change)="toggleGuideSetting('showGrid', $event.target.checked)" />
-                <span>{{ 'guides.showGrid' | t }}</span>
-              </label>
-              <label>
-                <input type="checkbox" [checked]="guides.showRulers"
-                  (change)="toggleGuideSetting('showRulers', $event.target.checked)" />
-                <span>{{ 'guides.showRulers' | t }}</span>
-              </label>
-              <label>
-                <input type="checkbox" [checked]="guides.showAlignment"
-                  (change)="toggleGuideSetting('showAlignment', $event.target.checked)" />
-                <span>{{ 'guides.showAlignment' | t }}</span>
-              </label>
-              <label>
-                <input type="checkbox" [checked]="guides.snapToGrid"
-                  (change)="toggleGuideSetting('snapToGrid', $event.target.checked)" />
-                <span>{{ 'guides.snapGrid' | t }}</span>
-              </label>
-              <label>
-                <input type="checkbox" [checked]="guides.snapToMargins"
-                  (change)="toggleGuideSetting('snapToMargins', $event.target.checked)" />
-                <span>{{ 'guides.snapMargins' | t }}</span>
-              </label>
-              <label>
-                <input type="checkbox" [checked]="guides.snapToCenters"
-                  (change)="toggleGuideSetting('snapToCenters', $event.target.checked)" />
-                <span>{{ 'guides.snapCenters' | t }}</span>
-              </label>
-              <label>
-                <input type="checkbox" [checked]="guides.snapToCustom"
-                  (change)="toggleGuideSetting('snapToCustom', $event.target.checked)" />
-                <span>{{ 'guides.snapCustom' | t }}</span>
-              </label>
-            </div>
+            <section class="guides-panel" *ngIf="guidesFeatureEnabled() && guideSettings() as guides">
+              <h5>{{ 'guides.title' | t }}</h5>
+              <div class="guides-toggles">
+                <label>
+                  <input type="checkbox" [checked]="guides.showGrid"
+                    (change)="toggleGuideSetting('showGrid', $event.target.checked)" />
+                  <span>{{ 'guides.showGrid' | t }}</span>
+                </label>
+                <label>
+                  <input type="checkbox" [checked]="guides.showRulers"
+                    (change)="toggleGuideSetting('showRulers', $event.target.checked)" />
+                  <span>{{ 'guides.showRulers' | t }}</span>
+                </label>
+                <label>
+                  <input type="checkbox" [checked]="guides.showAlignment"
+                    (change)="toggleGuideSetting('showAlignment', $event.target.checked)" />
+                  <span>{{ 'guides.showAlignment' | t }}</span>
+                </label>
+                <label>
+                  <input type="checkbox" [checked]="guides.snapToGrid"
+                    (change)="toggleGuideSetting('snapToGrid', $event.target.checked)" />
+                  <span>{{ 'guides.snapGrid' | t }}</span>
+                </label>
+                <label>
+                  <input type="checkbox" [checked]="guides.snapToMargins"
+                    (change)="toggleGuideSetting('snapToMargins', $event.target.checked)" />
+                  <span>{{ 'guides.snapMargins' | t }}</span>
+                </label>
+                <label>
+                  <input type="checkbox" [checked]="guides.snapToCenters"
+                    (change)="toggleGuideSetting('snapToCenters', $event.target.checked)" />
+                  <span>{{ 'guides.snapCenters' | t }}</span>
+                </label>
+                <label>
+                  <input type="checkbox" [checked]="guides.snapToCustom"
+                    (change)="toggleGuideSetting('snapToCustom', $event.target.checked)" />
+                  <span>{{ 'guides.snapCustom' | t }}</span>
+                </label>
+              </div>
 
-            <div class="guides-inputs">
-              <label>
-                <span>{{ 'guides.gridSize' | t }}</span>
-                <input type="number" min="0.5" step="0.5" [ngModel]="guides.gridSize"
-                  (ngModelChange)="updateGuideNumber('gridSize', $event)" [ngModelOptions]="{ standalone: true }" />
-              </label>
-              <label>
-                <span>{{ 'guides.marginSize' | t }}</span>
-                <input type="number" min="0" step="1" [ngModel]="guides.marginSize"
-                  (ngModelChange)="updateGuideNumber('marginSize', $event)" [ngModelOptions]="{ standalone: true }" />
-              </label>
-              <label>
-                <span>{{ 'guides.tolerance' | t }}</span>
-                <input type="number" min="0" step="1" [ngModel]="guides.snapTolerance"
-                  (ngModelChange)="updateGuideNumber('snapTolerance', $event)"
-                  [ngModelOptions]="{ standalone: true }" />
-              </label>
-            </div>
+              <div class="guides-inputs">
+                <label>
+                  <span>{{ 'guides.gridSize' | t }}</span>
+                  <input type="number" min="0.5" step="0.5" [ngModel]="guides.gridSize"
+                    (ngModelChange)="updateGuideNumber('gridSize', $event)" [ngModelOptions]="{ standalone: true }" />
+                </label>
+                <label>
+                  <span>{{ 'guides.marginSize' | t }}</span>
+                  <input type="number" min="0" step="1" [ngModel]="guides.marginSize"
+                    (ngModelChange)="updateGuideNumber('marginSize', $event)" [ngModelOptions]="{ standalone: true }" />
+                </label>
+                <label>
+                  <span>{{ 'guides.tolerance' | t }}</span>
+                  <input type="number" min="0" step="1" [ngModel]="guides.snapTolerance"
+                    (ngModelChange)="updateGuideNumber('snapTolerance', $event)"
+                    [ngModelOptions]="{ standalone: true }" />
+                </label>
+              </div>
 
-            <div class="guides-custom">
-              <label>
-                <span>{{ 'guides.customX' | t }}</span>
-                <input type="text" [ngModel]="snapPointsXText()" (ngModelChange)="onSnapPointsInput('x', $event)"
-                  [ngModelOptions]="{ standalone: true }" [placeholder]="'guides.customPlaceholder' | t" />
-              </label>
-              <label>
-                <span>{{ 'guides.customY' | t }}</span>
-                <input type="text" [ngModel]="snapPointsYText()" (ngModelChange)="onSnapPointsInput('y', $event)"
-                  [ngModelOptions]="{ standalone: true }" [placeholder]="'guides.customPlaceholder' | t" />
-              </label>
-              <small class="guides-hint">{{ 'guides.customHint' | t }}</small>
-            </div>
-          </section>
+              <div class="guides-custom">
+                <label>
+                  <span>{{ 'guides.customX' | t }}</span>
+                  <input type="text" [ngModel]="snapPointsXText()" (ngModelChange)="onSnapPointsInput('x', $event)"
+                    [ngModelOptions]="{ standalone: true }" [placeholder]="'guides.customPlaceholder' | t" />
+                </label>
+                <label>
+                  <span>{{ 'guides.customY' | t }}</span>
+                  <input type="text" [ngModel]="snapPointsYText()" (ngModelChange)="onSnapPointsInput('y', $event)"
+                    [ngModelOptions]="{ standalone: true }" [placeholder]="'guides.customPlaceholder' | t" />
+                </label>
+                <small class="guides-hint">{{ 'guides.customHint' | t }}</small>
+              </div>
+            </section>
+          </div>
         </ng-container>
       </section>
     </aside>

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -305,7 +305,7 @@ export class App implements AfterViewChecked, OnDestroy {
       return;
     }
 
-    let nextSnapPointsY = currentSettings.snapPointsY;
+    let nextSnapPointsY = [...currentSettings.snapPointsY];
     let nextSnapText = this.snapPointsYText();
     const canvas = this.pdfCanvasRef?.nativeElement;
     if (canvas && canvas.height > 0) {

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -697,6 +697,8 @@ export class App implements AfterViewChecked, OnDestroy {
     const height = pdfCanvas.height;
     const elementWidth = el.offsetWidth;
     const elementHeight = el.offsetHeight;
+    const usePdfCoordinates = settings.usePdfCoordinates;
+    const pdfBaselineOffset = usePdfCoordinates ? elementHeight : 0;
 
     type Candidate = { candidate: number; line: number; delta: number };
 
@@ -762,8 +764,9 @@ export class App implements AfterViewChecked, OnDestroy {
         pushVertical(linePx, linePx);
       });
       settings.snapPointsY.forEach((point) => {
-        const linePx = this.projectYPoint(point, height, scale, settings.usePdfCoordinates);
-        pushHorizontal(linePx, linePx);
+        const linePx = this.projectYPoint(point, height, scale, usePdfCoordinates);
+        const candidateTop = linePx - pdfBaselineOffset;
+        pushHorizontal(candidateTop, linePx);
       });
     }
 

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -122,6 +122,7 @@ export class App implements AfterViewChecked {
   editRgbInput = signal('rgb(0, 0, 0)');
   coordsTextModel = JSON.stringify({ pages: [] }, null, 2);
   guidesFeatureEnabled = signal(false);
+  advancedOptionsOpen = signal(false);
   guideSettings = signal<GuideSettings>({
     showGrid: true,
     gridSize: 10,
@@ -185,7 +186,11 @@ export class App implements AfterViewChecked {
 
   toggleGuidesFeature(enabled: boolean) {
     this.guidesFeatureEnabled.set(enabled);
+    if (enabled) {
+      this.advancedOptionsOpen.set(true);
+    }
     if (!enabled) {
+      this.advancedOptionsOpen.set(false);
       this.overlayDragRect = null;
       this.overlayGuides = [];
       this.refreshOverlay(null, []);
@@ -193,6 +198,10 @@ export class App implements AfterViewChecked {
     }
 
     this.refreshOverlay();
+  }
+
+  toggleAdvancedOptions(open: boolean) {
+    this.advancedOptionsOpen.set(open);
   }
 
   toggleGuideSetting(

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -82,6 +82,7 @@ type GuideSettings = {
   snapTolerance: number;
   snapPointsX: readonly number[];
   snapPointsY: readonly number[];
+  usePdfCoordinates: boolean;
 };
 
 type OverlayGuide = {
@@ -126,6 +127,7 @@ export class App implements AfterViewChecked, OnDestroy {
     snapTolerance: 8,
     snapPointsX: [],
     snapPointsY: [],
+    usePdfCoordinates: false,
   });
   snapPointsXText = signal('');
   snapPointsYText = signal('');
@@ -296,6 +298,39 @@ export class App implements AfterViewChecked, OnDestroy {
     this.refreshOverlay();
   }
 
+  setCoordinateMode(mode: 'canvas' | 'pdf') {
+    const usePdfCoordinates = mode === 'pdf';
+    const currentSettings = this.guideSettings();
+    if (currentSettings.usePdfCoordinates === usePdfCoordinates) {
+      return;
+    }
+
+    let nextSnapPointsY = currentSettings.snapPointsY;
+    let nextSnapText = this.snapPointsYText();
+    const canvas = this.pdfCanvasRef?.nativeElement;
+    if (canvas && canvas.height > 0) {
+      const scale = this.scale();
+      const pdfHeight = canvas.height / scale;
+      if (pdfHeight > 0) {
+        nextSnapPointsY = currentSettings.snapPointsY.map((value) => {
+          const clamped = Math.max(0, Math.min(value, pdfHeight));
+          const converted = pdfHeight - clamped;
+          return +converted.toFixed(2);
+        });
+        nextSnapPointsY.sort((a, b) => a - b);
+        nextSnapText = nextSnapPointsY.join(', ');
+      }
+    }
+
+    this.guideSettings.update((settings) => ({
+      ...settings,
+      usePdfCoordinates,
+      snapPointsY: nextSnapPointsY,
+    }));
+    this.snapPointsYText.set(nextSnapText);
+    this.refreshOverlay();
+  }
+
   updateGuideNumber(key: 'gridSize' | 'marginSize' | 'snapTolerance', rawValue: string | number) {
     const numeric = this.toFiniteNumber(rawValue);
     if (numeric === null) {
@@ -404,6 +439,20 @@ export class App implements AfterViewChecked, OnDestroy {
     }
   }
 
+  private projectYPoint(
+    point: number,
+    height: number,
+    scale: number,
+    usePdfCoordinates: boolean
+  ) {
+    const pdfHeight = height / scale;
+    const clamped = Math.max(0, Math.min(point, pdfHeight));
+    if (usePdfCoordinates) {
+      return height - clamped * scale;
+    }
+    return clamped * scale;
+  }
+
   private drawGrid(
     ctx: CanvasRenderingContext2D,
     settings: GuideSettings,
@@ -455,6 +504,9 @@ export class App implements AfterViewChecked, OnDestroy {
     const rulerSize = 22;
     const majorStep = Math.max(50 * scale, 40);
     const minorStep = Math.max(10 * scale, 8);
+    const usePdfCoordinates = settings.usePdfCoordinates;
+    const pdfHeight = height / scale;
+    const formatValue = (value: number) => (Math.round(value * 10) / 10).toString();
 
     ctx.save();
 
@@ -488,16 +540,18 @@ export class App implements AfterViewChecked, OnDestroy {
     ctx.textBaseline = 'top';
 
     for (let x = majorStep; x < width; x += majorStep) {
-      const value = Math.round((x / scale) * 10) / 10;
-      ctx.fillText(value.toString(), x + 4, 4);
+      const value = x / scale;
+      ctx.fillText(formatValue(value), x + 4, 4);
     }
 
     ctx.save();
     ctx.rotate(-Math.PI / 2);
     for (let y = majorStep; y < height; y += majorStep) {
-      const value = Math.round((y / scale) * 10) / 10;
-      ctx.fillText(value.toString(), -y - 24, 4);
+      const rawUnits = usePdfCoordinates ? (height - y) / scale : y / scale;
+      ctx.fillText(formatValue(rawUnits), -y - 24, 4);
     }
+    ctx.fillText(formatValue(usePdfCoordinates ? pdfHeight : 0), -24, 4);
+    ctx.fillText(formatValue(usePdfCoordinates ? 0 : pdfHeight), -height - 24, 4);
     ctx.restore();
 
     ctx.restore();
@@ -559,7 +613,7 @@ export class App implements AfterViewChecked, OnDestroy {
       });
 
       settings.snapPointsY.forEach((point) => {
-        const linePx = point * scale;
+        const linePx = this.projectYPoint(point, height, scale, settings.usePdfCoordinates);
         if (linePx >= 0 && linePx <= height) {
           ctx.beginPath();
           ctx.moveTo(0, Math.round(linePx) + 0.5);
@@ -708,7 +762,7 @@ export class App implements AfterViewChecked, OnDestroy {
         pushVertical(linePx, linePx);
       });
       settings.snapPointsY.forEach((point) => {
-        const linePx = point * scale;
+        const linePx = this.projectYPoint(point, height, scale, settings.usePdfCoordinates);
         pushHorizontal(linePx, linePx);
       });
     }

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -684,7 +684,8 @@ export class App implements AfterViewChecked, OnDestroy {
     baseTop: number,
     bounds: { maxLeft: number; minTop: number; maxTop: number },
     el: HTMLDivElement,
-    pdfCanvas: HTMLCanvasElement
+    pdfCanvas: HTMLCanvasElement,
+    fontSizePx: number
   ): { left: number; top: number; guides: OverlayGuide[] } {
     if (!this.guidesFeatureEnabled()) {
       return { left: baseLeft, top: baseTop, guides: [] };
@@ -698,7 +699,8 @@ export class App implements AfterViewChecked, OnDestroy {
     const elementWidth = el.offsetWidth;
     const elementHeight = el.offsetHeight;
     const usePdfCoordinates = settings.usePdfCoordinates;
-    const pdfBaselineOffset = usePdfCoordinates ? elementHeight : 0;
+    const baselineOffset = Number.isFinite(fontSizePx) ? fontSizePx : 0;
+    const pdfBaselineOffset = usePdfCoordinates ? baselineOffset : 0;
 
     type Candidate = { candidate: number; line: number; delta: number };
 
@@ -1708,7 +1710,8 @@ export class App implements AfterViewChecked, OnDestroy {
       clampedTop,
       { maxLeft, minTop, maxTop },
       el,
-      pdfCanvas
+      pdfCanvas,
+      this.dragInfo.fontSize
     );
 
     el.style.left = `${snapResult.left}px`;

--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -25,9 +25,12 @@
     "importJsonFile": "Importa des d'un fitxer",
     "applyJson": "Aplica el JSON",
     "jsonPlaceholder": "Enganxa o edita aquí les coordenades de les anotacions...",
-    "jsonHint": "Enganxa les coordenades o importa-les des d'un fitxer JSON amb el mateix format que l'exportat."
+    "jsonHint": "Enganxa les coordenades o importa-les des d'un fitxer JSON amb el mateix format que l'exportat.",
+    "advancedTitle": "Opcions avançades",
+    "advancedHint": "Activa les guies i el snapping només quan necessitis més precisió."
   },
   "guides": {
+    "enableFeature": "Activa les guies i el snapping",
     "title": "Guies i ajustos",
     "showGrid": "Mostrar la graella",
     "showRulers": "Mostrar regles",

--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -27,6 +27,23 @@
     "jsonPlaceholder": "Enganxa o edita aquí les coordenades de les anotacions...",
     "jsonHint": "Enganxa les coordenades o importa-les des d'un fitxer JSON amb el mateix format que l'exportat."
   },
+  "guides": {
+    "title": "Guies i ajustos",
+    "showGrid": "Mostrar la graella",
+    "showRulers": "Mostrar regles",
+    "showAlignment": "Ressaltar alineacions actives",
+    "snapGrid": "Ajustar a la graella",
+    "snapMargins": "Ajustar als marges",
+    "snapCenters": "Ajustar als eixos centrals",
+    "snapCustom": "Ajustar a coordenades personalitzades",
+    "gridSize": "Graella (pt)",
+    "marginSize": "Marge (pt)",
+    "tolerance": "Tolerància (px)",
+    "customX": "Coordenades X (pt)",
+    "customY": "Coordenades Y (pt des de la vora superior)",
+    "customPlaceholder": "Ex.: 24, 48, 120",
+    "customHint": "Introdueix valors en punts (pt) separats per comes o espais. Les Y es mesuren des de la vora superior del PDF."
+  },
   "annotation": {
   "fields": {
     "text": {

--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -78,9 +78,20 @@
     "marginSize": "Marge (pt)",
     "tolerance": "Tolerància (px)",
     "customX": "Coordenades X (pt)",
-    "customY": "Coordenades Y (pt des de la vora superior)",
+    "customY": {
+      "canvas": "Coordenades Y (pt des de la vora superior)",
+      "pdf": "Coordenades Y (pt des de la vora inferior)"
+    },
     "customPlaceholder": "Ex.: 24, 48, 120",
-    "customHint": "Introdueix valors en punts (pt) separats per comes o espais. Les Y es mesuren des de la vora superior del PDF."
+    "customHint": {
+      "canvas": "Introdueix valors en punts (pt) separats per comes o espais. Les Y es mesuren des de la vora superior del PDF.",
+      "pdf": "Introdueix valors en punts (pt) separats per comes o espais. Les Y es mesuren des de la vora inferior del PDF."
+    },
+    "coordinateMode": {
+      "label": "Origen de coordenades",
+      "canvas": "Cantonada superior esquerra (Canvas)",
+      "pdf": "Cantonada inferior esquerra (PDF)"
+    }
   },
   "annotation": {
     "fields": {

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -25,9 +25,12 @@
     "importJsonFile": "Import from file",
     "applyJson": "Apply JSON",
     "jsonPlaceholder": "Paste or edit annotation coordinates here...",
-    "jsonHint": "Paste coordinates or import them from a JSON file following the same format as the exported data."
+    "jsonHint": "Paste coordinates or import them from a JSON file following the same format as the exported data.",
+    "advancedTitle": "Advanced options",
+    "advancedHint": "Toggle guides and snapping helpers when you need extra precision."
   },
   "guides": {
+    "enableFeature": "Enable guides & snapping",
     "title": "Guides & snapping",
     "showGrid": "Show grid",
     "showRulers": "Show rulers",

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -27,6 +27,23 @@
     "jsonPlaceholder": "Paste or edit annotation coordinates here...",
     "jsonHint": "Paste coordinates or import them from a JSON file following the same format as the exported data."
   },
+  "guides": {
+    "title": "Guides & snapping",
+    "showGrid": "Show grid",
+    "showRulers": "Show rulers",
+    "showAlignment": "Highlight active alignments",
+    "snapGrid": "Snap to grid",
+    "snapMargins": "Snap to margins",
+    "snapCenters": "Snap to center axes",
+    "snapCustom": "Snap to custom coordinates",
+    "gridSize": "Grid spacing (pt)",
+    "marginSize": "Margin (pt)",
+    "tolerance": "Tolerance (px)",
+    "customX": "X coordinates (pt)",
+    "customY": "Y coordinates (pt from top edge)",
+    "customPlaceholder": "e.g. 24, 48, 120",
+    "customHint": "Enter point values separated by commas or spaces. Y values are measured from the top edge of the PDF."
+  },
   "annotation": {
   "fields": {
     "text": {

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -78,9 +78,20 @@
     "marginSize": "Margin (pt)",
     "tolerance": "Tolerance (px)",
     "customX": "X coordinates (pt)",
-    "customY": "Y coordinates (pt from top edge)",
+    "customY": {
+      "canvas": "Y coordinates (pt from top edge)",
+      "pdf": "Y coordinates (pt from bottom edge)"
+    },
     "customPlaceholder": "e.g. 24, 48, 120",
-    "customHint": "Enter point values separated by commas or spaces. Y values are measured from the top edge of the PDF."
+    "customHint": {
+      "canvas": "Enter point values separated by commas or spaces. Y values are measured from the top edge of the PDF.",
+      "pdf": "Enter point values separated by commas or spaces. Y values are measured from the bottom edge of the PDF."
+    },
+    "coordinateMode": {
+      "label": "Coordinate origin",
+      "canvas": "Top-left (Canvas)",
+      "pdf": "Bottom-left (PDF)"
+    }
   },
   "annotation": {
     "fields": {

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -78,9 +78,20 @@
     "marginSize": "Margen (pt)",
     "tolerance": "Tolerancia (px)",
     "customX": "Coordenadas X (pt)",
-    "customY": "Coordenadas Y (pt desde el borde superior)",
+    "customY": {
+      "canvas": "Coordenadas Y (pt desde el borde superior)",
+      "pdf": "Coordenadas Y (pt desde el borde inferior)"
+    },
     "customPlaceholder": "Ej.: 24, 48, 120",
-    "customHint": "Introduce valores en puntos (pt) separados por comas o espacios. Las Y se miden desde el borde superior del PDF."
+    "customHint": {
+      "canvas": "Introduce valores en puntos (pt) separados por comas o espacios. Las Y se miden desde el borde superior del PDF.",
+      "pdf": "Introduce valores en puntos (pt) separados por comas o espacios. Las Y se miden desde el borde inferior del PDF."
+    },
+    "coordinateMode": {
+      "label": "Origen de coordenadas",
+      "canvas": "Esquina superior izquierda (Canvas)",
+      "pdf": "Esquina inferior izquierda (PDF)"
+    }
   },
   "annotation": {
     "fields": {

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -25,9 +25,12 @@
     "importJsonFile": "Importar desde archivo",
     "applyJson": "Aplicar JSON",
     "jsonPlaceholder": "Pega o edita aquí las coordenadas de anotaciones...",
-    "jsonHint": "Pega las coordenadas o impórtalas desde un JSON con el mismo formato que el archivo exportado."
+    "jsonHint": "Pega las coordenadas o impórtalas desde un JSON con el mismo formato que el archivo exportado.",
+    "advancedTitle": "Opciones avanzadas",
+    "advancedHint": "Activa las guías y el snapping solo cuando necesites más precisión."
   },
   "guides": {
+    "enableFeature": "Activar guías y snapping",
     "title": "Guías y snapping",
     "showGrid": "Mostrar rejilla",
     "showRulers": "Mostrar reglas",

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -27,6 +27,23 @@
     "jsonPlaceholder": "Pega o edita aquí las coordenadas de anotaciones...",
     "jsonHint": "Pega las coordenadas o impórtalas desde un JSON con el mismo formato que el archivo exportado."
   },
+  "guides": {
+    "title": "Guías y snapping",
+    "showGrid": "Mostrar rejilla",
+    "showRulers": "Mostrar reglas",
+    "showAlignment": "Resaltar alineaciones activas",
+    "snapGrid": "Ajustar a rejilla",
+    "snapMargins": "Ajustar a márgenes",
+    "snapCenters": "Ajustar a ejes centrales",
+    "snapCustom": "Ajustar a coordenadas personalizadas",
+    "gridSize": "Rejilla (pt)",
+    "marginSize": "Margen (pt)",
+    "tolerance": "Tolerancia (px)",
+    "customX": "Coordenadas X (pt)",
+    "customY": "Coordenadas Y (pt desde el borde superior)",
+    "customPlaceholder": "Ej.: 24, 48, 120",
+    "customHint": "Introduce valores en puntos (pt) separados por comas o espacios. Las Y se miden desde el borde superior del PDF."
+  },
   "annotation": {
   "fields": {
     "text": {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -740,6 +740,69 @@ header .logo {
   accent-color: var(--accent);
 }
 
+.advanced-panel .guides-panel .guides-mode {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.28);
+  border: 1px solid rgba(94, 234, 212, 0.12);
+}
+
+.advanced-panel .guides-panel .guides-mode__label {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.advanced-panel .guides-panel .guides-mode__options {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 8px;
+}
+
+.advanced-panel .guides-panel .guides-mode__options label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  color: var(--text);
+}
+
+.advanced-panel .guides-panel .guides-mode__options label input[type='radio'] {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  accent-color: var(--accent);
+}
+
+.advanced-panel .guides-panel .guides-mode__options label span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid rgba(94, 234, 212, 0.18);
+  background: rgba(29, 29, 42, 0.85);
+  font-size: 0.8rem;
+  font-weight: 500;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.advanced-panel .guides-panel .guides-mode__options label input[type='radio']:checked + span {
+  border-color: var(--accent);
+  background: rgba(94, 234, 212, 0.18);
+  color: var(--accent);
+  box-shadow: 0 0 0 1px rgba(94, 234, 212, 0.15);
+}
+
+.advanced-panel .guides-panel .guides-mode__options label:hover span,
+.advanced-panel .guides-panel .guides-mode__options label:focus-within span {
+  border-color: rgba(94, 234, 212, 0.35);
+  box-shadow: 0 0 0 1px rgba(94, 234, 212, 0.15);
+}
+
 .advanced-panel .guides-panel .guides-inputs {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -166,22 +166,48 @@ header .logo {
   }
 
   .advanced-panel {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
+    margin-top: 12px;
 
-    h5 {
-      margin: 0;
-      font-size: 1rem;
+    .advanced-toggle {
+      width: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      background: transparent;
+      border: 1px solid rgba(94, 234, 212, 0.25);
+      border-radius: 8px;
+      padding: 8px 10px;
       color: var(--accent);
+      font-size: 0.95rem;
+      cursor: pointer;
+      transition: border-color 0.2s ease, background 0.2s ease;
     }
 
-    label {
+    .advanced-toggle:hover,
+    &.open .advanced-toggle,
+    &.active .advanced-toggle {
+      border-color: var(--accent);
+      background: rgba(94, 234, 212, 0.12);
+    }
+
+    .advanced-icon {
+      font-size: 0.9rem;
+      transform: rotate(-90deg);
+      transition: transform 0.2s ease;
+    }
+
+    &.open .advanced-icon {
+      transform: rotate(0deg);
+    }
+
+    .advanced-checkbox {
       display: flex;
       align-items: center;
       gap: 8px;
       font-size: 0.9rem;
       color: var(--text);
+      margin: 12px 0 4px;
     }
 
     input[type='checkbox'] {
@@ -192,6 +218,8 @@ header .logo {
       font-size: 0.75rem;
       color: var(--muted);
       line-height: 1.4;
+      margin-bottom: 12px;
+      display: block;
     }
   }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -159,6 +159,104 @@ header .logo {
     color: var(--muted);
     line-height: 1.4;
   }
+
+  .sidebar-divider {
+    margin: 16px 0;
+    border-top: 1px solid rgba(94, 234, 212, 0.15);
+  }
+
+  .guides-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+
+    h5 {
+      margin: 0;
+      font-size: 1rem;
+      color: var(--accent);
+    }
+
+    .guides-toggles {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 8px;
+
+      label {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 0.85rem;
+        color: var(--text);
+      }
+
+      input[type='checkbox'] {
+        accent-color: var(--accent);
+      }
+    }
+
+    .guides-inputs {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+      gap: 10px;
+
+      label {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        font-size: 0.8rem;
+        color: var(--muted);
+      }
+
+      input[type='number'] {
+        width: 100%;
+        border-radius: 6px;
+        border: 1px solid rgba(94, 234, 212, 0.25);
+        background: rgba(29, 29, 42, 0.9);
+        color: var(--text);
+        padding: 6px 8px;
+      }
+
+      input[type='number']:focus {
+        outline: none;
+        border-color: var(--accent);
+        box-shadow: 0 0 0 2px rgba(94, 234, 212, 0.15);
+      }
+    }
+
+    .guides-custom {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+
+      label {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        font-size: 0.8rem;
+        color: var(--muted);
+      }
+
+      input[type='text'] {
+        border-radius: 6px;
+        border: 1px solid rgba(94, 234, 212, 0.25);
+        background: rgba(29, 29, 42, 0.9);
+        color: var(--text);
+        padding: 6px 8px;
+      }
+
+      input[type='text']:focus {
+        outline: none;
+        border-color: var(--accent);
+        box-shadow: 0 0 0 2px rgba(94, 234, 212, 0.12);
+      }
+
+      .guides-hint {
+        font-size: 0.75rem;
+        color: var(--muted);
+        line-height: 1.4;
+      }
+    }
+  }
 }
 
 .viewer {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -802,12 +802,11 @@ header .logo {
   position: relative;
 }
 
-#pdfCanvas,
-#overlayCanvas {
+.canvas-container .canvas {
   display: block;
 }
 
-#overlayCanvas {
+.canvas--overlay {
   position: absolute;
   inset: 0;
   pointer-events: none;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -165,6 +165,36 @@ header .logo {
     border-top: 1px solid rgba(94, 234, 212, 0.15);
   }
 
+  .advanced-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+
+    h5 {
+      margin: 0;
+      font-size: 1rem;
+      color: var(--accent);
+    }
+
+    label {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 0.9rem;
+      color: var(--text);
+    }
+
+    input[type='checkbox'] {
+      accent-color: var(--accent);
+    }
+
+    .advanced-hint {
+      font-size: 0.75rem;
+      color: var(--muted);
+      line-height: 1.4;
+    }
+  }
+
   .guides-panel {
     display: flex;
     flex-direction: column;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -328,6 +328,20 @@ header .logo {
   padding: 12px;
 }
 
+.viewer .canvas-container {
+  margin: 0 auto;
+  transition: margin 0.2s ease;
+}
+
+.viewer.viewer--guides-enabled {
+  justify-content: flex-start;
+}
+
+.viewer.viewer--guides-enabled .canvas-container {
+  margin-left: 0;
+  margin-right: auto;
+}
+
 .footer {
   grid-area: footer;
   background: var(--panel);

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -567,162 +567,223 @@ header .logo {
 .templates__delete:hover {
   background: rgba(255, 77, 77, 0.15);
   border-color: var(--danger);
+}
 
-  .sidebar-divider {
-    margin: 16px 0;
-    border-top: 1px solid rgba(94, 234, 212, 0.15);
+.sidebar-divider {
+  width: 100%;
+  display: block;
+  margin: 16px 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(94, 234, 212, 0.45), transparent);
+  border-radius: 999px;
+}
+
+@keyframes advanced-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
   }
 
-  .advanced-panel {
-    margin-top: 12px;
-
-    .advanced-toggle {
-      width: 100%;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 8px;
-      background: transparent;
-      border: 1px solid rgba(94, 234, 212, 0.25);
-      border-radius: 8px;
-      padding: 8px 10px;
-      color: var(--accent);
-      font-size: 0.95rem;
-      cursor: pointer;
-      transition: border-color 0.2s ease, background 0.2s ease;
-    }
-
-    .advanced-toggle:hover,
-    &.open .advanced-toggle,
-    &.active .advanced-toggle {
-      border-color: var(--accent);
-      background: rgba(94, 234, 212, 0.12);
-    }
-
-    .advanced-icon {
-      font-size: 0.9rem;
-      transform: rotate(-90deg);
-      transition: transform 0.2s ease;
-    }
-
-    &.open .advanced-icon {
-      transform: rotate(0deg);
-    }
-
-    .advanced-checkbox {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      font-size: 0.9rem;
-      color: var(--text);
-      margin: 12px 0 4px;
-    }
-
-    input[type='checkbox'] {
-      accent-color: var(--accent);
-    }
-
-    .advanced-hint {
-      font-size: 0.75rem;
-      color: var(--muted);
-      line-height: 1.4;
-      margin-bottom: 12px;
-      display: block;
-    }
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
+}
 
-  .guides-panel {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
+.advanced-panel {
+  position: relative;
+  margin-top: 20px;
+  padding: 16px;
+  border-radius: 16px;
+  background: linear-gradient(140deg, rgba(29, 29, 42, 0.95), rgba(35, 35, 52, 0.92));
+  border: 1px solid rgba(94, 234, 212, 0.15);
+  box-shadow: 0 18px 36px -28px rgba(15, 23, 42, 0.95);
+  transition: border-color 0.25s ease, box-shadow 0.25s ease, transform 0.2s ease;
+  overflow: hidden;
+}
 
-    h5 {
-      margin: 0;
-      font-size: 1rem;
-      color: var(--accent);
-    }
+.advanced-panel::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(circle at top right, rgba(94, 234, 212, 0.12), transparent 55%);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  pointer-events: none;
+}
 
-    .guides-toggles {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-      gap: 8px;
+.advanced-panel.active {
+  border-color: rgba(94, 234, 212, 0.5);
+  box-shadow: 0 24px 44px -28px rgba(94, 234, 212, 0.28);
+}
 
-      label {
-        display: flex;
-        align-items: center;
-        gap: 6px;
-        font-size: 0.85rem;
-        color: var(--text);
-      }
+.advanced-panel.active::before {
+  opacity: 1;
+}
 
-      input[type='checkbox'] {
-        accent-color: var(--accent);
-      }
-    }
+.advanced-panel.open {
+  transform: translateY(-2px);
+}
 
-    .guides-inputs {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-      gap: 10px;
+.advanced-panel .advanced-toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(94, 234, 212, 0.2);
+  color: var(--text);
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  position: relative;
+  z-index: 1;
+}
 
-      label {
-        display: flex;
-        flex-direction: column;
-        gap: 4px;
-        font-size: 0.8rem;
-        color: var(--muted);
-      }
+.advanced-panel .advanced-toggle:hover,
+.advanced-panel .advanced-toggle:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  background: rgba(94, 234, 212, 0.18);
+  color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(94, 234, 212, 0.18);
+}
 
-      input[type='number'] {
-        width: 100%;
-        border-radius: 6px;
-        border: 1px solid rgba(94, 234, 212, 0.25);
-        background: rgba(29, 29, 42, 0.9);
-        color: var(--text);
-        padding: 6px 8px;
-      }
+.advanced-panel.active .advanced-toggle {
+  color: var(--accent);
+  border-color: rgba(94, 234, 212, 0.45);
+}
 
-      input[type='number']:focus {
-        outline: none;
-        border-color: var(--accent);
-        box-shadow: 0 0 0 2px rgba(94, 234, 212, 0.15);
-      }
-    }
+.advanced-panel .advanced-icon {
+  font-size: 0.9rem;
+  transform: rotate(-90deg);
+  transition: transform 0.2s ease;
+}
 
-    .guides-custom {
-      display: flex;
-      flex-direction: column;
-      gap: 8px;
+.advanced-panel.open .advanced-icon {
+  transform: rotate(0deg);
+}
 
-      label {
-        display: flex;
-        flex-direction: column;
-        gap: 4px;
-        font-size: 0.8rem;
-        color: var(--muted);
-      }
+.advanced-panel .advanced-content {
+  margin-top: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  animation: advanced-fade-in 0.25s ease;
+  position: relative;
+  z-index: 1;
+}
 
-      input[type='text'] {
-        border-radius: 6px;
-        border: 1px solid rgba(94, 234, 212, 0.25);
-        background: rgba(29, 29, 42, 0.9);
-        color: var(--text);
-        padding: 6px 8px;
-      }
+.advanced-panel .advanced-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.9rem;
+  color: var(--text);
+  font-weight: 500;
+}
 
-      input[type='text']:focus {
-        outline: none;
-        border-color: var(--accent);
-        box-shadow: 0 0 0 2px rgba(94, 234, 212, 0.12);
-      }
+.advanced-panel .advanced-checkbox input[type='checkbox'] {
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  accent-color: var(--accent);
+}
 
-      .guides-hint {
-        font-size: 0.75rem;
-        color: var(--muted);
-        line-height: 1.4;
-      }
-    }
-  }
+.advanced-panel .advanced-hint {
+  font-size: 0.78rem;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.advanced-panel .guides-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 14px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.35);
+  border: 1px solid rgba(94, 234, 212, 0.12);
+}
+
+.advanced-panel .guides-panel h5 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.advanced-panel .guides-panel .guides-toggles {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 10px;
+}
+
+.advanced-panel .guides-panel .guides-toggles label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.85rem;
+  color: var(--text);
+}
+
+.advanced-panel .guides-panel .guides-toggles input[type='checkbox'] {
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  accent-color: var(--accent);
+}
+
+.advanced-panel .guides-panel .guides-inputs {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+}
+
+.advanced-panel .guides-panel .guides-inputs label,
+.advanced-panel .guides-panel .guides-custom label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 0.8rem;
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.advanced-panel .guides-panel .guides-inputs input[type='number'],
+.advanced-panel .guides-panel .guides-custom input[type='text'] {
+  width: 100%;
+  border-radius: 8px;
+  border: 1px solid rgba(94, 234, 212, 0.25);
+  background: rgba(29, 29, 42, 0.9);
+  color: var(--text);
+  padding: 8px 10px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.advanced-panel .guides-panel .guides-inputs input[type='number']:focus,
+.advanced-panel .guides-panel .guides-custom input[type='text']:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(94, 234, 212, 0.15);
+}
+
+.advanced-panel .guides-panel .guides-custom {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.advanced-panel .guides-panel .guides-custom .guides-hint {
+  font-size: 0.75rem;
+  color: var(--muted);
+  line-height: 1.4;
 }
 
 .viewer {


### PR DESCRIPTION
## Summary
- add guide settings state to render rulers, grids, margins, and custom reference lines on the overlay canvas
- implement snapping logic with configurable tolerance, margins, grid, and custom coordinates plus visual highlights during drags
- expose sidebar controls, translations, and styles to manage guide visibility and snapping options

## Testing
- npm run build

------
