### PR TITLE
feat: simplify language picker layout

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,5 +1,12 @@
 <div class="app" [class.app--landing]="!pdfDoc">
   <ng-container *ngIf="!pdfDoc; else workspace">
+    <div class="landing__language">
+      <app-language-selector
+        [languages]="languages"
+        [selectedLanguage]="languageModel"
+        (languageChange)="onLanguageChange($event)"
+      ></app-language-selector>
+    </div>
     <section class="landing">
       <div class="landing__hero">
         <span class="landing__badge">{{ 'app.landing.badge' | t }}</span>
@@ -52,77 +59,79 @@
   <ng-template #workspace>
     <!-- HEADER -->
     <header class="header">
-      <div class="header__left">
+      <div class="header__toolbar">
         <div class="logo">{{ 'app.title' | t }}</div>
+        <div class="toolbar" role="toolbar" [attr.aria-label]="'controls.toolbarAriaLabel' | t">
+          <input
+            #coordsFileInput
+            type="file"
+            accept="application/json"
+            (change)="onCoordsFileSelected($event)"
+            hidden
+          />
+
+          <div class="toolbar__group" role="group" [attr.aria-label]="'controls.navigationGroup' | t">
+            <button class="btn btn--icon" (click)="prevPage()" [disabled]="!pdfDoc || pageIndex()===1">
+              <span class="btn__icon" aria-hidden="true">⟨</span>
+              <span class="btn__label">{{ 'controls.prev' | t }}</span>
+            </button>
+            <span class="toolbar__badge">
+              {{ 'controls.pageIndicator' | t : { current: pageIndex(), total: pageCount || 0 } }}
+            </span>
+            <button class="btn btn--icon" (click)="nextPage()" [disabled]="!pdfDoc || pageIndex()===pageCount">
+              <span class="btn__label">{{ 'controls.next' | t }}</span>
+              <span class="btn__icon" aria-hidden="true">⟩</span>
+            </button>
+          </div>
+
+          <div class="toolbar__group" role="group" [attr.aria-label]="'controls.zoomGroup' | t">
+            <button class="btn btn--icon" (click)="zoomOut()" [disabled]="!pdfDoc">
+              <span class="btn__icon" aria-hidden="true">−</span>
+              <span class="btn__label">{{ 'controls.zoomOut' | t }}</span>
+            </button>
+            <span class="toolbar__badge">{{ 'controls.zoomLabel' | t }} {{ scale() | number:'1.0-2' }}×</span>
+            <button class="btn btn--icon" (click)="zoomIn()" [disabled]="!pdfDoc">
+              <span class="btn__label">{{ 'controls.zoomIn' | t }}</span>
+              <span class="btn__icon" aria-hidden="true">＋</span>
+            </button>
+          </div>
+
+          <div class="toolbar__group" role="group" [attr.aria-label]="'controls.historyGroup' | t">
+            <button class="btn btn--icon" (click)="undo()" [disabled]="!canUndo()">
+              <span class="btn__icon" aria-hidden="true">↺</span>
+              <span class="btn__label">{{ 'controls.undo' | t }}</span>
+            </button>
+            <button class="btn btn--icon" (click)="redo()" [disabled]="!canRedo()">
+              <span class="btn__icon" aria-hidden="true">↻</span>
+              <span class="btn__label">{{ 'controls.redo' | t }}</span>
+            </button>
+            <button class="btn btn--icon btn--danger" (click)="clearAll()" [disabled]="!coords().length">
+              <span class="btn__icon" aria-hidden="true">🧹</span>
+              <span class="btn__label">{{ 'controls.clear' | t }}</span>
+            </button>
+          </div>
+
+          <div class="toolbar__group" role="group" [attr.aria-label]="'controls.exportGroup' | t">
+            <button
+              class="btn btn--icon"
+              (click)="downloadAnnotatedPDF()"
+              [disabled]="!coords().length || !pdfDoc"
+            >
+              <span class="btn__icon" aria-hidden="true">⬇</span>
+              <span class="btn__label">{{ 'controls.downloadPdf' | t }}</span>
+            </button>
+          </div>
+        </div>
+        <div class="header__language">
+          <app-language-selector
+            [languages]="languages"
+            [selectedLanguage]="languageModel"
+            (languageChange)="onLanguageChange($event)"
+          ></app-language-selector>
+        </div>
       </div>
 
-    <div class="toolbar" role="toolbar" [attr.aria-label]="'controls.toolbarAriaLabel' | t">
-      <input
-        #coordsFileInput
-        type="file"
-        accept="application/json"
-        (change)="onCoordsFileSelected($event)"
-        hidden
-      />
-
-      <div class="toolbar__group" role="group" [attr.aria-label]="'controls.navigationGroup' | t">
-        <button class="btn btn--icon" (click)="prevPage()" [disabled]="!pdfDoc || pageIndex()===1">
-          <span class="btn__icon" aria-hidden="true">⟨</span>
-          <span class="btn__label">{{ 'controls.prev' | t }}</span>
-        </button>
-        <span class="toolbar__badge">
-          {{ 'controls.pageIndicator' | t : { current: pageIndex(), total: pageCount || 0 } }}
-        </span>
-        <button class="btn btn--icon" (click)="nextPage()" [disabled]="!pdfDoc || pageIndex()===pageCount">
-          <span class="btn__label">{{ 'controls.next' | t }}</span>
-          <span class="btn__icon" aria-hidden="true">⟩</span>
-        </button>
-      </div>
-
-      <div class="toolbar__group" role="group" [attr.aria-label]="'controls.zoomGroup' | t">
-        <button class="btn btn--icon" (click)="zoomOut()" [disabled]="!pdfDoc">
-          <span class="btn__icon" aria-hidden="true">−</span>
-          <span class="btn__label">{{ 'controls.zoomOut' | t }}</span>
-        </button>
-        <span class="toolbar__badge">{{ 'controls.zoomLabel' | t }} {{ scale() | number:'1.0-2' }}×</span>
-        <button class="btn btn--icon" (click)="zoomIn()" [disabled]="!pdfDoc">
-          <span class="btn__label">{{ 'controls.zoomIn' | t }}</span>
-          <span class="btn__icon" aria-hidden="true">＋</span>
-        </button>
-      </div>
-
-      <div class="toolbar__group" role="group" [attr.aria-label]="'controls.historyGroup' | t">
-        <button class="btn btn--icon" (click)="undo()" [disabled]="!canUndo()">
-          <span class="btn__icon" aria-hidden="true">↺</span>
-          <span class="btn__label">{{ 'controls.undo' | t }}</span>
-        </button>
-        <button class="btn btn--icon" (click)="redo()" [disabled]="!canRedo()">
-          <span class="btn__icon" aria-hidden="true">↻</span>
-          <span class="btn__label">{{ 'controls.redo' | t }}</span>
-        </button>
-        <button class="btn btn--icon btn--danger" (click)="clearAll()" [disabled]="!coords().length">
-          <span class="btn__icon" aria-hidden="true">🧹</span>
-          <span class="btn__label">{{ 'controls.clear' | t }}</span>
-        </button>
-      </div>
-
-      <div class="toolbar__group" role="group" [attr.aria-label]="'controls.exportGroup' | t">
-        <button class="btn btn--icon" (click)="downloadAnnotatedPDF()"
-          [disabled]="!coords().length || !pdfDoc">
-          <span class="btn__icon" aria-hidden="true">⬇</span>
-          <span class="btn__label">{{ 'controls.downloadPdf' | t }}</span>
-        </button>
-      </div>
-    </div>
-
-    <div class="language-selector">
-      <label class="language-selector__label" for="language-select">{{ 'app.languageLabel' | t }}</label>
-      <select id="language-select" [(ngModel)]="languageModel" (ngModelChange)="onLanguageChange($event)"
-        [attr.aria-label]="'app.languageAriaLabel' | t">
-        <option *ngFor="let lang of languages" [value]="lang">{{ ('app.languages.' + lang) | t }}</option>
-      </select>
-    </div>
-  </header>
+    </header>
 
   <!-- LATERAL SIDEBAR -->
   <aside class="sidebar">

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -20,6 +20,7 @@ import './promise-with-resolvers.polyfill';
 import './array-buffer-transfer.polyfill';
 import { FieldType, PageAnnotations, PageField } from './models/annotation.model';
 import { AnnotationTemplatesService, AnnotationTemplate } from './annotation-templates.service';
+import { LanguageSelectorComponent } from './components/language-selector/language-selector.component';
 
 const PDF_WORKER_MODULE_SRC = '/assets/pdfjs/pdf.worker.entry.mjs';
 const PDF_WORKER_TYPE_MODULE = 'module';
@@ -72,7 +73,7 @@ type EditState = { pageIndex: number; fieldIndex: number; field: PageField } | n
   selector: 'app-root',
   standalone: true,
   templateUrl: './app.html',
-  imports: [CommonModule, FormsModule, TranslationPipe],
+  imports: [CommonModule, FormsModule, TranslationPipe, LanguageSelectorComponent],
   styleUrls: ['./app.scss'],
 })
 export class App implements AfterViewChecked, OnDestroy {
@@ -214,8 +215,8 @@ export class App implements AfterViewChecked, OnDestroy {
     this.redrawAllForPage();
   }
 
-  onLanguageChange(language: string) {
-    this.translationService.setLanguage(language as Language);
+  onLanguageChange(language: Language) {
+    this.translationService.setLanguage(language);
     this.languageModel = this.translationService.getCurrentLanguage();
   }
 

--- a/src/app/components/language-selector/language-selector.component.html
+++ b/src/app/components/language-selector/language-selector.component.html
@@ -1,0 +1,21 @@
+<label
+  *ngIf="showLabel"
+  class="language-selector__label"
+  [attr.for]="selectId"
+>
+  {{ labelTranslationKey | t }}
+</label>
+<div class="language-selector__control">
+  <select
+    [id]="selectId"
+    class="language-selector__select"
+    [attr.aria-label]="ariaLabelTranslationKey | t"
+    [ngModel]="selectedLanguage"
+    (ngModelChange)="onLanguageChange($event)"
+  >
+    <option *ngFor="let lang of languages" [value]="lang">
+      {{ ('app.languages.' + lang) | t }}
+    </option>
+  </select>
+  <span class="language-selector__chevron" aria-hidden="true">▾</span>
+</div>

--- a/src/app/components/language-selector/language-selector.component.scss
+++ b/src/app/components/language-selector/language-selector.component.scss
@@ -1,0 +1,48 @@
+:host {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.9rem;
+}
+
+.language-selector__label {
+  font-size: 0.75rem;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.language-selector__control {
+  position: relative;
+  display: inline-flex;
+  width: 100%;
+}
+
+.language-selector__select {
+  appearance: none;
+  width: 100%;
+  min-width: 160px;
+  padding: 8px 32px 8px 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(36, 36, 58, 0.85);
+  color: var(--text);
+  font-weight: 600;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.language-selector__select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(94, 234, 212, 0.25);
+}
+
+.language-selector__chevron {
+  position: absolute;
+  top: 50%;
+  right: 12px;
+  transform: translateY(-50%);
+  pointer-events: none;
+  color: var(--muted);
+  font-size: 0.8rem;
+}

--- a/src/app/components/language-selector/language-selector.component.ts
+++ b/src/app/components/language-selector/language-selector.component.ts
@@ -1,0 +1,33 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { TranslationPipe } from '../../i18n/translation.pipe';
+import { Language } from '../../i18n/translation.service';
+
+let uniqueId = 0;
+
+@Component({
+  selector: 'app-language-selector',
+  standalone: true,
+  imports: [CommonModule, FormsModule, TranslationPipe],
+  templateUrl: './language-selector.component.html',
+  styleUrls: ['./language-selector.component.scss'],
+  host: {
+    class: 'language-selector'
+  }
+})
+export class LanguageSelectorComponent {
+  @Input({ required: true }) languages: readonly Language[] = [];
+  @Input({ required: true }) selectedLanguage!: Language;
+  @Input() labelTranslationKey = 'app.languageLabel';
+  @Input() ariaLabelTranslationKey = 'app.languageAriaLabel';
+  @Input() showLabel = false;
+
+  @Output() readonly languageChange = new EventEmitter<Language>();
+
+  readonly selectId = `language-select-${++uniqueId}`;
+
+  onLanguageChange(language: Language | string) {
+    this.languageChange.emit(language as Language);
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -34,12 +34,14 @@ body {
 }
 
 .app--landing {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: 48px;
-  padding: 72px 16px;
+  min-height: 100vh;
+  padding: 64px 24px;
 }
 
 .landing {
@@ -49,6 +51,13 @@ body {
   text-align: center;
   gap: 32px;
   max-width: 720px;
+}
+
+.landing__language {
+  position: absolute;
+  top: 24px;
+  right: 24px;
+  z-index: 1;
 }
 
 .landing__hero {
@@ -168,6 +177,17 @@ body {
 }
 
 @media (max-width: 720px) {
+  .app--landing {
+    padding: 48px 16px;
+  }
+
+  .landing__language {
+    position: static;
+    align-self: stretch;
+    display: flex;
+    justify-content: center;
+  }
+
   .landing__dropzone {
     padding: 28px 20px;
   }
@@ -181,33 +201,42 @@ body {
 
 header.header {
   grid-area: header;
-  display: grid;
-  gap: 16px;
   padding: 16px;
   background: linear-gradient(135deg, rgba(36, 36, 58, 0.95), rgba(33, 33, 48, 0.95));
   border-radius: 20px;
   border: 1px solid rgba(94, 234, 212, 0.1);
   box-shadow: 0 18px 34px rgba(5, 5, 17, 0.45);
-  grid-template-columns: minmax(0, 1fr);
+}
+
+.header__toolbar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  width: 100%;
 }
 
 header .logo {
   font-weight: bold;
   font-size: 1.3rem;
   color: var(--accent);
-}
-
-.header__left {
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
+  min-width: max-content;
 }
 
 .toolbar {
   display: flex;
+  flex: 1 1 auto;
   flex-wrap: wrap;
   align-items: center;
   gap: 12px;
+  justify-content: center;
+}
+
+.header__language {
+  display: flex;
+  justify-content: flex-end;
+  flex: 0 0 auto;
+  margin-left: auto;
 }
 
 .toolbar__group {
@@ -283,48 +312,13 @@ header .logo {
   background: rgba(255, 77, 77, 0.25);
 }
 
-.language-selector {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  align-self: flex-start;
-}
-
-.language-selector__label {
-  font-size: 0.75rem;
-  color: var(--muted);
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-.language-selector select {
-  background: rgba(29, 29, 46, 0.9);
-  color: var(--text);
-  border-radius: 12px;
-  border: 1px solid rgba(94, 234, 212, 0.15);
-  padding: 10px 14px;
-  font-weight: 600;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.language-selector select:focus {
-  outline: none;
-  border-color: var(--accent);
-  box-shadow: 0 0 0 3px rgba(94, 234, 212, 0.25);
-}
-
 @media (min-width: 960px) {
-  header.header {
-    grid-template-columns: auto 1fr auto;
-    align-items: center;
-  }
-
-  .header__left {
+  .header__toolbar {
     flex-wrap: nowrap;
   }
 
-  .language-selector {
-    align-self: center;
+  .toolbar {
+    justify-content: flex-start;
   }
 }
 


### PR DESCRIPTION
## Summary
- replace the language selector with a lightweight dropdown component and optional label toggle
- pin the selector to the top-right of the landing view while keeping the hero content centered
- align the workspace title, control groups, and selector on a single header row with refreshed styles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69038c7914088325b780993a204e0be3