### PR TITLE
Fix overlay canvas styling regression

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -273,8 +273,8 @@
     <!-- VISOR PDF -->
     <main class="viewer" *ngIf="pdfDoc as _">
       <div class="canvas-container">
-        <canvas #pdfCanvas></canvas>
-        <canvas #overlayCanvas></canvas>
+        <canvas #pdfCanvas id="pdfCanvas"></canvas>
+        <canvas #overlayCanvas id="overlayCanvas"></canvas>
         <div #annotationsLayer class="annotations-layer"></div>
         <div class="hitbox" (click)="onHitboxClick($event)"></div>
 


### PR DESCRIPTION
## Summary
- add DOM ids to the viewer canvases so global style selectors apply again after the merge

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69045ca8bbac8325808e9eaa7f85994e