### PR TITLE
Fix advanced panel styling for guides feature

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -271,7 +271,7 @@
     </aside>
 
     <!-- VISOR PDF -->
-    <main class="viewer" *ngIf="pdfDoc as _">
+    <main class="viewer" *ngIf="pdfDoc as _" [class.viewer--guides-enabled]="guidesFeatureEnabled()">
       <div class="canvas-container">
         <canvas #pdfCanvas></canvas>
         <canvas #overlayCanvas></canvas>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -556,17 +556,17 @@ header .logo {
       color: var(--muted);
     }
   }
-}
 
-.templates__delete {
-  border-color: var(--danger);
-  color: var(--danger);
-  background: transparent;
-}
+  .templates__delete {
+    border-color: var(--danger);
+    color: var(--danger);
+    background: transparent;
+  }
 
-.templates__delete:hover {
-  background: rgba(255, 77, 77, 0.15);
-  border-color: var(--danger);
+  .templates__delete:hover {
+    background: rgba(255, 77, 77, 0.15);
+    border-color: var(--danger);
+  }
 
   .sidebar-divider {
     margin: 16px 0;
@@ -629,97 +629,97 @@ header .logo {
       margin-bottom: 12px;
       display: block;
     }
-  }
 
-  .guides-panel {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-
-    h5 {
-      margin: 0;
-      font-size: 1rem;
-      color: var(--accent);
-    }
-
-    .guides-toggles {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-      gap: 8px;
-
-      label {
-        display: flex;
-        align-items: center;
-        gap: 6px;
-        font-size: 0.85rem;
-        color: var(--text);
-      }
-
-      input[type='checkbox'] {
-        accent-color: var(--accent);
-      }
-    }
-
-    .guides-inputs {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-      gap: 10px;
-
-      label {
-        display: flex;
-        flex-direction: column;
-        gap: 4px;
-        font-size: 0.8rem;
-        color: var(--muted);
-      }
-
-      input[type='number'] {
-        width: 100%;
-        border-radius: 6px;
-        border: 1px solid rgba(94, 234, 212, 0.25);
-        background: rgba(29, 29, 42, 0.9);
-        color: var(--text);
-        padding: 6px 8px;
-      }
-
-      input[type='number']:focus {
-        outline: none;
-        border-color: var(--accent);
-        box-shadow: 0 0 0 2px rgba(94, 234, 212, 0.15);
-      }
-    }
-
-    .guides-custom {
+    .guides-panel {
       display: flex;
       flex-direction: column;
-      gap: 8px;
+      gap: 12px;
 
-      label {
+      h5 {
+        margin: 0;
+        font-size: 1rem;
+        color: var(--accent);
+      }
+
+      .guides-toggles {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        gap: 8px;
+
+        label {
+          display: flex;
+          align-items: center;
+          gap: 6px;
+          font-size: 0.85rem;
+          color: var(--text);
+        }
+
+        input[type='checkbox'] {
+          accent-color: var(--accent);
+        }
+      }
+
+      .guides-inputs {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+        gap: 10px;
+
+        label {
+          display: flex;
+          flex-direction: column;
+          gap: 4px;
+          font-size: 0.8rem;
+          color: var(--muted);
+        }
+
+        input[type='number'] {
+          width: 100%;
+          border-radius: 6px;
+          border: 1px solid rgba(94, 234, 212, 0.25);
+          background: rgba(29, 29, 42, 0.9);
+          color: var(--text);
+          padding: 6px 8px;
+        }
+
+        input[type='number']:focus {
+          outline: none;
+          border-color: var(--accent);
+          box-shadow: 0 0 0 2px rgba(94, 234, 212, 0.15);
+        }
+      }
+
+      .guides-custom {
         display: flex;
         flex-direction: column;
-        gap: 4px;
-        font-size: 0.8rem;
-        color: var(--muted);
-      }
+        gap: 8px;
 
-      input[type='text'] {
-        border-radius: 6px;
-        border: 1px solid rgba(94, 234, 212, 0.25);
-        background: rgba(29, 29, 42, 0.9);
-        color: var(--text);
-        padding: 6px 8px;
-      }
+        label {
+          display: flex;
+          flex-direction: column;
+          gap: 4px;
+          font-size: 0.8rem;
+          color: var(--muted);
+        }
 
-      input[type='text']:focus {
-        outline: none;
-        border-color: var(--accent);
-        box-shadow: 0 0 0 2px rgba(94, 234, 212, 0.12);
-      }
+        input[type='text'] {
+          border-radius: 6px;
+          border: 1px solid rgba(94, 234, 212, 0.25);
+          background: rgba(29, 29, 42, 0.9);
+          color: var(--text);
+          padding: 6px 8px;
+        }
 
-      .guides-hint {
-        font-size: 0.75rem;
-        color: var(--muted);
-        line-height: 1.4;
+        input[type='text']:focus {
+          outline: none;
+          border-color: var(--accent);
+          box-shadow: 0 0 0 2px rgba(94, 234, 212, 0.12);
+        }
+
+        .guides-hint {
+          font-size: 0.75rem;
+          color: var(--muted);
+          line-height: 1.4;
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- restore the viewer guides-enabled class binding so the canvas shifts when rulers and guides are active
- fix the sidebar advanced panel SCSS nesting so delete button, dividers, and guide controls style correctly after the merge

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69045ca8bbac8325808e9eaa7f85994e