### PR TITLE
Fix advanced panel styles after merge

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -567,160 +567,160 @@ header .logo {
 .templates__delete:hover {
   background: rgba(255, 77, 77, 0.15);
   border-color: var(--danger);
+}
 
-  .sidebar-divider {
-    margin: 16px 0;
-    border-top: 1px solid rgba(94, 234, 212, 0.15);
+.sidebar-divider {
+  margin: 16px 0;
+  border-top: 1px solid rgba(94, 234, 212, 0.15);
+}
+
+.advanced-panel {
+  margin-top: 12px;
+
+  .advanced-toggle {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    background: transparent;
+    border: 1px solid rgba(94, 234, 212, 0.25);
+    border-radius: 8px;
+    padding: 8px 10px;
+    color: var(--accent);
+    font-size: 0.95rem;
+    cursor: pointer;
+    transition: border-color 0.2s ease, background 0.2s ease;
   }
 
-  .advanced-panel {
-    margin-top: 12px;
+  .advanced-toggle:hover,
+  &.open .advanced-toggle,
+  &.active .advanced-toggle {
+    border-color: var(--accent);
+    background: rgba(94, 234, 212, 0.12);
+  }
 
-    .advanced-toggle {
-      width: 100%;
+  .advanced-icon {
+    font-size: 0.9rem;
+    transform: rotate(-90deg);
+    transition: transform 0.2s ease;
+  }
+
+  &.open .advanced-icon {
+    transform: rotate(0deg);
+  }
+
+  .advanced-checkbox {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.9rem;
+    color: var(--text);
+    margin: 12px 0 4px;
+  }
+
+  input[type='checkbox'] {
+    accent-color: var(--accent);
+  }
+
+  .advanced-hint {
+    font-size: 0.75rem;
+    color: var(--muted);
+    line-height: 1.4;
+    margin-bottom: 12px;
+    display: block;
+  }
+}
+
+.guides-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+
+  h5 {
+    margin: 0;
+    font-size: 1rem;
+    color: var(--accent);
+  }
+
+  .guides-toggles {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 8px;
+
+    label {
       display: flex;
       align-items: center;
-      justify-content: space-between;
-      gap: 8px;
-      background: transparent;
-      border: 1px solid rgba(94, 234, 212, 0.25);
-      border-radius: 8px;
-      padding: 8px 10px;
-      color: var(--accent);
-      font-size: 0.95rem;
-      cursor: pointer;
-      transition: border-color 0.2s ease, background 0.2s ease;
-    }
-
-    .advanced-toggle:hover,
-    &.open .advanced-toggle,
-    &.active .advanced-toggle {
-      border-color: var(--accent);
-      background: rgba(94, 234, 212, 0.12);
-    }
-
-    .advanced-icon {
-      font-size: 0.9rem;
-      transform: rotate(-90deg);
-      transition: transform 0.2s ease;
-    }
-
-    &.open .advanced-icon {
-      transform: rotate(0deg);
-    }
-
-    .advanced-checkbox {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      font-size: 0.9rem;
+      gap: 6px;
+      font-size: 0.85rem;
       color: var(--text);
-      margin: 12px 0 4px;
     }
 
     input[type='checkbox'] {
       accent-color: var(--accent);
     }
+  }
 
-    .advanced-hint {
-      font-size: 0.75rem;
+  .guides-inputs {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 10px;
+
+    label {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      font-size: 0.8rem;
       color: var(--muted);
-      line-height: 1.4;
-      margin-bottom: 12px;
-      display: block;
+    }
+
+    input[type='number'] {
+      width: 100%;
+      border-radius: 6px;
+      border: 1px solid rgba(94, 234, 212, 0.25);
+      background: rgba(29, 29, 42, 0.9);
+      color: var(--text);
+      padding: 6px 8px;
+    }
+
+    input[type='number']:focus {
+      outline: none;
+      border-color: var(--accent);
+      box-shadow: 0 0 0 2px rgba(94, 234, 212, 0.15);
     }
   }
 
-  .guides-panel {
+  .guides-custom {
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 8px;
 
-    h5 {
-      margin: 0;
-      font-size: 1rem;
-      color: var(--accent);
-    }
-
-    .guides-toggles {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-      gap: 8px;
-
-      label {
-        display: flex;
-        align-items: center;
-        gap: 6px;
-        font-size: 0.85rem;
-        color: var(--text);
-      }
-
-      input[type='checkbox'] {
-        accent-color: var(--accent);
-      }
-    }
-
-    .guides-inputs {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-      gap: 10px;
-
-      label {
-        display: flex;
-        flex-direction: column;
-        gap: 4px;
-        font-size: 0.8rem;
-        color: var(--muted);
-      }
-
-      input[type='number'] {
-        width: 100%;
-        border-radius: 6px;
-        border: 1px solid rgba(94, 234, 212, 0.25);
-        background: rgba(29, 29, 42, 0.9);
-        color: var(--text);
-        padding: 6px 8px;
-      }
-
-      input[type='number']:focus {
-        outline: none;
-        border-color: var(--accent);
-        box-shadow: 0 0 0 2px rgba(94, 234, 212, 0.15);
-      }
-    }
-
-    .guides-custom {
+    label {
       display: flex;
       flex-direction: column;
-      gap: 8px;
+      gap: 4px;
+      font-size: 0.8rem;
+      color: var(--muted);
+    }
 
-      label {
-        display: flex;
-        flex-direction: column;
-        gap: 4px;
-        font-size: 0.8rem;
-        color: var(--muted);
-      }
+    input[type='text'] {
+      border-radius: 6px;
+      border: 1px solid rgba(94, 234, 212, 0.25);
+      background: rgba(29, 29, 42, 0.9);
+      color: var(--text);
+      padding: 6px 8px;
+    }
 
-      input[type='text'] {
-        border-radius: 6px;
-        border: 1px solid rgba(94, 234, 212, 0.25);
-        background: rgba(29, 29, 42, 0.9);
-        color: var(--text);
-        padding: 6px 8px;
-      }
+    input[type='text']:focus {
+      outline: none;
+      border-color: var(--accent);
+      box-shadow: 0 0 0 2px rgba(94, 234, 212, 0.12);
+    }
 
-      input[type='text']:focus {
-        outline: none;
-        border-color: var(--accent);
-        box-shadow: 0 0 0 2px rgba(94, 234, 212, 0.12);
-      }
-
-      .guides-hint {
-        font-size: 0.75rem;
-        color: var(--muted);
-        line-height: 1.4;
-      }
+    .guides-hint {
+      font-size: 0.75rem;
+      color: var(--muted);
+      line-height: 1.4;
     }
   }
 }


### PR DESCRIPTION
## Summary
- unnest the advanced guides styles that were accidentally scoped under `.templates__delete:hover`
- restore the sidebar divider and guides controls styling so the workspace layout matches develop

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69045ca8bbac8325808e9eaa7f85994e