### PR TITLE
Move JSON actions into sidebar panel

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -26,9 +26,6 @@
       <button class="btn" (click)="undo()" [disabled]="!canUndo()">{{ 'controls.undo' | t }}</button>
       <button class="btn" (click)="redo()" [disabled]="!canRedo()">{{ 'controls.redo' | t }}</button>
       <button class="btn danger" (click)="clearAll()" [disabled]="!coords().length">{{ 'controls.clear' | t }}</button>
-      <button class="btn" (click)="copyJSON()" [disabled]="!coords().length">{{ 'controls.copyJson' | t }}</button>
-      <button class="btn" (click)="downloadJSON()"
-        [disabled]="!coords().length">{{ 'controls.downloadJson' | t }}</button>
       <button class="btn" (click)="downloadAnnotatedPDF()"
         [disabled]="!coords().length || !pdfDoc">{{ 'controls.downloadPdf' | t }}</button>
     </div>
@@ -115,6 +112,10 @@
       [placeholder]="'sidebar.jsonPlaceholder' | t"
       spellcheck="false"
     ></textarea>
+    <div class="json-toolbar">
+      <button class="btn" (click)="copyJSON()" [disabled]="!coords().length">{{ 'controls.copyJson' | t }}</button>
+      <button class="btn" (click)="downloadJSON()" [disabled]="!coords().length">{{ 'controls.downloadJson' | t }}</button>
+    </div>
     <small class="sidebar-hint">{{ 'sidebar.jsonHint' | t }}</small>
   </aside>
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -152,6 +152,13 @@ header .logo {
     box-shadow: 0 0 0 2px rgba(94, 234, 212, 0.15);
   }
 
+  .json-toolbar {
+    margin-top: 8px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
   .sidebar-hint {
     display: block;
     margin-top: 8px;


### PR DESCRIPTION
## Summary
- relocate the copy and download JSON controls from the header into the JSON sidebar panel
- add styling for the new JSON toolbar in the sidebar

## Testing
- not run


------
