### PR TITLE
Add copy and paste duplication for annotations

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -119,7 +119,7 @@
           <small class="color-hint">{{ 'annotation.color.hintPreview' | t }}</small>
         </div>
         <div class="editor-actions">
-          <button (click)="confirmPreview()">✅</button>
+          <button class="action-primary" (click)="confirmPreview()">✅</button>
           <button (click)="cancelPreview()">❌</button>
         </div>
       </div>
@@ -175,9 +175,12 @@
           <small class="color-hint">{{ 'annotation.color.hintEdit' | t }}</small>
         </div>
         <div class="editor-actions">
-          <button (click)="confirmEdit()">✅</button>
-          <button (click)="cancelEdit()">❌</button>
+          <button type="button" (click)="duplicateAnnotation()"
+            [title]="'annotation.actions.duplicate' | t"
+            [attr.aria-label]="'annotation.actions.duplicate' | t">⧉</button>
           <button class="btn-delete" (click)="deleteAnnotation()">🗑️</button>
+          <button class="action-primary" (click)="confirmEdit()">✅</button>
+          <button (click)="cancelEdit()">❌</button>
         </div>
       </div>
     </div>

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -124,6 +124,7 @@ export class App implements AfterViewChecked {
   } | null = null;
   private draggingElement: HTMLDivElement | null = null;
   private pdfByteSources = new Map<string, { bytes: Uint8Array; weight: number }>();
+  private clipboard: PageField | null = null;
 
   @ViewChild('pdfCanvas', { static: false }) pdfCanvasRef?: ElementRef<HTMLCanvasElement>;
   @ViewChild('overlayCanvas', { static: false }) overlayCanvasRef?: ElementRef<HTMLCanvasElement>;
@@ -554,6 +555,77 @@ export class App implements AfterViewChecked {
     this.syncCoordsTextModel();
     this.editing.set(null);
     this.redrawAllForPage();
+  }
+
+  copyAnnotation(): boolean {
+    const editState = this.editing();
+    if (!editState) {
+      return false;
+    }
+
+    const sanitized = this.prepareFieldForStorage(editState.field);
+    this.clipboard = { ...sanitized };
+    return true;
+  }
+
+  pasteAnnotation(targetPageNum?: number): boolean {
+    if (!this.clipboard || !this.pdfDoc) {
+      return false;
+    }
+
+    const pageNum = targetPageNum ?? this.pageIndex();
+    const pdfCanvas = this.pdfCanvasRef?.nativeElement ?? null;
+    const newField: PageField = { ...this.clipboard };
+
+    if (pdfCanvas) {
+      const scale = this.scale();
+      const offset = this.roundToTwo(8 / scale);
+      const maxX = this.roundToTwo(pdfCanvas.width / scale);
+      const maxY = this.roundToTwo(pdfCanvas.height / scale);
+      newField.x = this.roundToTwo(this.clamp(newField.x + offset, 0, maxX));
+      newField.y = this.roundToTwo(this.clamp(newField.y + offset, 0, maxY));
+    }
+
+    let insertedFieldIndex = -1;
+    let insertedPageIndex = -1;
+
+    this.coords.update((pages) => {
+      const updated = this.addFieldToPages(pageNum, newField, pages);
+      insertedPageIndex = updated.findIndex((page) => page.num === pageNum);
+      if (insertedPageIndex >= 0) {
+        insertedFieldIndex = updated[insertedPageIndex].fields.length - 1;
+      }
+      return updated;
+    });
+
+    this.syncCoordsTextModel();
+    this.redrawAllForPage();
+
+    if (insertedPageIndex >= 0 && insertedFieldIndex >= 0) {
+      const pages = this.coords();
+      const page = pages[insertedPageIndex];
+      const field = page?.fields[insertedFieldIndex];
+      if (field) {
+        this.startEditing(insertedPageIndex, insertedFieldIndex, field);
+      }
+    }
+
+    return true;
+  }
+
+  duplicateAnnotation() {
+    const editState = this.editing();
+    if (!editState) {
+      return;
+    }
+
+    const pages = this.coords();
+    const pageNum = pages[editState.pageIndex]?.num ?? this.pageIndex();
+    if (!this.copyAnnotation()) {
+      return;
+    }
+
+    this.pasteAnnotation(pageNum);
   }
 
   private fieldHasRenderableContent(field: PageField): boolean {
@@ -1443,5 +1515,38 @@ export class App implements AfterViewChecked {
     }
 
     return collapsed;
+  }
+
+  private isEditableElement(target: EventTarget | null): boolean {
+    const el = target as HTMLElement | null;
+    if (!el) {
+      return false;
+    }
+
+    if (el.isContentEditable) {
+      return true;
+    }
+
+    const tag = el.tagName?.toLowerCase();
+    if (tag === 'textarea' || tag === 'select') {
+      return true;
+    }
+
+    if (tag === 'input') {
+      const input = el as HTMLInputElement;
+      const type = input.type?.toLowerCase();
+      const nonEditableTypes = new Set(['button', 'checkbox', 'radio', 'range', 'color', 'submit', 'reset']);
+      return !nonEditableTypes.has(type);
+    }
+
+    return false;
+  }
+
+  private roundToTwo(value: number): number {
+    return Math.round(value * 100) / 100;
+  }
+
+  private clamp(value: number, min: number, max: number): number {
+    return Math.min(Math.max(value, min), max);
   }
 }

--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -68,6 +68,9 @@
       "hexPlaceholder": "#5eead4",
       "rgbPlaceholder": "rgb(94, 234, 212)"
     },
+    "actions": {
+      "duplicate": "Duplicar anotació"
+    },
     "editingBadge": "Editant"
   },
   "viewer": {

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -68,6 +68,9 @@
       "hexPlaceholder": "#5eead4",
       "rgbPlaceholder": "rgb(94, 234, 212)"
     },
+    "actions": {
+      "duplicate": "Duplicate annotation"
+    },
     "editingBadge": "Editing"
   },
   "viewer": {

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -68,6 +68,9 @@
       "hexPlaceholder": "#5eead4",
       "rgbPlaceholder": "rgb(94, 234, 212)"
     },
+    "actions": {
+      "duplicate": "Duplicar anotación"
+    },
     "editingBadge": "Editando"
   },
   "viewer": {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -431,7 +431,11 @@ header .logo {
   .editor-actions {
     display: flex;
     gap: 6px;
-    justify-content: flex-end;
+    justify-content: flex-start;
+
+    .action-primary {
+      margin-left: auto;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- remove the global copy/paste listener tied to annotation duplication
- realign editor action buttons with confirm/cancel on the right and other actions on the left
- match the duplicate button styling to the other inline controls

## Testing
- npm run i18n:check

------
