### PR TITLE
Add copy and paste duplication for annotations

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -177,6 +177,9 @@
         <div class="editor-actions">
           <button (click)="confirmEdit()">✅</button>
           <button (click)="cancelEdit()">❌</button>
+          <button type="button" class="btn-duplicate" (click)="duplicateAnnotation()"
+            [title]="'annotation.actions.duplicate' | t"
+            [attr.aria-label]="'annotation.actions.duplicate' | t">⧉</button>
           <button class="btn-delete" (click)="deleteAnnotation()">🗑️</button>
         </div>
       </div>

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -124,6 +124,7 @@ export class App implements AfterViewChecked {
   } | null = null;
   private draggingElement: HTMLDivElement | null = null;
   private pdfByteSources = new Map<string, { bytes: Uint8Array; weight: number }>();
+  private clipboard: PageField | null = null;
 
   @ViewChild('pdfCanvas', { static: false }) pdfCanvasRef?: ElementRef<HTMLCanvasElement>;
   @ViewChild('overlayCanvas', { static: false }) overlayCanvasRef?: ElementRef<HTMLCanvasElement>;
@@ -547,6 +548,37 @@ export class App implements AfterViewChecked {
     this.cancelEdit();
   }
 
+  @HostListener('window:keydown', ['$event'])
+  onGlobalKeydown(event: KeyboardEvent) {
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    const key = event.key.toLowerCase();
+    if (key !== 'c' && key !== 'v') {
+      return;
+    }
+
+    if (!(event.ctrlKey || event.metaKey)) {
+      return;
+    }
+
+    if (this.isEditableElement(event.target)) {
+      return;
+    }
+
+    if (key === 'c') {
+      if (this.copyAnnotation()) {
+        event.preventDefault();
+      }
+      return;
+    }
+
+    if (key === 'v' && this.pasteAnnotation()) {
+      event.preventDefault();
+    }
+  }
+
   deleteAnnotation() {
     const e = this.editing();
     if (!e) return;
@@ -554,6 +586,77 @@ export class App implements AfterViewChecked {
     this.syncCoordsTextModel();
     this.editing.set(null);
     this.redrawAllForPage();
+  }
+
+  copyAnnotation(): boolean {
+    const editState = this.editing();
+    if (!editState) {
+      return false;
+    }
+
+    const sanitized = this.prepareFieldForStorage(editState.field);
+    this.clipboard = { ...sanitized };
+    return true;
+  }
+
+  pasteAnnotation(targetPageNum?: number): boolean {
+    if (!this.clipboard || !this.pdfDoc) {
+      return false;
+    }
+
+    const pageNum = targetPageNum ?? this.pageIndex();
+    const pdfCanvas = this.pdfCanvasRef?.nativeElement ?? null;
+    const newField: PageField = { ...this.clipboard };
+
+    if (pdfCanvas) {
+      const scale = this.scale();
+      const offset = this.roundToTwo(8 / scale);
+      const maxX = this.roundToTwo(pdfCanvas.width / scale);
+      const maxY = this.roundToTwo(pdfCanvas.height / scale);
+      newField.x = this.roundToTwo(this.clamp(newField.x + offset, 0, maxX));
+      newField.y = this.roundToTwo(this.clamp(newField.y + offset, 0, maxY));
+    }
+
+    let insertedFieldIndex = -1;
+    let insertedPageIndex = -1;
+
+    this.coords.update((pages) => {
+      const updated = this.addFieldToPages(pageNum, newField, pages);
+      insertedPageIndex = updated.findIndex((page) => page.num === pageNum);
+      if (insertedPageIndex >= 0) {
+        insertedFieldIndex = updated[insertedPageIndex].fields.length - 1;
+      }
+      return updated;
+    });
+
+    this.syncCoordsTextModel();
+    this.redrawAllForPage();
+
+    if (insertedPageIndex >= 0 && insertedFieldIndex >= 0) {
+      const pages = this.coords();
+      const page = pages[insertedPageIndex];
+      const field = page?.fields[insertedFieldIndex];
+      if (field) {
+        this.startEditing(insertedPageIndex, insertedFieldIndex, field);
+      }
+    }
+
+    return true;
+  }
+
+  duplicateAnnotation() {
+    const editState = this.editing();
+    if (!editState) {
+      return;
+    }
+
+    const pages = this.coords();
+    const pageNum = pages[editState.pageIndex]?.num ?? this.pageIndex();
+    if (!this.copyAnnotation()) {
+      return;
+    }
+
+    this.pasteAnnotation(pageNum);
   }
 
   private fieldHasRenderableContent(field: PageField): boolean {
@@ -1443,5 +1546,38 @@ export class App implements AfterViewChecked {
     }
 
     return collapsed;
+  }
+
+  private isEditableElement(target: EventTarget | null): boolean {
+    const el = target as HTMLElement | null;
+    if (!el) {
+      return false;
+    }
+
+    if (el.isContentEditable) {
+      return true;
+    }
+
+    const tag = el.tagName?.toLowerCase();
+    if (tag === 'textarea' || tag === 'select') {
+      return true;
+    }
+
+    if (tag === 'input') {
+      const input = el as HTMLInputElement;
+      const type = input.type?.toLowerCase();
+      const nonEditableTypes = new Set(['button', 'checkbox', 'radio', 'range', 'color', 'submit', 'reset']);
+      return !nonEditableTypes.has(type);
+    }
+
+    return false;
+  }
+
+  private roundToTwo(value: number): number {
+    return Math.round(value * 100) / 100;
+  }
+
+  private clamp(value: number, min: number, max: number): number {
+    return Math.min(Math.max(value, min), max);
   }
 }

--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -68,6 +68,9 @@
       "hexPlaceholder": "#5eead4",
       "rgbPlaceholder": "rgb(94, 234, 212)"
     },
+    "actions": {
+      "duplicate": "Duplicar anotació"
+    },
     "editingBadge": "Editant"
   },
   "viewer": {

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -68,6 +68,9 @@
       "hexPlaceholder": "#5eead4",
       "rgbPlaceholder": "rgb(94, 234, 212)"
     },
+    "actions": {
+      "duplicate": "Duplicate annotation"
+    },
     "editingBadge": "Editing"
   },
   "viewer": {

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -68,6 +68,9 @@
       "hexPlaceholder": "#5eead4",
       "rgbPlaceholder": "rgb(94, 234, 212)"
     },
+    "actions": {
+      "duplicate": "Duplicar anotación"
+    },
     "editingBadge": "Editando"
   },
   "viewer": {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -333,6 +333,16 @@ header .logo {
     transform: translateY(-1px);
   }
 
+  .btn-duplicate {
+    background: rgba(94, 234, 212, 0.15);
+    color: var(--accent);
+    border: 1px solid rgba(94, 234, 212, 0.45);
+  }
+
+  .btn-duplicate:hover {
+    background: rgba(94, 234, 212, 0.25);
+  }
+
   &.editing {
     border-color: rgba(94, 234, 212, 0.65);
     box-shadow:


### PR DESCRIPTION
## Summary
- add a duplicate action to the annotation editor along with copy and paste keyboard shortcuts
- persist copied annotations on an internal clipboard and insert duplicates with a slight offset while reopening the editor
- localize and style the new duplicate control for all supported languages

## Testing
- npm run i18n:check

------
https://chatgpt.com/codex/tasks/task_e_690324cf10348325a3e5ae7632b712a7