### PR TITLE
feat: redesign language selector and show on landing

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -2,37 +2,19 @@
   <ng-container *ngIf="!pdfDoc; else workspace">
     <section class="landing">
       <div class="landing__language">
-        <app-language-selector
-          [languages]="languages"
-          [selectedLanguage]="languageModel"
-          (languageChange)="onLanguageChange($event)"
-          variant="compact"
-        ></app-language-selector>
+        <app-language-selector [languages]="languages" [selectedLanguage]="languageModel"
+          (languageChange)="onLanguageChange($event)" variant="compact"></app-language-selector>
       </div>
       <div class="landing__hero">
         <span class="landing__badge">{{ 'app.landing.badge' | t }}</span>
         <h1 class="landing__title">{{ 'app.landing.title' | t }}</h1>
         <p class="landing__description">{{ 'app.landing.description' | t }}</p>
       </div>
-      <div
-        class="landing__dropzone"
-        role="button"
-        tabindex="0"
-        (click)="openPdfFilePicker()"
-        (keydown)="onFileUploadKeydown($event)"
-        (dragover)="onFileDragOver($event)"
-        (dragleave)="onFileDragLeave($event)"
-        (drop)="onFileDrop($event)"
-        [class.landing__dropzone--active]="fileDropActive()"
-        [attr.aria-label]="'app.upload.title' | t"
-      >
-        <input
-          #pdfFileInput
-          type="file"
-          accept="application/pdf"
-          (change)="onFileSelected($event)"
-          hidden
-        />
+      <div class="landing__dropzone" role="button" tabindex="0" (click)="openPdfFilePicker()"
+        (keydown)="onFileUploadKeydown($event)" (dragover)="onFileDragOver($event)"
+        (dragleave)="onFileDragLeave($event)" (drop)="onFileDrop($event)"
+        [class.landing__dropzone--active]="fileDropActive()" [attr.aria-label]="'app.upload.title' | t">
+        <input #pdfFileInput type="file" accept="application/pdf" (change)="onFileSelected($event)" hidden />
         <div class="landing__icon" aria-hidden="true">📄</div>
         <div class="landing__text">
           <span class="landing__headline">{{ 'app.upload.title' | t }}</span>
@@ -60,328 +42,274 @@
   <ng-template #workspace>
     <!-- HEADER -->
     <header class="header">
-      <div class="header__top">
+      <div class="toolbar" role="toolbar" [attr.aria-label]="'controls.toolbarAriaLabel' | t">
         <div class="header__left">
           <div class="logo">{{ 'app.title' | t }}</div>
         </div>
-        <app-language-selector
-          class="header__language-selector"
-          [languages]="languages"
-          [selectedLanguage]="languageModel"
-          (languageChange)="onLanguageChange($event)"
-          variant="compact"
-        ></app-language-selector>
-      </div>
+        <input #coordsFileInput type="file" accept="application/json" (change)="onCoordsFileSelected($event)" hidden />
 
-    <div class="toolbar" role="toolbar" [attr.aria-label]="'controls.toolbarAriaLabel' | t">
-      <input
-        #coordsFileInput
-        type="file"
-        accept="application/json"
-        (change)="onCoordsFileSelected($event)"
-        hidden
-      />
-
-      <div class="toolbar__group" role="group" [attr.aria-label]="'controls.navigationGroup' | t">
-        <button class="btn btn--icon" (click)="prevPage()" [disabled]="!pdfDoc || pageIndex()===1">
-          <span class="btn__icon" aria-hidden="true">⟨</span>
-          <span class="btn__label">{{ 'controls.prev' | t }}</span>
-        </button>
-        <span class="toolbar__badge">
-          {{ 'controls.pageIndicator' | t : { current: pageIndex(), total: pageCount || 0 } }}
-        </span>
-        <button class="btn btn--icon" (click)="nextPage()" [disabled]="!pdfDoc || pageIndex()===pageCount">
-          <span class="btn__label">{{ 'controls.next' | t }}</span>
-          <span class="btn__icon" aria-hidden="true">⟩</span>
-        </button>
-      </div>
-
-      <div class="toolbar__group" role="group" [attr.aria-label]="'controls.zoomGroup' | t">
-        <button class="btn btn--icon" (click)="zoomOut()" [disabled]="!pdfDoc">
-          <span class="btn__icon" aria-hidden="true">−</span>
-          <span class="btn__label">{{ 'controls.zoomOut' | t }}</span>
-        </button>
-        <span class="toolbar__badge">{{ 'controls.zoomLabel' | t }} {{ scale() | number:'1.0-2' }}×</span>
-        <button class="btn btn--icon" (click)="zoomIn()" [disabled]="!pdfDoc">
-          <span class="btn__label">{{ 'controls.zoomIn' | t }}</span>
-          <span class="btn__icon" aria-hidden="true">＋</span>
-        </button>
-      </div>
-
-      <div class="toolbar__group" role="group" [attr.aria-label]="'controls.historyGroup' | t">
-        <button class="btn btn--icon" (click)="undo()" [disabled]="!canUndo()">
-          <span class="btn__icon" aria-hidden="true">↺</span>
-          <span class="btn__label">{{ 'controls.undo' | t }}</span>
-        </button>
-        <button class="btn btn--icon" (click)="redo()" [disabled]="!canRedo()">
-          <span class="btn__icon" aria-hidden="true">↻</span>
-          <span class="btn__label">{{ 'controls.redo' | t }}</span>
-        </button>
-        <button class="btn btn--icon btn--danger" (click)="clearAll()" [disabled]="!coords().length">
-          <span class="btn__icon" aria-hidden="true">🧹</span>
-          <span class="btn__label">{{ 'controls.clear' | t }}</span>
-        </button>
-      </div>
-
-      <div class="toolbar__group" role="group" [attr.aria-label]="'controls.exportGroup' | t">
-        <button class="btn btn--icon" (click)="downloadAnnotatedPDF()"
-          [disabled]="!coords().length || !pdfDoc">
-          <span class="btn__icon" aria-hidden="true">⬇</span>
-          <span class="btn__label">{{ 'controls.downloadPdf' | t }}</span>
-        </button>
-      </div>
-    </div>
-
-  </header>
-
-  <!-- LATERAL SIDEBAR -->
-  <aside class="sidebar">
-    <section
-      class="sidebar-upload"
-      role="button"
-      tabindex="0"
-      (click)="openPdfFilePicker()"
-      (keydown)="onFileUploadKeydown($event)"
-      (dragover)="onFileDragOver($event)"
-      (dragleave)="onFileDragLeave($event)"
-      (drop)="onFileDrop($event)"
-      [class.sidebar-upload--active]="fileDropActive()"
-      [attr.aria-label]="'app.workspaceUpload.ariaLabel' | t"
-    >
-      <input
-        #pdfFileInput
-        type="file"
-        accept="application/pdf"
-        (change)="onFileSelected($event)"
-        hidden
-      />
-      <div class="sidebar-upload__header">
-        <span class="sidebar-upload__badge">{{ 'app.workspaceUpload.badge' | t }}</span>
-        <span class="sidebar-upload__cta">{{ 'app.workspaceUpload.cta' | t }}</span>
-      </div>
-      <div class="sidebar-upload__body">
-        <div class="sidebar-upload__icon" aria-hidden="true">🗂️</div>
-        <div class="sidebar-upload__copy">
-          <span class="sidebar-upload__title">{{ 'app.workspaceUpload.title' | t }}</span>
-          <span class="sidebar-upload__subtitle">{{ 'app.workspaceUpload.subtitle' | t }}</span>
+        <div class="toolbar__group" role="group" [attr.aria-label]="'controls.navigationGroup' | t">
+          <button class="btn btn--icon" (click)="prevPage()" [disabled]="!pdfDoc || pageIndex()===1">
+            <span class="btn__icon" aria-hidden="true">⟨</span>
+            <span class="btn__label">{{ 'controls.prev' | t }}</span>
+          </button>
+          <span class="toolbar__badge">
+            {{ 'controls.pageIndicator' | t : { current: pageIndex(), total: pageCount || 0 } }}
+          </span>
+          <button class="btn btn--icon" (click)="nextPage()" [disabled]="!pdfDoc || pageIndex()===pageCount">
+            <span class="btn__label">{{ 'controls.next' | t }}</span>
+            <span class="btn__icon" aria-hidden="true">⟩</span>
+          </button>
         </div>
+
+        <div class="toolbar__group" role="group" [attr.aria-label]="'controls.zoomGroup' | t">
+          <button class="btn btn--icon" (click)="zoomOut()" [disabled]="!pdfDoc">
+            <span class="btn__icon" aria-hidden="true">−</span>
+            <span class="btn__label">{{ 'controls.zoomOut' | t }}</span>
+          </button>
+          <span class="toolbar__badge">{{ 'controls.zoomLabel' | t }} {{ scale() | number:'1.0-2' }}×</span>
+          <button class="btn btn--icon" (click)="zoomIn()" [disabled]="!pdfDoc">
+            <span class="btn__label">{{ 'controls.zoomIn' | t }}</span>
+            <span class="btn__icon" aria-hidden="true">＋</span>
+          </button>
+        </div>
+
+        <div class="toolbar__group" role="group" [attr.aria-label]="'controls.historyGroup' | t">
+          <button class="btn btn--icon" (click)="undo()" [disabled]="!canUndo()">
+            <span class="btn__icon" aria-hidden="true">↺</span>
+            <span class="btn__label">{{ 'controls.undo' | t }}</span>
+          </button>
+          <button class="btn btn--icon" (click)="redo()" [disabled]="!canRedo()">
+            <span class="btn__icon" aria-hidden="true">↻</span>
+            <span class="btn__label">{{ 'controls.redo' | t }}</span>
+          </button>
+          <button class="btn btn--icon btn--danger" (click)="clearAll()" [disabled]="!coords().length">
+            <span class="btn__icon" aria-hidden="true">🧹</span>
+            <span class="btn__label">{{ 'controls.clear' | t }}</span>
+          </button>
+        </div>
+
+        <div class="toolbar__group" role="group" [attr.aria-label]="'controls.exportGroup' | t">
+          <button class="btn btn--icon" (click)="downloadAnnotatedPDF()" [disabled]="!coords().length || !pdfDoc">
+            <span class="btn__icon" aria-hidden="true">⬇</span>
+            <span class="btn__label">{{ 'controls.downloadPdf' | t }}</span>
+          </button>
+        </div>
+
+        <app-language-selector class="header__language-selector" [languages]="languages"
+          [selectedLanguage]="languageModel" (languageChange)="onLanguageChange($event)" variant="compact">
+        </app-language-selector>
       </div>
-      <span class="sidebar-upload__hint">{{ 'app.upload.hint' | t }}</span>
-    </section>
-    <h4>{{ 'sidebar.title' | t }}</h4>
-    <div class="sidebar-actions">
-      <button type="button" class="btn" (click)="triggerImportCoords()">
-        {{ 'sidebar.importJsonFile' | t }}
-      </button>
-      <button type="button" class="btn" (click)="applyCoordsText()">
-        {{ 'sidebar.applyJson' | t }}
-      </button>
-    </div>
-    <section class="templates">
-      <h5>{{ 'sidebar.templates.title' | t }}</h5>
-      <div class="templates__save">
-        <input
-          type="text"
-          [(ngModel)]="templateNameModel"
-          [ngModelOptions]="{ standalone: true }"
-          [placeholder]="'sidebar.templates.placeholder' | t"
-        />
-        <button
-          type="button"
-          class="btn"
-          (click)="saveCurrentAsTemplate()"
-          [disabled]="!coords().length || !templateNameModel.trim()"
-        >
-          {{ 'sidebar.templates.saveButton' | t }}
+
+    </header>
+
+    <!-- LATERAL SIDEBAR -->
+    <aside class="sidebar">
+      <section class="sidebar-upload" role="button" tabindex="0" (click)="openPdfFilePicker()"
+        (keydown)="onFileUploadKeydown($event)" (dragover)="onFileDragOver($event)"
+        (dragleave)="onFileDragLeave($event)" (drop)="onFileDrop($event)"
+        [class.sidebar-upload--active]="fileDropActive()" [attr.aria-label]="'app.workspaceUpload.ariaLabel' | t">
+        <input #pdfFileInput type="file" accept="application/pdf" (change)="onFileSelected($event)" hidden />
+        <div class="sidebar-upload__header">
+          <span class="sidebar-upload__badge">{{ 'app.workspaceUpload.badge' | t }}</span>
+          <span class="sidebar-upload__cta">{{ 'app.workspaceUpload.cta' | t }}</span>
+        </div>
+        <div class="sidebar-upload__body">
+          <div class="sidebar-upload__icon" aria-hidden="true">🗂️</div>
+          <div class="sidebar-upload__copy">
+            <span class="sidebar-upload__title">{{ 'app.workspaceUpload.title' | t }}</span>
+            <span class="sidebar-upload__subtitle">{{ 'app.workspaceUpload.subtitle' | t }}</span>
+          </div>
+        </div>
+        <span class="sidebar-upload__hint">{{ 'app.upload.hint' | t }}</span>
+      </section>
+      <h4>{{ 'sidebar.title' | t }}</h4>
+      <div class="sidebar-actions">
+        <button type="button" class="btn" (click)="triggerImportCoords()">
+          {{ 'sidebar.importJsonFile' | t }}
+        </button>
+        <button type="button" class="btn" (click)="applyCoordsText()">
+          {{ 'sidebar.applyJson' | t }}
         </button>
       </div>
-      <ng-container *ngIf="templates().length; else emptyTemplates">
-        <div class="templates__select">
-          <label>{{ 'sidebar.templates.selectLabel' | t }}</label>
-          <div class="templates__controls">
-            <select
-              [(ngModel)]="selectedTemplateId"
-              [ngModelOptions]="{ standalone: true }"
-            >
-              <option *ngFor="let template of templates()" [value]="template.id">
-                {{ template.name }}
-              </option>
-            </select>
-            <button
-              type="button"
-              class="btn"
-              (click)="loadSelectedTemplate()"
-              [disabled]="!selectedTemplateId"
-            >
-              {{ 'sidebar.templates.loadButton' | t }}
-            </button>
-            <button
-              type="button"
-              class="btn templates__delete"
-              (click)="deleteSelectedTemplate()"
-              [disabled]="
+      <section class="templates">
+        <h5>{{ 'sidebar.templates.title' | t }}</h5>
+        <div class="templates__save">
+          <input type="text" [(ngModel)]="templateNameModel" [ngModelOptions]="{ standalone: true }"
+            [placeholder]="'sidebar.templates.placeholder' | t" />
+          <button type="button" class="btn" (click)="saveCurrentAsTemplate()"
+            [disabled]="!coords().length || !templateNameModel.trim()">
+            {{ 'sidebar.templates.saveButton' | t }}
+          </button>
+        </div>
+        <ng-container *ngIf="templates().length; else emptyTemplates">
+          <div class="templates__select">
+            <label>{{ 'sidebar.templates.selectLabel' | t }}</label>
+            <div class="templates__controls">
+              <select [(ngModel)]="selectedTemplateId" [ngModelOptions]="{ standalone: true }">
+                <option *ngFor="let template of templates()" [value]="template.id">
+                  {{ template.name }}
+                </option>
+              </select>
+              <button type="button" class="btn" (click)="loadSelectedTemplate()" [disabled]="!selectedTemplateId">
+                {{ 'sidebar.templates.loadButton' | t }}
+              </button>
+              <button type="button" class="btn templates__delete" (click)="deleteSelectedTemplate()" [disabled]="
                 !selectedTemplateId || selectedTemplateId === defaultTemplateId
-              "
-            >
-              {{ 'sidebar.templates.deleteButton' | t }}
-            </button>
-          </div>
-        </div>
-      </ng-container>
-      <ng-template #emptyTemplates>
-        <p class="templates__empty">{{ 'sidebar.templates.empty' | t }}</p>
-      </ng-template>
-    </section>
-    <textarea
-      class="json-editor"
-      [(ngModel)]="coordsTextModel"
-      [placeholder]="'sidebar.jsonPlaceholder' | t"
-      spellcheck="false"
-    ></textarea>
-    <div class="json-toolbar">
-      <button class="btn" (click)="copyJSON()" [disabled]="!coords().length">{{ 'controls.copyJson' | t }}</button>
-      <button class="btn" (click)="downloadJSON()" [disabled]="!coords().length">{{ 'controls.downloadJson' | t }}</button>
-    </div>
-    <small class="sidebar-hint">{{ 'sidebar.jsonHint' | t }}</small>
-  </aside>
-
-  <!-- VISOR PDF -->
-  <main class="viewer" *ngIf="pdfDoc as _">
-    <div class="canvas-container" #pdfViewer>
-      <canvas #pdfCanvas></canvas>
-      <canvas #overlayCanvas></canvas>
-      <div #annotationsLayer class="annotations-layer"></div>
-      <div class="hitbox" (click)="onHitboxClick($event)"></div>
-
-      <!-- NUEVA ANOTACIÓN -->
-      <div *ngIf="preview() as p" class="annotation-editor" #previewEditor [style.left.px]="p.field.x*scale()"
-        [style.top.px]="pdfCanvasRef!.nativeElement.height - p.field.y*scale()"
-        (keydown)="onEditorKeydown($event, 'preview')">
-        <label class="field">
-          <span class="field-label">{{ 'annotation.fields.text.label' | t }}</span>
-          <input type="text" [(ngModel)]="p.field.mapField"
-            [placeholder]="'annotation.fields.text.placeholder' | t" />
-        </label>
-        <label class="field">
-          <span class="field-label">{{ 'annotation.fields.type.label' | t }}</span>
-          <select [(ngModel)]="p.field.type">
-            <option value="text">{{ 'annotation.fields.type.options.text' | t }}</option>
-            <option value="check">{{ 'annotation.fields.type.options.check' | t }}</option>
-            <option value="radio">{{ 'annotation.fields.type.options.radio' | t }}</option>
-            <option value="number">{{ 'annotation.fields.type.options.number' | t }}</option>
-          </select>
-        </label>
-        <label class="field">
-          <span class="field-label">{{ 'annotation.fields.value.label' | t }}</span>
-          <input type="text" [(ngModel)]="p.field.value"
-            [placeholder]="'annotation.fields.value.placeholder' | t" />
-        </label>
-        <label class="field field-small" *ngIf="p.field.type === 'number'">
-          <span class="field-label">{{ 'annotation.fields.number.decimals.label' | t }}</span>
-          <input type="number" [(ngModel)]="p.field.decimals" min="0" />
-        </label>
-        <label class="field field-small" *ngIf="p.field.type === 'number'">
-          <span class="field-label">{{ 'annotation.fields.number.appender.label' | t }}</span>
-          <input type="text" [(ngModel)]="p.field.appender"
-            [placeholder]="'annotation.fields.number.appender.placeholder' | t" />
-        </label>
-        <label class="field field-small">
-          <span class="field-label">{{ 'annotation.fields.size.label' | t }}</span>
-          <input type="number" [(ngModel)]="p.field.fontSize" min="8" max="72" />
-        </label>
-        <div class="color-section">
-          <span class="field-label">{{ 'annotation.fields.color.label' | t }}</span>
-          <div class="color-row">
-            <input type="color" [(ngModel)]="p.field.color" (ngModelChange)="onPreviewColorPicker($event)" />
-            <div class="color-inputs">
-              <input type="text" [ngModel]="previewHexInput()" (ngModelChange)="setPreviewColorFromHex($event)"
-                [ngModelOptions]="{ standalone: true }" [placeholder]="'annotation.color.hexPlaceholder' | t" />
-              <input type="text" [ngModel]="previewRgbInput()" (ngModelChange)="setPreviewColorFromRgb($event)"
-                [ngModelOptions]="{ standalone: true }" [placeholder]="'annotation.color.rgbPlaceholder' | t" />
+              ">
+                {{ 'sidebar.templates.deleteButton' | t }}
+              </button>
             </div>
           </div>
-          <small class="color-hint">{{ 'annotation.color.hintPreview' | t }}</small>
-        </div>
-        <div class="editor-actions">
-          <button class="action-primary" (click)="confirmPreview()">✅</button>
-          <button (click)="cancelPreview()">❌</button>
-        </div>
+        </ng-container>
+        <ng-template #emptyTemplates>
+          <p class="templates__empty">{{ 'sidebar.templates.empty' | t }}</p>
+        </ng-template>
+      </section>
+      <textarea class="json-editor" [(ngModel)]="coordsTextModel" [placeholder]="'sidebar.jsonPlaceholder' | t"
+        spellcheck="false"></textarea>
+      <div class="json-toolbar">
+        <button class="btn" (click)="copyJSON()" [disabled]="!coords().length">{{ 'controls.copyJson' | t }}</button>
+        <button class="btn" (click)="downloadJSON()"
+          [disabled]="!coords().length">{{ 'controls.downloadJson' | t }}</button>
       </div>
+      <small class="sidebar-hint">{{ 'sidebar.jsonHint' | t }}</small>
+    </aside>
 
-      <!-- EDITAR ANOTACIÓN -->
-      <div *ngIf="editing() as e" class="annotation-editor editing" #editEditor [style.left.px]="e.field.x*scale()"
-        [style.top.px]="pdfCanvasRef!.nativeElement.height - e.field.y*scale()"
-        (keydown)="onEditorKeydown($event, 'edit')">
-        <span class="editor-badge">{{ 'annotation.editingBadge' | t }}</span>
-        <label class="field">
-          <span class="field-label">{{ 'annotation.fields.text.label' | t }}</span>
-          <input type="text" [(ngModel)]="e.field.mapField"
-            [placeholder]="'annotation.fields.text.placeholder' | t" />
-        </label>
-        <label class="field">
-          <span class="field-label">{{ 'annotation.fields.type.label' | t }}</span>
-          <select [(ngModel)]="e.field.type">
-            <option value="text">{{ 'annotation.fields.type.options.text' | t }}</option>
-            <option value="check">{{ 'annotation.fields.type.options.check' | t }}</option>
-            <option value="radio">{{ 'annotation.fields.type.options.radio' | t }}</option>
-            <option value="number">{{ 'annotation.fields.type.options.number' | t }}</option>
-          </select>
-        </label>
-        <label class="field">
-          <span class="field-label">{{ 'annotation.fields.value.label' | t }}</span>
-          <input type="text" [(ngModel)]="e.field.value"
-            [placeholder]="'annotation.fields.value.placeholder' | t" />
-        </label>
-        <label class="field field-small" *ngIf="e.field.type === 'number'">
-          <span class="field-label">{{ 'annotation.fields.number.decimals.label' | t }}</span>
-          <input type="number" [(ngModel)]="e.field.decimals" min="0" />
-        </label>
-        <label class="field field-small" *ngIf="e.field.type === 'number'">
-          <span class="field-label">{{ 'annotation.fields.number.appender.label' | t }}</span>
-          <input type="text" [(ngModel)]="e.field.appender"
-            [placeholder]="'annotation.fields.number.appender.placeholder' | t" />
-        </label>
-        <label class="field field-small">
-          <span class="field-label">{{ 'annotation.fields.size.label' | t }}</span>
-          <input type="number" [(ngModel)]="e.field.fontSize" min="8" max="72" />
-        </label>
-        <div class="color-section">
-          <span class="field-label">{{ 'annotation.fields.color.label' | t }}</span>
-          <div class="color-row">
-            <input type="color" [(ngModel)]="e.field.color" (ngModelChange)="onEditColorPicker($event)" />
-            <div class="color-inputs">
-              <input type="text" [ngModel]="editHexInput()" (ngModelChange)="setEditColorFromHex($event)"
-                [ngModelOptions]="{ standalone: true }" [placeholder]="'annotation.color.hexPlaceholder' | t" />
-              <input type="text" [ngModel]="editRgbInput()" (ngModelChange)="setEditColorFromRgb($event)"
-                [ngModelOptions]="{ standalone: true }" [placeholder]="'annotation.color.rgbPlaceholder' | t" />
+    <!-- VISOR PDF -->
+    <main class="viewer" *ngIf="pdfDoc as _">
+      <div class="canvas-container" #pdfViewer>
+        <canvas #pdfCanvas></canvas>
+        <canvas #overlayCanvas></canvas>
+        <div #annotationsLayer class="annotations-layer"></div>
+        <div class="hitbox" (click)="onHitboxClick($event)"></div>
+
+        <!-- NUEVA ANOTACIÓN -->
+        <div *ngIf="preview() as p" class="annotation-editor" #previewEditor [style.left.px]="p.field.x*scale()"
+          [style.top.px]="pdfCanvasRef!.nativeElement.height - p.field.y*scale()"
+          (keydown)="onEditorKeydown($event, 'preview')">
+          <label class="field">
+            <span class="field-label">{{ 'annotation.fields.text.label' | t }}</span>
+            <input type="text" [(ngModel)]="p.field.mapField"
+              [placeholder]="'annotation.fields.text.placeholder' | t" />
+          </label>
+          <label class="field">
+            <span class="field-label">{{ 'annotation.fields.type.label' | t }}</span>
+            <select [(ngModel)]="p.field.type">
+              <option value="text">{{ 'annotation.fields.type.options.text' | t }}</option>
+              <option value="check">{{ 'annotation.fields.type.options.check' | t }}</option>
+              <option value="radio">{{ 'annotation.fields.type.options.radio' | t }}</option>
+              <option value="number">{{ 'annotation.fields.type.options.number' | t }}</option>
+            </select>
+          </label>
+          <label class="field">
+            <span class="field-label">{{ 'annotation.fields.value.label' | t }}</span>
+            <input type="text" [(ngModel)]="p.field.value" [placeholder]="'annotation.fields.value.placeholder' | t" />
+          </label>
+          <label class="field field-small" *ngIf="p.field.type === 'number'">
+            <span class="field-label">{{ 'annotation.fields.number.decimals.label' | t }}</span>
+            <input type="number" [(ngModel)]="p.field.decimals" min="0" />
+          </label>
+          <label class="field field-small" *ngIf="p.field.type === 'number'">
+            <span class="field-label">{{ 'annotation.fields.number.appender.label' | t }}</span>
+            <input type="text" [(ngModel)]="p.field.appender"
+              [placeholder]="'annotation.fields.number.appender.placeholder' | t" />
+          </label>
+          <label class="field field-small">
+            <span class="field-label">{{ 'annotation.fields.size.label' | t }}</span>
+            <input type="number" [(ngModel)]="p.field.fontSize" min="8" max="72" />
+          </label>
+          <div class="color-section">
+            <span class="field-label">{{ 'annotation.fields.color.label' | t }}</span>
+            <div class="color-row">
+              <input type="color" [(ngModel)]="p.field.color" (ngModelChange)="onPreviewColorPicker($event)" />
+              <div class="color-inputs">
+                <input type="text" [ngModel]="previewHexInput()" (ngModelChange)="setPreviewColorFromHex($event)"
+                  [ngModelOptions]="{ standalone: true }" [placeholder]="'annotation.color.hexPlaceholder' | t" />
+                <input type="text" [ngModel]="previewRgbInput()" (ngModelChange)="setPreviewColorFromRgb($event)"
+                  [ngModelOptions]="{ standalone: true }" [placeholder]="'annotation.color.rgbPlaceholder' | t" />
+              </div>
             </div>
+            <small class="color-hint">{{ 'annotation.color.hintPreview' | t }}</small>
           </div>
-          <small class="color-hint">{{ 'annotation.color.hintEdit' | t }}</small>
+          <div class="editor-actions">
+            <button class="action-primary" (click)="confirmPreview()">✅</button>
+            <button (click)="cancelPreview()">❌</button>
+          </div>
         </div>
-        <div class="editor-actions">
-          <button type="button" (click)="duplicateAnnotation()"
-            [title]="'annotation.actions.duplicate' | t"
-            [attr.aria-label]="'annotation.actions.duplicate' | t">⧉</button>
-          <button class="btn-delete" (click)="deleteAnnotation()">🗑️</button>
-          <button class="action-primary" (click)="confirmEdit()">✅</button>
-          <button (click)="cancelEdit()">❌</button>
-        </div>
-      </div>
-    </div>
-  </main>
 
-  <footer class="footer">
-    <div class="footer__brand">
-      <img class="footer__logo" src="/logo.svg" [attr.alt]="'Logotipo de ' + appName" />
-      <div class="footer__brand-text">
-        <span class="footer__app-name">{{ appName }}</span>
-        <span class="footer__version">v{{ version }}</span>
+        <!-- EDITAR ANOTACIÓN -->
+        <div *ngIf="editing() as e" class="annotation-editor editing" #editEditor [style.left.px]="e.field.x*scale()"
+          [style.top.px]="pdfCanvasRef!.nativeElement.height - e.field.y*scale()"
+          (keydown)="onEditorKeydown($event, 'edit')">
+          <span class="editor-badge">{{ 'annotation.editingBadge' | t }}</span>
+          <label class="field">
+            <span class="field-label">{{ 'annotation.fields.text.label' | t }}</span>
+            <input type="text" [(ngModel)]="e.field.mapField"
+              [placeholder]="'annotation.fields.text.placeholder' | t" />
+          </label>
+          <label class="field">
+            <span class="field-label">{{ 'annotation.fields.type.label' | t }}</span>
+            <select [(ngModel)]="e.field.type">
+              <option value="text">{{ 'annotation.fields.type.options.text' | t }}</option>
+              <option value="check">{{ 'annotation.fields.type.options.check' | t }}</option>
+              <option value="radio">{{ 'annotation.fields.type.options.radio' | t }}</option>
+              <option value="number">{{ 'annotation.fields.type.options.number' | t }}</option>
+            </select>
+          </label>
+          <label class="field">
+            <span class="field-label">{{ 'annotation.fields.value.label' | t }}</span>
+            <input type="text" [(ngModel)]="e.field.value" [placeholder]="'annotation.fields.value.placeholder' | t" />
+          </label>
+          <label class="field field-small" *ngIf="e.field.type === 'number'">
+            <span class="field-label">{{ 'annotation.fields.number.decimals.label' | t }}</span>
+            <input type="number" [(ngModel)]="e.field.decimals" min="0" />
+          </label>
+          <label class="field field-small" *ngIf="e.field.type === 'number'">
+            <span class="field-label">{{ 'annotation.fields.number.appender.label' | t }}</span>
+            <input type="text" [(ngModel)]="e.field.appender"
+              [placeholder]="'annotation.fields.number.appender.placeholder' | t" />
+          </label>
+          <label class="field field-small">
+            <span class="field-label">{{ 'annotation.fields.size.label' | t }}</span>
+            <input type="number" [(ngModel)]="e.field.fontSize" min="8" max="72" />
+          </label>
+          <div class="color-section">
+            <span class="field-label">{{ 'annotation.fields.color.label' | t }}</span>
+            <div class="color-row">
+              <input type="color" [(ngModel)]="e.field.color" (ngModelChange)="onEditColorPicker($event)" />
+              <div class="color-inputs">
+                <input type="text" [ngModel]="editHexInput()" (ngModelChange)="setEditColorFromHex($event)"
+                  [ngModelOptions]="{ standalone: true }" [placeholder]="'annotation.color.hexPlaceholder' | t" />
+                <input type="text" [ngModel]="editRgbInput()" (ngModelChange)="setEditColorFromRgb($event)"
+                  [ngModelOptions]="{ standalone: true }" [placeholder]="'annotation.color.rgbPlaceholder' | t" />
+              </div>
+            </div>
+            <small class="color-hint">{{ 'annotation.color.hintEdit' | t }}</small>
+          </div>
+          <div class="editor-actions">
+            <button type="button" (click)="duplicateAnnotation()" [title]="'annotation.actions.duplicate' | t"
+              [attr.aria-label]="'annotation.actions.duplicate' | t">⧉</button>
+            <button class="btn-delete" (click)="deleteAnnotation()">🗑️</button>
+            <button class="action-primary" (click)="confirmEdit()">✅</button>
+            <button (click)="cancelEdit()">❌</button>
+          </div>
+        </div>
       </div>
-    </div>
-    <div class="footer__details">
-      <span>© {{ currentYear }} {{ appName }}</span>
-      <span>Desarrollado por {{ appAuthor }}</span>
-    </div>
-  </footer>
+    </main>
+
+    <footer class="footer">
+      <div class="footer__brand">
+        <img class="footer__logo" src="/logo.svg" [attr.alt]="'Logotipo de ' + appName" />
+        <div class="footer__brand-text">
+          <span class="footer__app-name">{{ appName }}</span>
+          <span class="footer__version">v{{ version }}</span>
+        </div>
+      </div>
+      <div class="footer__details">
+        <span>© {{ currentYear }} {{ appName }}</span>
+        <span>Desarrollado por {{ appAuthor }}</span>
+      </div>
+    </footer>
   </ng-template>
 </div>

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,6 +1,14 @@
 <div class="app" [class.app--landing]="!pdfDoc">
   <ng-container *ngIf="!pdfDoc; else workspace">
     <section class="landing">
+      <div class="landing__language">
+        <app-language-selector
+          [languages]="languages"
+          [selectedLanguage]="languageModel"
+          (languageChange)="onLanguageChange($event)"
+          variant="compact"
+        ></app-language-selector>
+      </div>
       <div class="landing__hero">
         <span class="landing__badge">{{ 'app.landing.badge' | t }}</span>
         <h1 class="landing__title">{{ 'app.landing.title' | t }}</h1>
@@ -52,8 +60,17 @@
   <ng-template #workspace>
     <!-- HEADER -->
     <header class="header">
-      <div class="header__left">
-        <div class="logo">{{ 'app.title' | t }}</div>
+      <div class="header__top">
+        <div class="header__left">
+          <div class="logo">{{ 'app.title' | t }}</div>
+        </div>
+        <app-language-selector
+          class="header__language-selector"
+          [languages]="languages"
+          [selectedLanguage]="languageModel"
+          (languageChange)="onLanguageChange($event)"
+          variant="compact"
+        ></app-language-selector>
       </div>
 
     <div class="toolbar" role="toolbar" [attr.aria-label]="'controls.toolbarAriaLabel' | t">
@@ -115,13 +132,6 @@
       </div>
     </div>
 
-    <div class="language-selector">
-      <label class="language-selector__label" for="language-select">{{ 'app.languageLabel' | t }}</label>
-      <select id="language-select" [(ngModel)]="languageModel" (ngModelChange)="onLanguageChange($event)"
-        [attr.aria-label]="'app.languageAriaLabel' | t">
-        <option *ngFor="let lang of languages" [value]="lang">{{ ('app.languages.' + lang) | t }}</option>
-      </select>
-    </div>
   </header>
 
   <!-- LATERAL SIDEBAR -->

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -20,6 +20,7 @@ import './promise-with-resolvers.polyfill';
 import './array-buffer-transfer.polyfill';
 import { FieldType, PageAnnotations, PageField } from './models/annotation.model';
 import { AnnotationTemplatesService, AnnotationTemplate } from './annotation-templates.service';
+import { LanguageSelectorComponent } from './components/language-selector/language-selector.component';
 
 const PDF_WORKER_MODULE_SRC = '/assets/pdfjs/pdf.worker.entry.mjs';
 const PDF_WORKER_TYPE_MODULE = 'module';
@@ -72,7 +73,7 @@ type EditState = { pageIndex: number; fieldIndex: number; field: PageField } | n
   selector: 'app-root',
   standalone: true,
   templateUrl: './app.html',
-  imports: [CommonModule, FormsModule, TranslationPipe],
+  imports: [CommonModule, FormsModule, TranslationPipe, LanguageSelectorComponent],
   styleUrls: ['./app.scss'],
 })
 export class App implements AfterViewChecked, OnDestroy {
@@ -214,8 +215,8 @@ export class App implements AfterViewChecked, OnDestroy {
     this.redrawAllForPage();
   }
 
-  onLanguageChange(language: string) {
-    this.translationService.setLanguage(language as Language);
+  onLanguageChange(language: Language) {
+    this.translationService.setLanguage(language);
     this.languageModel = this.translationService.getCurrentLanguage();
   }
 

--- a/src/app/components/language-selector/language-selector.component.html
+++ b/src/app/components/language-selector/language-selector.component.html
@@ -1,0 +1,26 @@
+<div class="language-selector__header">
+  <div class="language-selector__icon" aria-hidden="true">{{ getFlag(selectedLanguage) }}</div>
+  <div class="language-selector__meta">
+    <label class="language-selector__label" [attr.for]="selectId">
+      {{ labelTranslationKey | t }}
+    </label>
+    <span class="language-selector__current">
+      {{ getFlag(selectedLanguage) }}
+      {{ ('app.languages.' + selectedLanguage) | t }}
+    </span>
+  </div>
+</div>
+
+<div class="language-selector__control">
+  <select
+    [id]="selectId"
+    [attr.aria-label]="ariaLabelTranslationKey | t"
+    [ngModel]="selectedLanguage"
+    (ngModelChange)="onLanguageChange($event)"
+  >
+    <option *ngFor="let lang of languages" [value]="lang">
+      {{ getFlag(lang) }} {{ ('app.languages.' + lang) | t }}
+    </option>
+  </select>
+  <span class="language-selector__chevron" aria-hidden="true">▾</span>
+</div>

--- a/src/app/components/language-selector/language-selector.component.html
+++ b/src/app/components/language-selector/language-selector.component.html
@@ -1,23 +1,6 @@
-<div class="language-selector__header">
-  <div class="language-selector__icon" aria-hidden="true">{{ getFlag(selectedLanguage) }}</div>
-  <div class="language-selector__meta">
-    <label class="language-selector__label" [attr.for]="selectId">
-      {{ labelTranslationKey | t }}
-    </label>
-    <span class="language-selector__current">
-      {{ getFlag(selectedLanguage) }}
-      {{ ('app.languages.' + selectedLanguage) | t }}
-    </span>
-  </div>
-</div>
-
 <div class="language-selector__control">
-  <select
-    [id]="selectId"
-    [attr.aria-label]="ariaLabelTranslationKey | t"
-    [ngModel]="selectedLanguage"
-    (ngModelChange)="onLanguageChange($event)"
-  >
+  <select [id]="selectId" [attr.aria-label]="ariaLabelTranslationKey | t" [ngModel]="selectedLanguage"
+    (ngModelChange)="onLanguageChange($event)">
     <option *ngFor="let lang of languages" [value]="lang">
       {{ getFlag(lang) }} {{ ('app.languages.' + lang) | t }}
     </option>

--- a/src/app/components/language-selector/language-selector.component.scss
+++ b/src/app/components/language-selector/language-selector.component.scss
@@ -1,0 +1,116 @@
+:host {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  background: linear-gradient(145deg, rgba(44, 44, 68, 0.9), rgba(30, 30, 46, 0.9));
+  border: 1px solid rgba(94, 234, 212, 0.2);
+  box-shadow: 0 14px 28px rgba(5, 5, 17, 0.35);
+  min-width: 220px;
+}
+
+.language-selector__header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.language-selector__icon {
+  display: grid;
+  place-items: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  background: rgba(94, 234, 212, 0.18);
+  font-size: 1.4rem;
+}
+
+.language-selector__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.language-selector__label {
+  font-size: 0.75rem;
+  color: var(--muted);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.language-selector__current {
+  font-weight: 600;
+  font-size: 0.95rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.language-selector__control {
+  position: relative;
+}
+
+select {
+  appearance: none;
+  width: 100%;
+  padding: 12px 42px 12px 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(94, 234, 212, 0.25);
+  background: rgba(24, 24, 38, 0.9);
+  color: var(--text);
+  font-weight: 600;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(94, 234, 212, 0.25);
+}
+
+.language-selector__chevron {
+  position: absolute;
+  top: 50%;
+  right: 16px;
+  transform: translateY(-50%);
+  pointer-events: none;
+  color: var(--muted);
+}
+
+:host(.language-selector--compact) {
+  flex-direction: row;
+  align-items: center;
+  gap: 14px;
+  padding: 10px 14px;
+  min-width: 0;
+}
+
+:host(.language-selector--compact) .language-selector__icon {
+  width: 32px;
+  height: 32px;
+  font-size: 1.1rem;
+}
+
+:host(.language-selector--compact) .language-selector__label {
+  font-size: 0.7rem;
+}
+
+:host(.language-selector--compact) .language-selector__current {
+  font-size: 0.9rem;
+}
+
+:host(.language-selector--compact) select {
+  padding-block: 10px;
+  padding-inline: 12px 36px;
+}
+
+:host(.language-selector--compact) .language-selector__header {
+  gap: 10px;
+}
+
+@media (max-width: 600px) {
+  :host {
+    width: 100%;
+  }
+}

--- a/src/app/components/language-selector/language-selector.component.ts
+++ b/src/app/components/language-selector/language-selector.component.ts
@@ -1,0 +1,51 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, HostBinding, Input, Output } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { TranslationPipe } from '../../i18n/translation.pipe';
+import { Language } from '../../i18n/translation.service';
+
+let uniqueId = 0;
+
+const LANGUAGE_FLAGS: Record<Language, string> = {
+  'es-ES': '🇪🇸',
+  en: '🇬🇧',
+  ca: '🏴',
+};
+
+function getLanguageFlag(language: Language): string {
+  return LANGUAGE_FLAGS[language] ?? '🌐';
+}
+
+@Component({
+  selector: 'app-language-selector',
+  standalone: true,
+  imports: [CommonModule, FormsModule, TranslationPipe],
+  templateUrl: './language-selector.component.html',
+  styleUrls: ['./language-selector.component.scss'],
+  host: {
+    class: 'language-selector'
+  }
+})
+export class LanguageSelectorComponent {
+  @Input({ required: true }) languages: readonly Language[] = [];
+  @Input({ required: true }) selectedLanguage!: Language;
+  @Input() labelTranslationKey = 'app.languageLabel';
+  @Input() ariaLabelTranslationKey = 'app.languageAriaLabel';
+  @Input() variant: 'default' | 'compact' = 'default';
+
+  @Output() readonly languageChange = new EventEmitter<Language>();
+
+  readonly selectId = `language-select-${++uniqueId}`;
+  getFlag(language: Language): string {
+    return getLanguageFlag(language);
+  }
+
+  @HostBinding('class.language-selector--compact')
+  get isCompact() {
+    return this.variant === 'compact';
+  }
+
+  onLanguageChange(language: Language | string) {
+    this.languageChange.emit(language as Language);
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -51,6 +51,16 @@ body {
   max-width: 720px;
 }
 
+.landing__language {
+  align-self: stretch;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.landing__language app-language-selector {
+  max-width: 260px;
+}
+
 .landing__hero {
   display: flex;
   flex-direction: column;
@@ -168,6 +178,10 @@ body {
 }
 
 @media (max-width: 720px) {
+  .landing__language {
+    justify-content: center;
+  }
+
   .landing__dropzone {
     padding: 28px 20px;
   }
@@ -189,6 +203,18 @@ header.header {
   border: 1px solid rgba(94, 234, 212, 0.1);
   box-shadow: 0 18px 34px rgba(5, 5, 17, 0.45);
   grid-template-columns: minmax(0, 1fr);
+}
+
+.header__top {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.header__language-selector {
+  display: inline-flex;
 }
 
 header .logo {
@@ -283,48 +309,14 @@ header .logo {
   background: rgba(255, 77, 77, 0.25);
 }
 
-.language-selector {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  align-self: flex-start;
-}
-
-.language-selector__label {
-  font-size: 0.75rem;
-  color: var(--muted);
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-.language-selector select {
-  background: rgba(29, 29, 46, 0.9);
-  color: var(--text);
-  border-radius: 12px;
-  border: 1px solid rgba(94, 234, 212, 0.15);
-  padding: 10px 14px;
-  font-weight: 600;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.language-selector select:focus {
-  outline: none;
-  border-color: var(--accent);
-  box-shadow: 0 0 0 3px rgba(94, 234, 212, 0.25);
-}
-
 @media (min-width: 960px) {
   header.header {
-    grid-template-columns: auto 1fr auto;
-    align-items: center;
+    grid-template-columns: 1fr;
+    align-items: stretch;
   }
 
-  .header__left {
+  .header__top {
     flex-wrap: nowrap;
-  }
-
-  .language-selector {
-    align-self: center;
   }
 }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -40,6 +40,7 @@ body {
   justify-content: center;
   gap: 48px;
   padding: 72px 16px;
+  position: relative;
 }
 
 .landing {
@@ -52,7 +53,9 @@ body {
 }
 
 .landing__language {
-  align-self: stretch;
+  position: absolute;
+  top: 32px;
+  right: 32px;
   display: flex;
   justify-content: flex-end;
 }
@@ -178,8 +181,9 @@ body {
 }
 
 @media (max-width: 720px) {
-  .landing__language {
-    justify-content: center;
+  .app--landing .landing__language {
+    top: 16px;
+    right: 16px;
   }
 
   .landing__dropzone {
@@ -215,6 +219,7 @@ header.header {
 
 .header__language-selector {
   display: inline-flex;
+  margin-left: auto;
 }
 
 header .logo {
@@ -234,6 +239,7 @@ header .logo {
   flex-wrap: wrap;
   align-items: center;
   gap: 12px;
+  width: 100%;
 }
 
 .toolbar__group {


### PR DESCRIPTION
## Summary
- extract a reusable language selector component with a compact variant and visual improvements
- replace the old dropdown in the workspace header and surface the selector on the landing screen
- tweak layout styles so the selector fits both the landing page and header top bar

## Testing
- npm run build

------
