### PR TITLE
Adjust language selector placement

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -40,6 +40,7 @@ body {
   justify-content: center;
   gap: 48px;
   padding: 72px 16px;
+  position: relative;
 }
 
 .landing {
@@ -52,7 +53,9 @@ body {
 }
 
 .landing__language {
-  align-self: stretch;
+  position: absolute;
+  top: 32px;
+  right: 32px;
   display: flex;
   justify-content: flex-end;
 }
@@ -178,8 +181,9 @@ body {
 }
 
 @media (max-width: 720px) {
-  .landing__language {
-    justify-content: center;
+  .app--landing .landing__language {
+    top: 16px;
+    right: 16px;
   }
 
   .landing__dropzone {
@@ -215,6 +219,7 @@ header.header {
 
 .header__language-selector {
   display: inline-flex;
+  margin-left: auto;
 }
 
 header .logo {
@@ -234,6 +239,7 @@ header .logo {
   flex-wrap: wrap;
   align-items: center;
   gap: 12px;
+  width: 100%;
 }
 
 .toolbar__group {


### PR DESCRIPTION
## Summary
- pin the landing language selector to the top-right corner of the landing view
- push the workspace language selector to the far right edge of the toolbar for consistent alignment

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690391cb0ea483258b2683ed0b93776a