### PR TITLE
Close annotation modals when clicking outside the PDF viewer

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -118,7 +118,7 @@
 
   <!-- VISOR PDF -->
   <main class="viewer" *ngIf="pdfDoc as _">
-    <div class="canvas-container">
+    <div class="canvas-container" #pdfViewer>
       <canvas #pdfCanvas></canvas>
       <canvas #overlayCanvas></canvas>
       <div #annotationsLayer class="annotations-layer"></div>

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -122,7 +122,8 @@ export class App implements AfterViewChecked, OnDestroy {
   @ViewChild('pdfCanvas', { static: false }) pdfCanvasRef?: ElementRef<HTMLCanvasElement>;
   @ViewChild('overlayCanvas', { static: false }) overlayCanvasRef?: ElementRef<HTMLCanvasElement>;
   @ViewChild('annotationsLayer', { static: false })
-  annotationsLayerRef?: ElementRef<HTMLDivElement>;
+    annotationsLayerRef?: ElementRef<HTMLDivElement>;
+  @ViewChild('pdfViewer', { static: false }) pdfViewerRef?: ElementRef<HTMLDivElement>;
   @ViewChild('previewEditor') previewEditorRef?: ElementRef<HTMLDivElement>;
   @ViewChild('editEditor') editEditorRef?: ElementRef<HTMLDivElement>;
   @ViewChild('coordsFileInput', { static: false }) coordsFileInputRef?: ElementRef<HTMLInputElement>;
@@ -569,6 +570,32 @@ export class App implements AfterViewChecked, OnDestroy {
     }
 
     this.cancelEdit();
+  }
+
+  @HostListener('document:click', ['$event'])
+  onDocumentClick(event: MouseEvent) {
+    if (!this.preview() && !this.editing()) {
+      return;
+    }
+
+    const viewer = this.pdfViewerRef?.nativeElement;
+    const target = event.target as Node | null;
+
+    if (!viewer || !target) {
+      return;
+    }
+
+    if (viewer.contains(target)) {
+      return;
+    }
+
+    if (this.preview()) {
+      this.cancelPreview();
+    }
+
+    if (this.editing()) {
+      this.cancelEdit();
+    }
   }
 
   deleteAnnotation() {


### PR DESCRIPTION
## Summary
- add a template reference to the PDF viewer container
- dismiss preview and edit annotation modals when clicks happen outside the viewer

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69032a4f33e08325944c6cdd62878197