### PR TITLE
Add Playwright E2E tests and CI workflow enhancements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Use Node.js 20
+      - name: Use Node.js 22.12.0
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22.12.0
           cache: 'npm'
       - name: Install dependencies
         run: npm install --no-audit --no-fund
@@ -30,10 +30,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Use Node.js 20
+      - name: Use Node.js 22.12.0
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22.12.0
           cache: 'npm'
       - name: Install dependencies
         run: npm install --no-audit --no-fund

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - '*'
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+      - name: Run unit build
+        run: npm run build
+
+  e2e:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+      - name: Build application
+        run: npm run build
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+      - name: Run Playwright tests
+        env:
+          PLAYWRIGHT_TEST_PORT: 4400
+        run: npx playwright test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           node-version: 22.12.0
           cache: 'npm'
+          cache-dependency-path: package.json
       - name: Install dependencies
         run: npm install --no-audit --no-fund
       - name: Run unit build
@@ -35,6 +36,7 @@ jobs:
         with:
           node-version: 22.12.0
           cache: 'npm'
+          cache-dependency-path: package.json
       - name: Install dependencies
         run: npm install --no-audit --no-fund
       - name: Build application

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,8 @@ Thumbs.db
 
 # Otros
 *.tgz
+playwright-report/
+test-results/
 
 # Archivo de bloqueo de paquetes
 package-lock.json

--- a/e2e/pdf-annotator.e2e-spec.ts
+++ b/e2e/pdf-annotator.e2e-spec.ts
@@ -1,0 +1,88 @@
+import { expect, test, type Download } from '@playwright/test';
+import { promises as fs } from 'node:fs';
+import { Readable } from 'node:stream';
+
+async function streamToBuffer(stream: Readable): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    const bufferChunk =
+      typeof chunk === 'string' ? Buffer.from(chunk, 'utf-8') : Buffer.from(chunk);
+    chunks.push(bufferChunk);
+  }
+  return Buffer.concat(chunks);
+}
+
+async function downloadToBuffer(download: Download): Promise<Buffer> {
+  const stream = await download.createReadStream();
+  if (stream) {
+    return streamToBuffer(stream);
+  }
+  const filePath = await download.path();
+  if (!filePath) {
+    throw new Error('Unable to read download contents');
+  }
+  return fs.readFile(filePath);
+}
+
+test.describe('PDF annotation end-to-end', () => {
+  test('creates, duplicates and exports annotations', async ({ page }) => {
+    await page.goto('/');
+
+    const fileInput = page.locator('input.input-file[type="file"]');
+    await expect(fileInput).toBeVisible();
+
+    await fileInput.setInputFiles('public/assets/test-documents/sample.pdf');
+
+    const viewer = page.locator('main.viewer');
+    await expect(viewer).toBeVisible();
+    await expect(page.locator('.hitbox')).toBeVisible();
+
+    const hitbox = page.locator('.hitbox');
+    await hitbox.click({ position: { x: 200, y: 250 } });
+
+    const previewEditor = page.locator('.annotation-editor:not(.editing)');
+    await expect(previewEditor).toBeVisible();
+
+    const previewFields = previewEditor.locator('label.field');
+    await previewFields.nth(0).locator('input').fill('Test map field');
+    await previewFields.nth(1).locator('select').selectOption('text');
+    await previewFields.nth(2).locator('input').fill('Test annotation');
+    await previewEditor.locator('button', { hasText: '✅' }).click();
+
+    const annotations = page.locator('.annotations-layer .annotation');
+    await expect(annotations).toHaveCount(1);
+    await expect(annotations.first()).toContainText('Test annotation');
+
+    await annotations.first().click();
+
+    const editingPanel = page.locator('.annotation-editor.editing');
+    await expect(editingPanel).toBeVisible();
+
+    await editingPanel.locator('button', { hasText: '⧉' }).click();
+
+    const duplicateEditor = page.locator('.annotation-editor.editing');
+    await expect(duplicateEditor).toBeVisible();
+    await duplicateEditor.locator('button', { hasText: '✅' }).click();
+    await expect(duplicateEditor).toHaveCount(0);
+
+    await expect(annotations).toHaveCount(2);
+    await expect(annotations).toContainText(['Test annotation', 'Test annotation']);
+
+    const downloadJsonPromise = page.waitForEvent('download');
+    await page.getByRole('button', { name: /Descargar JSON/i }).click();
+    const jsonDownload = await downloadJsonPromise;
+    const jsonBuffer = await downloadToBuffer(jsonDownload);
+    const jsonData = JSON.parse(jsonBuffer.toString('utf-8'));
+    const pages = Array.isArray(jsonData.pages) ? jsonData.pages : [];
+    expect(pages.length).toBeGreaterThan(0);
+    const firstPage = pages[0] ?? { fields: [] };
+    const fields = Array.isArray(firstPage.fields) ? firstPage.fields : [];
+    expect(fields.length).toBeGreaterThanOrEqual(2);
+
+    const downloadPdfPromise = page.waitForEvent('download');
+    await page.getByRole('button', { name: /Descargar PDF/i }).click();
+    const pdfDownload = await downloadPdfPromise;
+    const pdfBuffer = await downloadToBuffer(pdfDownload);
+    expect(pdfBuffer.subarray(0, 4).toString()).toBe('%PDF');
+  });
+});

--- a/e2e/pdf-annotator.e2e-spec.ts
+++ b/e2e/pdf-annotator.e2e-spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, type Download } from '@playwright/test';
 import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
 import { Readable } from 'node:stream';
 
 async function streamToBuffer(stream: Readable): Promise<Buffer> {
@@ -31,7 +32,15 @@ test.describe('PDF annotation end-to-end', () => {
     const fileInput = page.locator('input.input-file[type="file"]');
     await expect(fileInput).toBeVisible();
 
-    await fileInput.setInputFiles('public/assets/test-documents/sample.pdf');
+    const samplePdfPath = join(
+      process.cwd(),
+      'public',
+      'assets',
+      'test-documents',
+      'sample.pdf'
+    );
+
+    await fileInput.setInputFiles(samplePdfPath);
 
     const viewer = page.locator('main.viewer');
     await expect(viewer).toBeVisible();

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2022",
+    "types": ["node", "@playwright/test"],
+    "resolveJsonModule": true,
+    "esModuleInterop": true
+  },
+  "include": ["./**/*.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     ]
   },
   "private": true,
+  "engines": {
+    "node": "22.12.0"
+  },
   "dependencies": {
     "@angular/common": "^20.2.0",
     "@angular/compiler": "^20.2.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "npm run i18n:check && ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
+    "e2e": "playwright test",
     "serve:ssr:pdf-annotator": "node dist/pdf-annotator/server/server.mjs",
     "i18n:check": "node scripts/check-translations.mjs"
   },
@@ -46,6 +47,7 @@
     "@angular/build": "^20.2.1",
     "@angular/cli": "^20.2.1",
     "@angular/compiler-cli": "^20.2.0",
+    "@playwright/test": "^1.48.2",
     "@types/express": "^5.0.1",
     "@types/jasmine": "~5.1.0",
     "@types/node": "^20.17.19",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = process.env.PLAYWRIGHT_TEST_PORT ? Number(process.env.PLAYWRIGHT_TEST_PORT) : 4300;
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 120_000,
+  expect: {
+    timeout: 10_000,
+  },
+  retries: process.env.CI ? 2 : 0,
+  fullyParallel: true,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL: `http://127.0.0.1:${PORT}`,
+    headless: true,
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: `npm run start -- --host 0.0.0.0 --port ${PORT}`,
+    url: `http://127.0.0.1:${PORT}`,
+    reuseExistingServer: !process.env.CI,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    timeout: 180_000,
+  },
+});

--- a/public/assets/test-documents/sample.pdf
+++ b/public/assets/test-documents/sample.pdf
@@ -1,0 +1,32 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 400 400] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 55 >>
+stream
+BT /F1 24 Tf 72 300 Td (Sample PDF) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000332 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+402
+%%EOF


### PR DESCRIPTION
## Summary
- add Playwright configuration and an end-to-end test that uploads a sample PDF, duplicates annotations, and validates JSON/PDF exports
- provide a lightweight sample PDF asset, supporting e2e TypeScript config, and update package metadata and ignores for Playwright artifacts
- extend the CI workflow with dedicated build and Playwright jobs that install browsers and run the new e2e suite

## Testing
- `npm run build`
- `npx playwright test` *(fails locally: npm returns 403 Forbidden when downloading the Playwright package through the proxy)*

------
