### PR TITLE
feat: refresh toolbar ui and pdf upload

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -54,33 +54,7 @@
     <header class="header">
       <div class="header__left">
         <div class="logo">{{ 'app.title' | t }}</div>
-        <div
-          class="file-upload"
-          role="button"
-          tabindex="0"
-          (click)="openPdfFilePicker()"
-          (keydown)="onFileUploadKeydown($event)"
-          (dragover)="onFileDragOver($event)"
-          (dragleave)="onFileDragLeave($event)"
-          (drop)="onFileDrop($event)"
-          [class.file-upload--active]="fileDropActive()"
-          [attr.aria-label]="'app.upload.title' | t"
-        >
-        <input
-          #pdfFileInput
-          type="file"
-          accept="application/pdf"
-          (change)="onFileSelected($event)"
-          hidden
-        />
-        <div class="file-upload__icon" aria-hidden="true">📄</div>
-        <div class="file-upload__content">
-          <span class="file-upload__title">{{ 'app.upload.title' | t }}</span>
-          <span class="file-upload__subtitle">{{ 'app.upload.subtitle' | t }}</span>
-        </div>
-        <span class="file-upload__hint">{{ 'app.upload.hint' | t }}</span>
       </div>
-    </div>
 
     <div class="toolbar" role="toolbar" [attr.aria-label]="'controls.toolbarAriaLabel' | t">
       <input
@@ -152,6 +126,38 @@
 
   <!-- LATERAL SIDEBAR -->
   <aside class="sidebar">
+    <section
+      class="sidebar-upload"
+      role="button"
+      tabindex="0"
+      (click)="openPdfFilePicker()"
+      (keydown)="onFileUploadKeydown($event)"
+      (dragover)="onFileDragOver($event)"
+      (dragleave)="onFileDragLeave($event)"
+      (drop)="onFileDrop($event)"
+      [class.sidebar-upload--active]="fileDropActive()"
+      [attr.aria-label]="'app.workspaceUpload.ariaLabel' | t"
+    >
+      <input
+        #pdfFileInput
+        type="file"
+        accept="application/pdf"
+        (change)="onFileSelected($event)"
+        hidden
+      />
+      <div class="sidebar-upload__header">
+        <span class="sidebar-upload__badge">{{ 'app.workspaceUpload.badge' | t }}</span>
+        <span class="sidebar-upload__cta">{{ 'app.workspaceUpload.cta' | t }}</span>
+      </div>
+      <div class="sidebar-upload__body">
+        <div class="sidebar-upload__icon" aria-hidden="true">🗂️</div>
+        <div class="sidebar-upload__copy">
+          <span class="sidebar-upload__title">{{ 'app.workspaceUpload.title' | t }}</span>
+          <span class="sidebar-upload__subtitle">{{ 'app.workspaceUpload.subtitle' | t }}</span>
+        </div>
+      </div>
+      <span class="sidebar-upload__hint">{{ 'app.upload.hint' | t }}</span>
+    </section>
     <h4>{{ 'sidebar.title' | t }}</h4>
     <div class="sidebar-actions">
       <button type="button" class="btn" (click)="triggerImportCoords()">

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,10 +1,37 @@
 <div class="app">
   <!-- HEADER -->
   <header class="header">
-    <div class="logo">{{ 'app.title' | t }}</div>
-    <input type="file" accept="application/pdf" (change)="onFileSelected($event)" class="input-file" />
+    <div class="header__left">
+      <div class="logo">{{ 'app.title' | t }}</div>
+      <div
+        class="file-upload"
+        role="button"
+        tabindex="0"
+        (click)="openPdfFilePicker()"
+        (keydown)="onFileUploadKeydown($event)"
+        (dragover)="onFileDragOver($event)"
+        (dragleave)="onFileDragLeave($event)"
+        (drop)="onFileDrop($event)"
+        [class.file-upload--active]="fileDropActive()"
+        [attr.aria-label]="'app.upload.title' | t"
+      >
+        <input
+          #pdfFileInput
+          type="file"
+          accept="application/pdf"
+          (change)="onFileSelected($event)"
+          hidden
+        />
+        <div class="file-upload__icon" aria-hidden="true">📄</div>
+        <div class="file-upload__content">
+          <span class="file-upload__title">{{ 'app.upload.title' | t }}</span>
+          <span class="file-upload__subtitle">{{ 'app.upload.subtitle' | t }}</span>
+        </div>
+        <span class="file-upload__hint">{{ 'app.upload.hint' | t }}</span>
+      </div>
+    </div>
 
-    <div class="controls">
+    <div class="toolbar" role="toolbar" [attr.aria-label]="'controls.toolbarAriaLabel' | t">
       <input
         #coordsFileInput
         type="file"
@@ -12,31 +39,63 @@
         (change)="onCoordsFileSelected($event)"
         hidden
       />
-      <button class="btn" (click)="prevPage()" [disabled]="!pdfDoc || pageIndex()===1">◀
-        {{ 'controls.prev' | t }}</button>
-      <span
-        class="page-indicator">{{ 'controls.pageIndicator' | t : { current: pageIndex(), total: pageCount || 0 } }}</span>
-      <button class="btn" (click)="nextPage()" [disabled]="!pdfDoc || pageIndex()===pageCount">{{ 'controls.next' | t }}
-        ▶</button>
 
-      <button class="btn" (click)="zoomOut()" [disabled]="!pdfDoc">−</button>
-      <span class="page-indicator">{{ 'controls.zoomLabel' | t }} {{ scale() | number:'1.0-2' }}×</span>
-      <button class="btn" (click)="zoomIn()" [disabled]="!pdfDoc">+</button>
+      <div class="toolbar__group" role="group" [attr.aria-label]="'controls.navigationGroup' | t">
+        <button class="btn btn--icon" (click)="prevPage()" [disabled]="!pdfDoc || pageIndex()===1">
+          <span class="btn__icon" aria-hidden="true">⟨</span>
+          <span class="btn__label">{{ 'controls.prev' | t }}</span>
+        </button>
+        <span class="toolbar__badge">
+          {{ 'controls.pageIndicator' | t : { current: pageIndex(), total: pageCount || 0 } }}
+        </span>
+        <button class="btn btn--icon" (click)="nextPage()" [disabled]="!pdfDoc || pageIndex()===pageCount">
+          <span class="btn__label">{{ 'controls.next' | t }}</span>
+          <span class="btn__icon" aria-hidden="true">⟩</span>
+        </button>
+      </div>
 
-      <button class="btn" (click)="undo()" [disabled]="!canUndo()">{{ 'controls.undo' | t }}</button>
-      <button class="btn" (click)="redo()" [disabled]="!canRedo()">{{ 'controls.redo' | t }}</button>
-      <button class="btn danger" (click)="clearAll()" [disabled]="!coords().length">{{ 'controls.clear' | t }}</button>
-      <button class="btn" (click)="downloadAnnotatedPDF()"
-        [disabled]="!coords().length || !pdfDoc">{{ 'controls.downloadPdf' | t }}</button>
+      <div class="toolbar__group" role="group" [attr.aria-label]="'controls.zoomGroup' | t">
+        <button class="btn btn--icon" (click)="zoomOut()" [disabled]="!pdfDoc">
+          <span class="btn__icon" aria-hidden="true">−</span>
+          <span class="btn__label">{{ 'controls.zoomOut' | t }}</span>
+        </button>
+        <span class="toolbar__badge">{{ 'controls.zoomLabel' | t }} {{ scale() | number:'1.0-2' }}×</span>
+        <button class="btn btn--icon" (click)="zoomIn()" [disabled]="!pdfDoc">
+          <span class="btn__label">{{ 'controls.zoomIn' | t }}</span>
+          <span class="btn__icon" aria-hidden="true">＋</span>
+        </button>
+      </div>
+
+      <div class="toolbar__group" role="group" [attr.aria-label]="'controls.historyGroup' | t">
+        <button class="btn btn--icon" (click)="undo()" [disabled]="!canUndo()">
+          <span class="btn__icon" aria-hidden="true">↺</span>
+          <span class="btn__label">{{ 'controls.undo' | t }}</span>
+        </button>
+        <button class="btn btn--icon" (click)="redo()" [disabled]="!canRedo()">
+          <span class="btn__icon" aria-hidden="true">↻</span>
+          <span class="btn__label">{{ 'controls.redo' | t }}</span>
+        </button>
+        <button class="btn btn--icon btn--danger" (click)="clearAll()" [disabled]="!coords().length">
+          <span class="btn__icon" aria-hidden="true">🧹</span>
+          <span class="btn__label">{{ 'controls.clear' | t }}</span>
+        </button>
+      </div>
+
+      <div class="toolbar__group" role="group" [attr.aria-label]="'controls.exportGroup' | t">
+        <button class="btn btn--icon" (click)="downloadAnnotatedPDF()"
+          [disabled]="!coords().length || !pdfDoc">
+          <span class="btn__icon" aria-hidden="true">⬇</span>
+          <span class="btn__label">{{ 'controls.downloadPdf' | t }}</span>
+        </button>
+      </div>
     </div>
 
     <div class="language-selector">
-      <label for="language-select">{{ 'app.languageLabel' | t }}</label>
+      <label class="language-selector__label" for="language-select">{{ 'app.languageLabel' | t }}</label>
       <select id="language-select" [(ngModel)]="languageModel" (ngModelChange)="onLanguageChange($event)"
         [attr.aria-label]="'app.languageAriaLabel' | t">
         <option *ngFor="let lang of languages" [value]="lang">{{ ('app.languages.' + lang) | t }}</option>
       </select>
-
     </div>
   </header>
 

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,10 +1,13 @@
-<div class="app">
-  <!-- HEADER -->
-  <header class="header">
-    <div class="header__left">
-      <div class="logo">{{ 'app.title' | t }}</div>
+<div class="app" [class.app--landing]="!pdfDoc">
+  <ng-container *ngIf="!pdfDoc; else workspace">
+    <section class="landing">
+      <div class="landing__hero">
+        <span class="landing__badge">{{ 'app.landing.badge' | t }}</span>
+        <h1 class="landing__title">{{ 'app.landing.title' | t }}</h1>
+        <p class="landing__description">{{ 'app.landing.description' | t }}</p>
+      </div>
       <div
-        class="file-upload"
+        class="landing__dropzone"
         role="button"
         tabindex="0"
         (click)="openPdfFilePicker()"
@@ -12,9 +15,57 @@
         (dragover)="onFileDragOver($event)"
         (dragleave)="onFileDragLeave($event)"
         (drop)="onFileDrop($event)"
-        [class.file-upload--active]="fileDropActive()"
+        [class.landing__dropzone--active]="fileDropActive()"
         [attr.aria-label]="'app.upload.title' | t"
       >
+        <input
+          #pdfFileInput
+          type="file"
+          accept="application/pdf"
+          (change)="onFileSelected($event)"
+          hidden
+        />
+        <div class="landing__icon" aria-hidden="true">📄</div>
+        <div class="landing__text">
+          <span class="landing__headline">{{ 'app.upload.title' | t }}</span>
+          <span class="landing__subheadline">{{ 'app.upload.subtitle' | t }}</span>
+        </div>
+        <button type="button" class="landing__cta">{{ 'app.landing.cta' | t }}</button>
+        <span class="landing__hint">{{ 'app.upload.hint' | t }}</span>
+      </div>
+    </section>
+    <footer class="footer landing__footer">
+      <div class="footer__brand">
+        <img class="footer__logo" src="/logo.svg" [attr.alt]="'Logotipo de ' + appName" />
+        <div class="footer__brand-text">
+          <span class="footer__app-name">{{ appName }}</span>
+          <span class="footer__version">v{{ version }}</span>
+        </div>
+      </div>
+      <div class="footer__details">
+        <span>© {{ currentYear }} {{ appName }}</span>
+        <span>Desarrollado por {{ appAuthor }}</span>
+      </div>
+    </footer>
+  </ng-container>
+
+  <ng-template #workspace>
+    <!-- HEADER -->
+    <header class="header">
+      <div class="header__left">
+        <div class="logo">{{ 'app.title' | t }}</div>
+        <div
+          class="file-upload"
+          role="button"
+          tabindex="0"
+          (click)="openPdfFilePicker()"
+          (keydown)="onFileUploadKeydown($event)"
+          (dragover)="onFileDragOver($event)"
+          (dragleave)="onFileDragLeave($event)"
+          (drop)="onFileDrop($event)"
+          [class.file-upload--active]="fileDropActive()"
+          [attr.aria-label]="'app.upload.title' | t"
+        >
         <input
           #pdfFileInput
           type="file"
@@ -303,10 +354,6 @@
     </div>
   </main>
 
-  <main class="viewer empty" *ngIf="!pdfDoc">
-    <p class="empty-text">{{ 'viewer.emptyMessage' | t }}</p>
-  </main>
-
   <footer class="footer">
     <div class="footer__brand">
       <img class="footer__logo" src="/logo.svg" [attr.alt]="'Logotipo de ' + appName" />
@@ -320,4 +367,5 @@
       <span>Desarrollado por {{ appAuthor }}</span>
     </div>
   </footer>
+  </ng-template>
 </div>

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -89,6 +89,7 @@ export class App implements AfterViewChecked, OnDestroy {
   editHexInput = signal('#000000');
   editRgbInput = signal('rgb(0, 0, 0)');
   coordsTextModel = JSON.stringify({ pages: [] }, null, 2);
+  fileDropActive = signal(false);
   private readonly translationService = inject(TranslationService);
   private readonly title = inject(Title);
   private readonly meta = inject(Meta);
@@ -129,6 +130,7 @@ export class App implements AfterViewChecked, OnDestroy {
   @ViewChild('pdfViewer', { static: false }) pdfViewerRef?: ElementRef<HTMLDivElement>;
   @ViewChild('previewEditor') previewEditorRef?: ElementRef<HTMLDivElement>;
   @ViewChild('editEditor') editEditorRef?: ElementRef<HTMLDivElement>;
+  @ViewChild('pdfFileInput', { static: false }) pdfFileInputRef?: ElementRef<HTMLInputElement>;
   @ViewChild('coordsFileInput', { static: false }) coordsFileInputRef?: ElementRef<HTMLInputElement>;
 
   constructor() {
@@ -307,7 +309,70 @@ export class App implements AfterViewChecked, OnDestroy {
   async onFileSelected(event: Event) {
     const input = event.target as HTMLInputElement;
     const file = input.files?.[0];
-    if (!file) return;
+    if (!file) {
+      return;
+    }
+
+    try {
+      await this.loadPdfFile(file);
+    } finally {
+      input.value = '';
+    }
+  }
+
+  openPdfFilePicker() {
+    this.fileDropActive.set(false);
+    const input = this.pdfFileInputRef?.nativeElement;
+    if (!input) {
+      return;
+    }
+
+    input.value = '';
+    input.click();
+  }
+
+  onFileUploadKeydown(event: KeyboardEvent) {
+    if (event.key !== 'Enter' && event.key !== ' ' && event.key !== 'Space') {
+      return;
+    }
+    event.preventDefault();
+    this.openPdfFilePicker();
+  }
+
+  onFileDragOver(event: DragEvent) {
+    event.preventDefault();
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = 'copy';
+    }
+    this.fileDropActive.set(true);
+  }
+
+  onFileDragLeave(event: DragEvent) {
+    if (event.currentTarget instanceof HTMLElement && event.relatedTarget instanceof Node) {
+      if (event.currentTarget.contains(event.relatedTarget)) {
+        return;
+      }
+    }
+    this.fileDropActive.set(false);
+  }
+
+  async onFileDrop(event: DragEvent) {
+    event.preventDefault();
+    this.fileDropActive.set(false);
+
+    const file = event.dataTransfer?.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    await this.loadPdfFile(file);
+  }
+
+  private async loadPdfFile(file: File) {
+    if (!this.isPdfFile(file)) {
+      alert(this.translationService.translate('app.upload.invalidFormat'));
+      return;
+    }
 
     this.pdfByteSources.clear();
     const buf = await file.arrayBuffer();
@@ -340,6 +405,14 @@ export class App implements AfterViewChecked, OnDestroy {
     this.resetHistory();
     this.clearAll({ skipHistory: true });
     await this.render();
+  }
+
+  private isPdfFile(file: File) {
+    if (!file.type) {
+      return file.name.toLowerCase().endsWith('.pdf');
+    }
+
+    return file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf');
   }
 
   async render() {

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -405,6 +405,7 @@ export class App implements AfterViewChecked, OnDestroy {
     this.resetHistory();
     this.clearAll({ skipHistory: true });
     await this.render();
+    this.fileDropActive.set(false);
   }
 
   private isPdfFile(file: File) {

--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -8,6 +8,12 @@
       "en": "Anglès",
       "ca": "Català"
     },
+    "landing": {
+      "badge": "Comença a anotar",
+      "title": "Organitza qualsevol PDF en segons",
+      "description": "Puja el document per afegir anotacions vinculades a JSON, reutilitzar plantilles i exportar fitxers a punt per treballar.",
+      "cta": "Selecciona PDF"
+    },
     "upload": {
       "title": "Carrega el teu PDF",
       "subtitle": "Arrossega i deixa anar el fitxer aquí o fes clic per cercar",

--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -19,6 +19,13 @@
       "subtitle": "Arrossega i deixa anar el fitxer aquí o fes clic per cercar",
       "hint": "Només PDF",
       "invalidFormat": "Només s'admeten fitxers PDF."
+    },
+    "workspaceUpload": {
+      "badge": "Nou inici",
+      "title": "Vols començar de zero?",
+      "subtitle": "Arrossega un altre PDF o fes clic per substituir el document actual.",
+      "cta": "Puja un altre PDF",
+      "ariaLabel": "Puja un nou PDF per reiniciar l'espai de treball"
     }
   },
   "controls": {

--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -7,6 +7,12 @@
       "es-ES": "Espanyol",
       "en": "Anglès",
       "ca": "Català"
+    },
+    "upload": {
+      "title": "Carrega el teu PDF",
+      "subtitle": "Arrossega i deixa anar el fitxer aquí o fes clic per cercar",
+      "hint": "Només PDF",
+      "invalidFormat": "Només s'admeten fitxers PDF."
     }
   },
   "controls": {
@@ -14,13 +20,20 @@
     "next": "Següent",
     "pageIndicator": "Pàgina {{current}} / {{total}}",
     "zoomLabel": "Zoom",
+    "zoomIn": "Apropa",
+    "zoomOut": "Allunya",
     "undo": "Desfer",
     "redo": "Refer",
     "clear": "Esborrar",
     "copyJson": "Copiar JSON",
     "importJson": "Importar JSON",
     "downloadJson": "Descarregar JSON",
-    "downloadPdf": "Descarregar PDF"
+    "downloadPdf": "Descarregar PDF",
+    "toolbarAriaLabel": "Accions del PDF",
+    "navigationGroup": "Navegació de pàgines",
+    "zoomGroup": "Controls de zoom",
+    "historyGroup": "Accions d'historial",
+    "exportGroup": "Opcions d'exportació"
   },
   "sidebar": {
     "title": "Anotacions (JSON)",

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -8,6 +8,12 @@
       "en": "English",
       "ca": "Catalan"
     },
+    "landing": {
+      "badge": "Annotate smarter",
+      "title": "Bring structure to any PDF in seconds",
+      "description": "Upload your document to add JSON-backed annotations, reuse templates and export your work-ready files.",
+      "cta": "Select PDF"
+    },
     "upload": {
       "title": "Upload your PDF",
       "subtitle": "Drag & drop the file here or click to browse",

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -7,6 +7,12 @@
       "es-ES": "Spanish",
       "en": "English",
       "ca": "Catalan"
+    },
+    "upload": {
+      "title": "Upload your PDF",
+      "subtitle": "Drag & drop the file here or click to browse",
+      "hint": "PDF only",
+      "invalidFormat": "Only PDF files are supported."
     }
   },
   "controls": {
@@ -14,13 +20,20 @@
     "next": "Next",
     "pageIndicator": "Page {{current}} / {{total}}",
     "zoomLabel": "Zoom",
+    "zoomIn": "Zoom in",
+    "zoomOut": "Zoom out",
     "undo": "Undo",
     "redo": "Redo",
     "clear": "Clear",
     "copyJson": "Copy JSON",
     "importJson": "Import JSON",
     "downloadJson": "Download JSON",
-    "downloadPdf": "Download PDF"
+    "downloadPdf": "Download PDF",
+    "toolbarAriaLabel": "PDF actions",
+    "navigationGroup": "Page navigation",
+    "zoomGroup": "Zoom controls",
+    "historyGroup": "History actions",
+    "exportGroup": "Export options"
   },
   "sidebar": {
     "title": "Annotations (JSON)",

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -19,6 +19,13 @@
       "subtitle": "Drag & drop the file here or click to browse",
       "hint": "PDF only",
       "invalidFormat": "Only PDF files are supported."
+    },
+    "workspaceUpload": {
+      "badge": "Start over",
+      "title": "Need to reset this project?",
+      "subtitle": "Drop a different PDF or click to replace the current document.",
+      "cta": "Upload another PDF",
+      "ariaLabel": "Upload a new PDF to restart the annotation workspace"
     }
   },
   "controls": {

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -8,6 +8,12 @@
       "en": "Inglés",
       "ca": "Catalán"
     },
+    "landing": {
+      "badge": "Empieza a anotar",
+      "title": "Organiza cualquier PDF en segundos",
+      "description": "Sube tu documento para añadir anotaciones vinculadas a JSON, reutilizar plantillas y exportar archivos listos para trabajar.",
+      "cta": "Seleccionar PDF"
+    },
     "upload": {
       "title": "Carga tu PDF",
       "subtitle": "Arrastra y suelta el archivo aquí o haz clic para buscar",

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -19,6 +19,13 @@
       "subtitle": "Arrastra y suelta el archivo aquí o haz clic para buscar",
       "hint": "Solo PDF",
       "invalidFormat": "Solo se admiten archivos PDF."
+    },
+    "workspaceUpload": {
+      "badge": "Nuevo comienzo",
+      "title": "¿Quieres empezar de cero?",
+      "subtitle": "Arrastra otro PDF o haz clic para sustituir el documento actual.",
+      "cta": "Subir otro PDF",
+      "ariaLabel": "Subir un nuevo PDF para reiniciar el espacio de trabajo"
     }
   },
   "controls": {

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -7,6 +7,12 @@
       "es-ES": "Español",
       "en": "Inglés",
       "ca": "Catalán"
+    },
+    "upload": {
+      "title": "Carga tu PDF",
+      "subtitle": "Arrastra y suelta el archivo aquí o haz clic para buscar",
+      "hint": "Solo PDF",
+      "invalidFormat": "Solo se admiten archivos PDF."
     }
   },
   "controls": {
@@ -14,13 +20,20 @@
     "next": "Siguiente",
     "pageIndicator": "Página {{current}} / {{total}}",
     "zoomLabel": "Zoom",
+    "zoomIn": "Acercar",
+    "zoomOut": "Alejar",
     "undo": "Deshacer",
     "redo": "Rehacer",
     "clear": "Limpiar",
     "copyJson": "Copiar JSON",
     "importJson": "Importar JSON",
     "downloadJson": "Descargar JSON",
-    "downloadPdf": "Descargar PDF"
+    "downloadPdf": "Descargar PDF",
+    "toolbarAriaLabel": "Acciones del PDF",
+    "navigationGroup": "Navegación de páginas",
+    "zoomGroup": "Controles de zoom",
+    "historyGroup": "Acciones de historial",
+    "exportGroup": "Opciones de exportación"
   },
   "sidebar": {
     "title": "Anotaciones (JSON)",

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -33,6 +33,152 @@ body {
   padding: 12px;
 }
 
+.app--landing {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 48px;
+  padding: 72px 16px;
+}
+
+.landing {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 32px;
+  max-width: 720px;
+}
+
+.landing__hero {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.landing__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(94, 234, 212, 0.12);
+  color: var(--accent);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+}
+
+.landing__title {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 3rem);
+}
+
+.landing__description {
+  margin: 0;
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.landing__dropzone {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 18px;
+  width: min(520px, 90vw);
+  padding: 36px;
+  border-radius: 28px;
+  border: 1px dashed rgba(94, 234, 212, 0.3);
+  background: rgba(26, 26, 40, 0.75);
+  box-shadow: 0 24px 48px rgba(5, 5, 17, 0.45);
+  cursor: pointer;
+  transition: border-color 0.2s ease, transform 0.2s ease, background 0.2s ease;
+  outline: none;
+}
+
+.landing__dropzone:hover {
+  transform: translateY(-2px);
+  border-color: rgba(94, 234, 212, 0.6);
+  background: rgba(32, 32, 52, 0.85);
+}
+
+.landing__dropzone:focus-visible {
+  box-shadow: 0 0 0 3px rgba(94, 234, 212, 0.35);
+}
+
+.landing__dropzone--active {
+  border-color: var(--accent);
+  background: rgba(26, 41, 45, 0.85);
+}
+
+.landing__icon {
+  display: grid;
+  place-items: center;
+  width: 84px;
+  height: 84px;
+  border-radius: 24px;
+  background: rgba(94, 234, 212, 0.15);
+  font-size: 2.8rem;
+}
+
+.landing__text {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.landing__headline {
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.landing__subheadline {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.landing__cta {
+  padding: 10px 20px;
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+  background: var(--accent);
+  color: #041818;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.landing__cta:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 22px rgba(94, 234, 212, 0.35);
+}
+
+.landing__hint {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.landing__footer {
+  width: min(720px, 100%);
+  align-self: center;
+}
+
+@media (max-width: 720px) {
+  .landing__dropzone {
+    padding: 28px 20px;
+  }
+
+  .landing__icon {
+    width: 68px;
+    height: 68px;
+    font-size: 2.2rem;
+  }
+}
+
 header.header {
   grid-area: header;
   display: grid;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -35,10 +35,14 @@ body {
 
 header.header {
   grid-area: header;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 12px;
+  display: grid;
+  gap: 16px;
+  padding: 16px;
+  background: linear-gradient(135deg, rgba(36, 36, 58, 0.95), rgba(33, 33, 48, 0.95));
+  border-radius: 20px;
+  border: 1px solid rgba(94, 234, 212, 0.1);
+  box-shadow: 0 18px 34px rgba(5, 5, 17, 0.45);
+  grid-template-columns: minmax(0, 1fr);
 }
 
 header .logo {
@@ -47,71 +51,198 @@ header .logo {
   color: var(--accent);
 }
 
-.language-selector {
-  margin-left: auto;
+.header__left {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  gap: 16px;
+}
+
+.file-upload {
+  display: inline-flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 18px;
+  background: rgba(28, 28, 42, 0.9);
+  border: 1px dashed rgba(94, 234, 212, 0.25);
+  border-radius: 16px;
+  cursor: pointer;
+  transition: border-color 0.2s ease, transform 0.2s ease, background 0.2s ease;
+  min-width: 260px;
+  outline: none;
+}
+
+.file-upload:focus-visible {
+  box-shadow: 0 0 0 3px rgba(94, 234, 212, 0.35);
+}
+
+.file-upload:hover {
+  transform: translateY(-1px);
+  border-color: rgba(94, 234, 212, 0.6);
+  background: rgba(32, 32, 52, 0.95);
+}
+
+.file-upload--active {
+  border-color: var(--accent);
+  background: rgba(26, 41, 45, 0.9);
+}
+
+.file-upload__icon {
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background: rgba(94, 234, 212, 0.15);
+  font-size: 1.6rem;
+}
+
+.file-upload__content {
   display: flex;
   flex-direction: column;
   gap: 4px;
 }
 
-.language-selector label {
-  font-size: 0.75rem;
+.file-upload__title {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.file-upload__subtitle {
+  font-size: 0.8rem;
   color: var(--muted);
 }
 
-.language-selector select {
-  background: var(--panel);
-  color: var(--text);
-  border-radius: 8px;
-  border: 1px solid #444;
-  padding: 6px 10px;
+.file-upload__hint {
+  margin-left: auto;
+  font-size: 0.75rem;
+  color: var(--accent);
+  font-weight: 600;
 }
 
-.input-file {
-  background: var(--panel);
-  color: var(--text);
-  border-radius: 8px;
-  padding: 6px 10px;
-  border: none;
-  cursor: pointer;
-}
-
-.controls {
+.toolbar {
   display: flex;
   flex-wrap: wrap;
-  gap: 6px;
   align-items: center;
+  gap: 12px;
+}
+
+.toolbar__group {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  border: 1px solid rgba(94, 234, 212, 0.12);
+  background: rgba(26, 26, 40, 0.7);
+  backdrop-filter: blur(10px);
+}
+
+.toolbar__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(94, 234, 212, 0.1);
+  color: var(--accent);
+  font-size: 0.85rem;
+  font-weight: 600;
 }
 
 .btn {
-  background: var(--panel);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(94, 234, 212, 0.2);
+  background: rgba(43, 43, 64, 0.9);
   color: var(--text);
-  border: 1px solid #444;
-  border-radius: 8px;
-  padding: 6px 10px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
   cursor: pointer;
-  transition: .2s;
+  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
 }
 
-.btn:hover {
+.btn:hover:not(:disabled) {
+  transform: translateY(-1px);
   border-color: var(--accent);
+  background: rgba(52, 52, 80, 0.95);
 }
 
-.btn.danger {
-  background: var(--danger);
-  color: #fff;
-  border: none;
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
 }
 
-.btn.danger:hover {
-  opacity: 0.8;
+.btn__icon {
+  font-size: 1rem;
 }
 
-.page-indicator {
-  padding: 2px 6px;
-  background: #333;
-  border-radius: 6px;
-  font-size: .9rem;
+.btn__label {
+  font-size: 0.85rem;
+}
+
+.btn--icon {
+  padding-inline: 14px;
+}
+
+.btn--danger {
+  border-color: rgba(255, 77, 77, 0.4);
+  background: rgba(255, 77, 77, 0.15);
+  color: #ffe5e5;
+}
+
+.btn--danger:hover:not(:disabled) {
+  border-color: rgba(255, 77, 77, 0.6);
+  background: rgba(255, 77, 77, 0.25);
+}
+
+.language-selector {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-self: flex-start;
+}
+
+.language-selector__label {
+  font-size: 0.75rem;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.language-selector select {
+  background: rgba(29, 29, 46, 0.9);
+  color: var(--text);
+  border-radius: 12px;
+  border: 1px solid rgba(94, 234, 212, 0.15);
+  padding: 10px 14px;
+  font-weight: 600;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.language-selector select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(94, 234, 212, 0.25);
+}
+
+@media (min-width: 960px) {
+  header.header {
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+  }
+
+  .header__left {
+    flex-wrap: nowrap;
+  }
+
+  .language-selector {
+    align-self: center;
+  }
 }
 
 .sidebar {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -199,71 +199,8 @@ header .logo {
 
 .header__left {
   display: flex;
-  flex-wrap: wrap;
-  align-items: stretch;
-  gap: 16px;
-}
-
-.file-upload {
-  display: inline-flex;
   align-items: center;
-  gap: 14px;
-  padding: 14px 18px;
-  background: rgba(28, 28, 42, 0.9);
-  border: 1px dashed rgba(94, 234, 212, 0.25);
-  border-radius: 16px;
-  cursor: pointer;
-  transition: border-color 0.2s ease, transform 0.2s ease, background 0.2s ease;
-  min-width: 260px;
-  outline: none;
-}
-
-.file-upload:focus-visible {
-  box-shadow: 0 0 0 3px rgba(94, 234, 212, 0.35);
-}
-
-.file-upload:hover {
-  transform: translateY(-1px);
-  border-color: rgba(94, 234, 212, 0.6);
-  background: rgba(32, 32, 52, 0.95);
-}
-
-.file-upload--active {
-  border-color: var(--accent);
-  background: rgba(26, 41, 45, 0.9);
-}
-
-.file-upload__icon {
-  display: grid;
-  place-items: center;
-  width: 44px;
-  height: 44px;
-  border-radius: 12px;
-  background: rgba(94, 234, 212, 0.15);
-  font-size: 1.6rem;
-}
-
-.file-upload__content {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.file-upload__title {
-  font-weight: 600;
-  font-size: 1rem;
-}
-
-.file-upload__subtitle {
-  font-size: 0.8rem;
-  color: var(--muted);
-}
-
-.file-upload__hint {
-  margin-left: auto;
-  font-size: 0.75rem;
-  color: var(--accent);
-  font-weight: 600;
+  justify-content: flex-start;
 }
 
 .toolbar {
@@ -389,6 +326,112 @@ header .logo {
   .language-selector {
     align-self: center;
   }
+}
+
+.sidebar-upload {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 18px;
+  margin-bottom: 16px;
+  border-radius: 16px;
+  border: 1px dashed rgba(94, 234, 212, 0.2);
+  background: rgba(32, 32, 48, 0.85);
+  box-shadow: 0 12px 24px rgba(5, 5, 17, 0.35);
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
+  outline: none;
+}
+
+.sidebar-upload:hover {
+  transform: translateY(-2px);
+  border-color: rgba(94, 234, 212, 0.45);
+  background: rgba(40, 40, 62, 0.9);
+}
+
+.sidebar-upload:focus-visible {
+  box-shadow: 0 0 0 3px rgba(94, 234, 212, 0.35);
+}
+
+.sidebar-upload--active {
+  border-color: var(--accent);
+  background: rgba(26, 41, 45, 0.85);
+}
+
+.sidebar-upload__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.sidebar-upload__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: rgba(94, 234, 212, 0.15);
+  color: var(--accent);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.sidebar-upload__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 14px;
+  border-radius: 999px;
+  font-weight: 600;
+  background: var(--accent);
+  color: #041818;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.sidebar-upload:hover .sidebar-upload__cta {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 20px rgba(94, 234, 212, 0.3);
+}
+
+.sidebar-upload__body {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.sidebar-upload__icon {
+  display: grid;
+  place-items: center;
+  width: 52px;
+  height: 52px;
+  border-radius: 14px;
+  background: rgba(94, 234, 212, 0.18);
+  font-size: 1.8rem;
+}
+
+.sidebar-upload__copy {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sidebar-upload__title {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.sidebar-upload__subtitle {
+  font-size: 0.85rem;
+  color: var(--muted);
+  line-height: 1.4;
+}
+
+.sidebar-upload__hint {
+  font-size: 0.75rem;
+  color: var(--muted);
 }
 
 .sidebar {


### PR DESCRIPTION
## Summary
- redesign the header controls with grouped actions, accent buttons, and improved language selector styling
- add a drag-and-drop PDF upload dropzone with keyboard support and validation messaging
- extend translations for new toolbar labels and upload helper text while refreshing global styles

## Testing
- npm run i18n:check

------
