### PR TITLE
docs: clarify local and docker workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ npm install
 npm run start:local
 ```
 
-El servidor de desarrollo queda disponible en `http://localhost:4200` con soporte para hot-reload. El script comprueba si faltan las dependencias de Angular (por ejemplo `@angular/build`) y ejecuta `npm install` automáticamente antes de lanzar `ng serve`, evitando el error `Could not find the '@angular/build:dev-server' builder's node package.` en entornos recién clonados.
+El servidor de desarrollo queda disponible en `http://localhost:4200` con soporte para hot-reload. Si faltan dependencias críticas de Angular (por ejemplo `@angular/build`), el script se detiene con un aviso para que ejecutes `npm install` manualmente antes de volver a lanzar `ng serve`; así evitas el error `Could not find the '@angular/build:dev-server' builder's node package.` típico de los entornos recién clonados.
 
 > ¿Tu equipo no puede instalar Node.js 22 o Angular 20? Ejecuta la versión en contenedor.
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ npm install
 npm run start:local
 ```
 
-El servidor de desarrollo queda disponible en `http://localhost:4200` con soporte para hot-reload.
+El servidor de desarrollo queda disponible en `http://localhost:4200` con soporte para hot-reload. El script comprueba si faltan las dependencias de Angular (por ejemplo `@angular/build`) y ejecuta `npm install` automáticamente antes de lanzar `ng serve`, evitando el error `Could not find the '@angular/build:dev-server' builder's node package.` en entornos recién clonados.
 
 > ¿Tu equipo no puede instalar Node.js 22 o Angular 20? Ejecuta la versión en contenedor.
 

--- a/README.md
+++ b/README.md
@@ -67,11 +67,29 @@ cd pdf-annotator
 npm install
 ```
 
+### ▶️ Ejecuta la app en tu máquina (Node 22)
+
+```bash
+npm run start:local
+```
+
+El servidor de desarrollo queda disponible en `http://localhost:4200` con soporte para hot-reload.
+
+> ¿Tu equipo no puede instalar Node.js 22 o Angular 20? Ejecuta la versión en contenedor.
+
+### 🐳 Ejecuta la app con Docker (alternativa)
+
+```bash
+npm run start:docker
+```
+
+El comando delega en `scripts/docker-up.sh` para construir la imagen y exponer la SPA en `http://localhost:4444`.
+
 ## 🚀 Despliegue con Docker
 > Requiere Docker Desktop, Docker Engine o una instalación compatible con Docker Compose.
 
 ```bash
-sh scripts/docker-up.sh
+npm run start:docker
 ```
 
 El script compila la aplicación con Node.js 22.12.0, construye la imagen `pdf-annotator:latest` y levanta el servicio detrás de NGINX. Una vez completado, la SPA queda disponible en `http://localhost:4444`.
@@ -87,7 +105,7 @@ Al finalizar, la aplicación dejará de estar disponible en `http://localhost:44
 ## ▶ Uso paso a paso
 ### 1. Inicia el servidor de desarrollo
 ```bash
-npm start -- --host 0.0.0.0 --port 4200
+npm run start:local
 ```
 Abre `http://localhost:4200` en tu navegador (o la IP indicada si usaste otro host).
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "start:local": "ng serve --host 0.0.0.0 --port 4200",
+    "start:local": "node scripts/start-local.mjs",
     "start:docker": "sh scripts/docker-up.sh",
     "build": "npm run i18n:check && ng build",
     "watch": "ng build --watch --configuration development",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "ng": "ng",
     "start": "ng serve",
     "start:local": "node scripts/start-local.mjs",
-    "start:docker": "sh scripts/docker-up.sh",
+    "start:docker": "bash scripts/docker-up.sh",
     "build": "npm run i18n:check && ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "Pdf Annotator",
-  "version": "1.0.2",
-  "description": "Ejecuta en local con 'npm run start:local' o usa 'npm run start:docker' para servir vía Docker en el puerto 4444 cuando tu entorno no soporte la versión requerida de Node o Angular.",
+  "version": "1.0.1",
   "author": "AlvaroMaxter",
   "scripts": {
     "ng": "ng",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,13 @@
 {
   "name": "Pdf Annotator",
-  "version": "1.0.1",
+  "version": "1.0.2",
+  "description": "Ejecuta en local con 'npm run start:local' o usa 'npm run start:docker' para servir vía Docker en el puerto 4444 cuando tu entorno no soporte la versión requerida de Node o Angular.",
   "author": "AlvaroMaxter",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
+    "start:local": "ng serve --host 0.0.0.0 --port 4200",
+    "start:docker": "sh scripts/docker-up.sh",
     "build": "npm run i18n:check && ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",

--- a/scripts/start-local.mjs
+++ b/scripts/start-local.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+import { existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawn, spawnSync } from 'node:child_process';
+
+const projectRoot = resolve(fileURLToPath(new URL('..', import.meta.url)));
+const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const angularBuilderPath = join(projectRoot, 'node_modules', '@angular', 'build', 'package.json');
+
+if (!existsSync(angularBuilderPath)) {
+  console.log('Dependencias de Angular no encontradas. Ejecutando "npm install" antes del arranque...');
+  const installResult = spawnSync(npmCmd, ['install'], {
+    cwd: projectRoot,
+    stdio: 'inherit'
+  });
+
+  if (installResult.status !== 0) {
+    console.error('\nError: "npm install" falló. Revisa los mensajes anteriores para más detalles.');
+    process.exit(installResult.status ?? 1);
+  }
+}
+
+const serve = spawn(
+  npmCmd,
+  ['run', 'ng', '--', 'serve', '--host', '0.0.0.0', '--port', '4200'],
+  {
+    cwd: projectRoot,
+    stdio: 'inherit'
+  }
+);
+
+serve.on('exit', (code, signal) => {
+  if (typeof code === 'number') {
+    process.exit(code);
+  }
+
+  if (signal) {
+    process.kill(process.pid, signal);
+  }
+});

--- a/scripts/start-local.mjs
+++ b/scripts/start-local.mjs
@@ -2,23 +2,18 @@
 import { existsSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { spawn, spawnSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 
 const projectRoot = resolve(fileURLToPath(new URL('..', import.meta.url)));
 const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 const angularBuilderPath = join(projectRoot, 'node_modules', '@angular', 'build', 'package.json');
 
 if (!existsSync(angularBuilderPath)) {
-  console.log('Dependencias de Angular no encontradas. Ejecutando "npm install" antes del arranque...');
-  const installResult = spawnSync(npmCmd, ['install'], {
-    cwd: projectRoot,
-    stdio: 'inherit'
-  });
-
-  if (installResult.status !== 0) {
-    console.error('\nError: "npm install" falló. Revisa los mensajes anteriores para más detalles.');
-    process.exit(installResult.status ?? 1);
-  }
+  console.error(
+    '\n❌ No se encontraron las dependencias de Angular necesarias (por ejemplo @angular/build). ' +
+      'Ejecuta "npm install" en la raíz del proyecto y vuelve a lanzar "npm run start:local".'
+  );
+  process.exit(1);
 }
 
 const serve = spawn(

--- a/scripts/start-local.mjs
+++ b/scripts/start-local.mjs
@@ -5,20 +5,20 @@ import { fileURLToPath } from 'node:url';
 import { spawn } from 'node:child_process';
 
 const projectRoot = resolve(fileURLToPath(new URL('..', import.meta.url)));
-const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
-const angularBuilderPath = join(projectRoot, 'node_modules', '@angular', 'build', 'package.json');
+const angularCliEntrypoint = join(projectRoot, 'node_modules', '@angular', 'cli', 'bin', 'ng.js');
+const angularBuilderPkg = join(projectRoot, 'node_modules', '@angular', 'build', 'package.json');
 
-if (!existsSync(angularBuilderPath)) {
+if (!existsSync(angularCliEntrypoint) || !existsSync(angularBuilderPkg)) {
   console.error(
-    '\n❌ No se encontraron las dependencias de Angular necesarias (por ejemplo @angular/build). ' +
+    '\n❌ No se encontraron las dependencias de Angular necesarias (por ejemplo @angular/cli o @angular/build). ' +
       'Ejecuta "npm install" en la raíz del proyecto y vuelve a lanzar "npm run start:local".'
   );
   process.exit(1);
 }
 
 const serve = spawn(
-  npmCmd,
-  ['run', 'ng', '--', 'serve', '--host', '0.0.0.0', '--port', '4200'],
+  process.execPath,
+  [angularCliEntrypoint, 'serve', '--host', '0.0.0.0', '--port', '4200'],
   {
     cwd: projectRoot,
     stdio: 'inherit'

--- a/scripts/start-local.mjs
+++ b/scripts/start-local.mjs
@@ -10,7 +10,7 @@ const angularBuilderPkg = join(projectRoot, 'node_modules', '@angular', 'build',
 
 if (!existsSync(angularCliEntrypoint) || !existsSync(angularBuilderPkg)) {
   console.error(
-    '\n❌ No se encontraron las dependencias de Angular necesarias (por ejemplo @angular/cli o @angular/build). ' +
+    '\nERROR ~ No se encontraron las dependencias de Angular necesarias (por ejemplo @angular/cli o @angular/build). ' +
       'Ejecuta "npm install" en la raíz del proyecto y vuelve a lanzar "npm run start:local".'
   );
   process.exit(1);


### PR DESCRIPTION
## Summary
- document the local (`npm run start:local`) and Docker (`npm run start:docker`) flows in the README, clarifying Docker as the fallback when Node/Angular versions are unavailable locally
- route the `start:docker` npm script through the existing `scripts/docker-up.sh` helper and remove the changelog entry that duplicated the README guidance

## Testing
- not run


------
