### PR TITLE
Add tree view option to JSON annotation menu

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -183,10 +183,21 @@
         </ng-template>
       </ng-template>
       <div class="json-toolbar">
-        <button type="button" class="btn btn--ghost json-toolbar__view-toggle" (click)="toggleJsonView()"
-          [attr.aria-pressed]="jsonViewMode() === 'tree'">
-          {{ jsonViewMode() === 'tree' ? ('controls.viewJsonText' | t) : ('controls.viewJsonTree' | t) }}
-        </button>
+        <div class="json-toolbar__view-toggle-group" role="group"
+          [attr.aria-label]="'controls.jsonViewModeToggle' | t">
+          <button type="button" class="json-toolbar__view-toggle-option"
+            [class.json-toolbar__view-toggle-option--active]="jsonViewMode() === 'text'"
+            (click)="setJsonViewMode('text')" [attr.aria-pressed]="jsonViewMode() === 'text'">
+            <span class="json-toolbar__view-toggle-icon" aria-hidden="true">📝</span>
+            <span>{{ 'controls.viewJsonText' | t }}</span>
+          </button>
+          <button type="button" class="json-toolbar__view-toggle-option"
+            [class.json-toolbar__view-toggle-option--active]="jsonViewMode() === 'tree'"
+            (click)="setJsonViewMode('tree')" [attr.aria-pressed]="jsonViewMode() === 'tree'">
+            <span class="json-toolbar__view-toggle-icon" aria-hidden="true">🌳</span>
+            <span>{{ 'controls.viewJsonTree' | t }}</span>
+          </button>
+        </div>
         <button type="button" class="btn" (click)="copyJSON()"
           [disabled]="!coords().length">{{ 'controls.copyJson' | t }}</button>
         <button type="button" class="btn" (click)="downloadJSON()"

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -167,11 +167,29 @@
           <p class="templates__empty">{{ 'sidebar.templates.empty' | t }}</p>
         </ng-template>
       </section>
-      <textarea class="json-editor" [(ngModel)]="coordsTextModel" [placeholder]="'sidebar.jsonPlaceholder' | t"
-        spellcheck="false"></textarea>
+      <ng-container *ngIf="jsonViewMode() === 'text'; else jsonTreeView">
+        <textarea class="json-editor" [ngModel]="coordsTextModel" (ngModelChange)="onCoordsTextChange($event)"
+          [placeholder]="'sidebar.jsonPlaceholder' | t" spellcheck="false"></textarea>
+      </ng-container>
+      <ng-template #jsonTreeView>
+        <div *ngIf="jsonTreePreview.status === 'ready'; else jsonTreePlaceholder" class="json-tree-container">
+          <app-json-tree [value]="jsonTreePreview.value"></app-json-tree>
+        </div>
+        <ng-template #jsonTreePlaceholder>
+          <div class="json-tree-placeholder">
+            <p *ngIf="jsonTreePreview.status === 'empty'">{{ 'sidebar.jsonTree.empty' | t }}</p>
+            <p *ngIf="jsonTreePreview.status === 'error'">{{ 'sidebar.jsonTree.invalid' | t }}</p>
+          </div>
+        </ng-template>
+      </ng-template>
       <div class="json-toolbar">
-        <button class="btn" (click)="copyJSON()" [disabled]="!coords().length">{{ 'controls.copyJson' | t }}</button>
-        <button class="btn" (click)="downloadJSON()"
+        <button type="button" class="btn btn--ghost json-toolbar__view-toggle" (click)="toggleJsonView()"
+          [attr.aria-pressed]="jsonViewMode() === 'tree'">
+          {{ jsonViewMode() === 'tree' ? ('controls.viewJsonText' | t) : ('controls.viewJsonTree' | t) }}
+        </button>
+        <button type="button" class="btn" (click)="copyJSON()"
+          [disabled]="!coords().length">{{ 'controls.copyJson' | t }}</button>
+        <button type="button" class="btn" (click)="downloadJSON()"
           [disabled]="!coords().length">{{ 'controls.downloadJson' | t }}</button>
       </div>
       <small class="sidebar-hint">{{ 'sidebar.jsonHint' | t }}</small>

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1230,12 +1230,16 @@ export class App implements AfterViewChecked, OnDestroy {
     this.refreshJsonPreview();
   }
 
-  toggleJsonView() {
-    const nextMode: JsonViewMode = this.jsonViewMode() === 'text' ? 'tree' : 'text';
-    if (nextMode === 'tree') {
+  setJsonViewMode(mode: JsonViewMode) {
+    if (this.jsonViewMode() === mode) {
+      return;
+    }
+
+    if (mode === 'tree') {
       this.refreshJsonPreview();
     }
-    this.jsonViewMode.set(nextMode);
+
+    this.jsonViewMode.set(mode);
   }
 
   applyCoordsText() {

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -21,6 +21,7 @@ import './array-buffer-transfer.polyfill';
 import { FieldType, PageAnnotations, PageField } from './models/annotation.model';
 import { AnnotationTemplatesService, AnnotationTemplate } from './annotation-templates.service';
 import { LanguageSelectorComponent } from './components/language-selector/language-selector.component';
+import { JsonTreeComponent } from './components/json-tree/json-tree.component';
 
 const PDF_WORKER_MODULE_SRC = '/assets/pdfjs/pdf.worker.entry.mjs';
 const PDF_WORKER_TYPE_MODULE = 'module';
@@ -69,11 +70,20 @@ type PreviewState = { page: number; field: PageField } | null;
 
 type EditState = { pageIndex: number; fieldIndex: number; field: PageField } | null;
 
+type JsonViewMode = 'text' | 'tree';
+
+type JsonTreePreviewStatus = 'empty' | 'ready' | 'error';
+
+interface JsonTreePreview {
+  status: JsonTreePreviewStatus;
+  value: unknown | null;
+}
+
 @Component({
   selector: 'app-root',
   standalone: true,
   templateUrl: './app.html',
-  imports: [CommonModule, FormsModule, TranslationPipe, LanguageSelectorComponent],
+  imports: [CommonModule, FormsModule, TranslationPipe, LanguageSelectorComponent, JsonTreeComponent],
   styleUrls: ['./app.scss'],
 })
 export class App implements AfterViewChecked, OnDestroy {
@@ -90,7 +100,9 @@ export class App implements AfterViewChecked, OnDestroy {
   editHexInput = signal('#000000');
   editRgbInput = signal('rgb(0, 0, 0)');
   coordsTextModel = JSON.stringify({ pages: [] }, null, 2);
+  jsonTreePreview: JsonTreePreview = this.buildJsonTreePreview(this.coordsTextModel);
   fileDropActive = signal(false);
+  readonly jsonViewMode = signal<JsonViewMode>('text');
   private readonly translationService = inject(TranslationService);
   private readonly title = inject(Title);
   private readonly meta = inject(Meta);
@@ -1213,6 +1225,19 @@ export class App implements AfterViewChecked, OnDestroy {
     navigator.clipboard.writeText(this.coordsTextModel).catch(() => {});
   }
 
+  onCoordsTextChange(value: string) {
+    this.coordsTextModel = value;
+    this.refreshJsonPreview();
+  }
+
+  toggleJsonView() {
+    const nextMode: JsonViewMode = this.jsonViewMode() === 'text' ? 'tree' : 'text';
+    if (nextMode === 'tree') {
+      this.refreshJsonPreview();
+    }
+    this.jsonViewMode.set(nextMode);
+  }
+
   applyCoordsText() {
     const text = this.coordsTextModel.trim();
 
@@ -1503,6 +1528,7 @@ export class App implements AfterViewChecked, OnDestroy {
   private syncCoordsTextModel(persist = true) {
     const currentCoords = this.coords();
     this.coordsTextModel = JSON.stringify({ pages: currentCoords }, null, 2);
+    this.refreshJsonPreview();
     if (persist) {
       this.templatesService.storeLastCoords(currentCoords);
     }
@@ -1584,6 +1610,25 @@ export class App implements AfterViewChecked, OnDestroy {
       (a.appender ?? undefined) === (b.appender ?? undefined) &&
       (a.decimals ?? undefined) === (b.decimals ?? undefined)
     );
+  }
+
+  private refreshJsonPreview() {
+    this.jsonTreePreview = this.buildJsonTreePreview(this.coordsTextModel);
+  }
+
+  private buildJsonTreePreview(text: string): JsonTreePreview {
+    const trimmed = text.trim();
+
+    if (!trimmed) {
+      return { status: 'empty', value: null };
+    }
+
+    try {
+      const parsed = this.parseLooseJson(trimmed);
+      return { status: 'ready', value: parsed };
+    } catch {
+      return { status: 'error', value: null };
+    }
   }
 
   private parseLooseJson(text: string): unknown {

--- a/src/app/components/json-tree/json-tree.component.html
+++ b/src/app/components/json-tree/json-tree.component.html
@@ -1,0 +1,59 @@
+<ul *ngIf="rootNode as root" class="json-tree" role="tree">
+  <ng-container *ngTemplateOutlet="nodeTemplate; context: { node: root }"></ng-container>
+</ul>
+
+<ng-template #nodeTemplate let-node="node">
+  <li
+    class="json-tree__node"
+    role="treeitem"
+    [attr.aria-expanded]="node.children?.length ? !isCollapsed(node) : null"
+  >
+    <div class="json-tree__row">
+      <button
+        *ngIf="node.children?.length"
+        type="button"
+        class="json-tree__toggle"
+        (click)="toggleNode(node)"
+        [attr.aria-label]="'Toggle node'"
+        [attr.aria-expanded]="!isCollapsed(node)"
+      >
+        <span class="json-tree__chevron" [class.json-tree__chevron--collapsed]="isCollapsed(node)"></span>
+      </button>
+      <span *ngIf="!node.children?.length" class="json-tree__toggle-placeholder"></span>
+      <span *ngIf="node.label !== undefined" class="json-tree__label">
+        <ng-container *ngIf="node.isIndex; else objectLabel">
+          {{ node.label }}
+        </ng-container>
+        <ng-template #objectLabel>"{{ node.label }}"</ng-template>
+        <span class="json-tree__colon">:</span>
+      </span>
+      <ng-container [ngSwitch]="node.kind">
+        <span
+          *ngSwitchCase="'value'"
+          class="json-tree__value"
+          [ngClass]="'json-tree__value--' + (node.valueType ?? 'unknown')"
+        >
+          {{ formatValue(node.value, node.valueType ?? 'unknown') }}
+        </span>
+        <ng-container *ngSwitchDefault>
+          <span class="json-tree__brackets">
+            {{ node.kind === 'array' ? '[' : '{' }}
+            <ng-container *ngIf="isCollapsed(node)">…{{ node.kind === 'array' ? ']' : '}' }}</ng-container>
+            <ng-container *ngIf="!node.children?.length">{{ node.kind === 'array' ? ']' : '}' }}</ng-container>
+          </span>
+          <span class="json-tree__meta" *ngIf="node.children">
+            ({{ node.children.length }})
+          </span>
+        </ng-container>
+      </ng-container>
+    </div>
+    <ul *ngIf="node.children?.length && !isCollapsed(node)" class="json-tree__children" role="group">
+      <ng-container *ngFor="let child of node.children; trackBy: trackByPath">
+        <ng-container *ngTemplateOutlet="nodeTemplate; context: { node: child }"></ng-container>
+      </ng-container>
+    </ul>
+    <div *ngIf="node.children?.length && !isCollapsed(node)" class="json-tree__closing">
+      {{ node.kind === 'array' ? ']' : '}' }}
+    </div>
+  </li>
+</ng-template>

--- a/src/app/components/json-tree/json-tree.component.scss
+++ b/src/app/components/json-tree/json-tree.component.scss
@@ -1,0 +1,118 @@
+:host {
+  display: block;
+  color: var(--text);
+}
+
+.json-tree {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-family: 'Fira Code', monospace;
+  font-size: 0.85rem;
+}
+
+.json-tree__node {
+  margin: 0;
+  padding: 0;
+}
+
+.json-tree__row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  line-height: 1.6;
+}
+
+.json-tree__toggle {
+  width: 20px;
+  height: 20px;
+  display: grid;
+  place-items: center;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.json-tree__toggle:hover,
+.json-tree__toggle:focus-visible {
+  background: rgba(94, 234, 212, 0.15);
+  outline: none;
+}
+
+.json-tree__toggle-placeholder {
+  width: 20px;
+  height: 20px;
+  display: inline-block;
+}
+
+.json-tree__chevron {
+  width: 6px;
+  height: 6px;
+  border-right: 2px solid var(--muted);
+  border-bottom: 2px solid var(--muted);
+  transform: rotate(45deg);
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.json-tree__chevron--collapsed {
+  transform: rotate(-45deg);
+}
+
+.json-tree__label {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--accent);
+}
+
+.json-tree__colon {
+  color: var(--muted);
+}
+
+.json-tree__brackets {
+  color: var(--muted);
+}
+
+.json-tree__meta {
+  color: var(--muted);
+  font-size: 0.75rem;
+}
+
+.json-tree__value {
+  font-family: inherit;
+}
+
+.json-tree__value--string {
+  color: #9cdcfe;
+}
+
+.json-tree__value--number {
+  color: #b5cea8;
+}
+
+.json-tree__value--boolean {
+  color: #569cd6;
+}
+
+.json-tree__value--null {
+  color: #c586c0;
+}
+
+.json-tree__value--unknown {
+  color: var(--muted);
+}
+
+.json-tree__children {
+  list-style: none;
+  margin: 4px 0 4px 24px;
+  padding: 0 0 0 12px;
+  border-left: 1px solid rgba(94, 234, 212, 0.12);
+}
+
+.json-tree__closing {
+  margin-left: 32px;
+  color: var(--muted);
+}

--- a/src/app/components/json-tree/json-tree.component.ts
+++ b/src/app/components/json-tree/json-tree.component.ts
@@ -42,7 +42,11 @@ export class JsonTreeComponent implements OnChanges {
         label: this.label,
         path: 'root',
       });
-      this.collapsedPaths.set(new Set());
+      const collapsed = new Set<string>();
+      if (this.rootNode) {
+        this.populateCollapsedPaths(this.rootNode, collapsed);
+      }
+      this.collapsedPaths.set(collapsed);
     }
   }
 
@@ -155,5 +159,14 @@ export class JsonTreeComponent implements OnChanges {
 
   private escapePathSegment(value: string): string {
     return encodeURIComponent(value);
+  }
+
+  private populateCollapsedPaths(node: JsonTreeNode, target: Set<string>) {
+    if (node.children?.length) {
+      target.add(node.path);
+      for (const child of node.children) {
+        this.populateCollapsedPaths(child, target);
+      }
+    }
   }
 }

--- a/src/app/components/json-tree/json-tree.component.ts
+++ b/src/app/components/json-tree/json-tree.component.ts
@@ -1,0 +1,159 @@
+import { CommonModule } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  OnChanges,
+  SimpleChanges,
+  signal,
+} from '@angular/core';
+
+interface JsonTreeNode {
+  label?: string;
+  kind: 'object' | 'array' | 'value';
+  path: string;
+  isIndex?: boolean;
+  children?: JsonTreeNode[];
+  value?: unknown;
+  valueType?: JsonPrimitiveType;
+}
+
+type JsonPrimitiveType = 'string' | 'number' | 'boolean' | 'null' | 'unknown';
+
+@Component({
+  selector: 'app-json-tree',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './json-tree.component.html',
+  styleUrls: ['./json-tree.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class JsonTreeComponent implements OnChanges {
+  @Input() value: unknown = null;
+  @Input() label: string | null = null;
+
+  protected rootNode: JsonTreeNode | null = null;
+
+  private readonly collapsedPaths = signal<Set<string>>(new Set());
+
+  ngOnChanges(changes: SimpleChanges) {
+    if ('value' in changes || 'label' in changes) {
+      this.rootNode = this.buildNode(this.value, {
+        label: this.label,
+        path: 'root',
+      });
+      this.collapsedPaths.set(new Set());
+    }
+  }
+
+  protected toggleNode(node: JsonTreeNode) {
+    if (!node.children?.length) {
+      return;
+    }
+
+    this.collapsedPaths.update((paths) => {
+      const next = new Set(paths);
+      if (next.has(node.path)) {
+        next.delete(node.path);
+      } else {
+        next.add(node.path);
+      }
+      return next;
+    });
+  }
+
+  protected isCollapsed(node: JsonTreeNode): boolean {
+    return this.collapsedPaths().has(node.path);
+  }
+
+  protected trackByPath(_index: number, node: JsonTreeNode): string {
+    return node.path;
+  }
+
+  protected formatValue(value: unknown, type: JsonPrimitiveType): string {
+    if (type === 'string') {
+      return `"${String(value)}"`;
+    }
+
+    if (type === 'null') {
+      return 'null';
+    }
+
+    return String(value);
+  }
+
+  private buildNode(
+    value: unknown,
+    options: { label: string | null; path: string; isIndex?: boolean }
+  ): JsonTreeNode {
+    const { label, path, isIndex } = options;
+
+    if (Array.isArray(value)) {
+      return {
+        label: label ?? undefined,
+        kind: 'array',
+        path,
+        isIndex,
+        children: value.map((item, index) =>
+          this.buildNode(item, {
+            label: `[${index}]`,
+            path: this.joinPath(path, index.toString()),
+            isIndex: true,
+          })
+        ),
+      };
+    }
+
+    if (value !== null && typeof value === 'object') {
+      const entries = Object.entries(value as Record<string, unknown>);
+      return {
+        label: label ?? undefined,
+        kind: 'object',
+        path,
+        isIndex,
+        children: entries.map(([key, childValue]) =>
+          this.buildNode(childValue, {
+            label: key,
+            path: this.joinPath(path, this.escapePathSegment(key)),
+          })
+        ),
+      };
+    }
+
+    const valueType = this.resolveValueType(value);
+
+    return {
+      label: label ?? undefined,
+      kind: 'value',
+      path,
+      isIndex,
+      value,
+      valueType,
+    };
+  }
+
+  private resolveValueType(value: unknown): JsonPrimitiveType {
+    if (value === null) {
+      return 'null';
+    }
+
+    switch (typeof value) {
+      case 'string':
+        return 'string';
+      case 'number':
+        return 'number';
+      case 'boolean':
+        return 'boolean';
+      default:
+        return 'unknown';
+    }
+  }
+
+  private joinPath(parent: string, segment: string): string {
+    return parent ? `${parent}/${segment}` : segment;
+  }
+
+  private escapePathSegment(value: string): string {
+    return encodeURIComponent(value);
+  }
+}

--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -39,6 +39,8 @@
     "copyJson": "Copiar JSON",
     "importJson": "Importar JSON",
     "downloadJson": "Descarregar JSON",
+    "viewJsonTree": "Veure com arbre",
+    "viewJsonText": "Veure editor JSON",
     "downloadPdf": "Descarregar PDF",
     "toolbarAriaLabel": "Accions del PDF",
     "navigationGroup": "Navegació de pàgines",
@@ -51,6 +53,10 @@
     "importJsonFile": "Importa des d'un fitxer",
     "applyJson": "Aplica el JSON",
     "jsonPlaceholder": "Enganxa o edita aquí les coordenades de les anotacions...",
+    "jsonTree": {
+      "empty": "L'editor JSON és buit.",
+      "invalid": "El contingut no és un JSON vàlid. Corregeix els errors per veure l'arbre."
+    },
     "templates": {
       "title": "Plantilles reutilitzables",
       "placeholder": "Nom de la plantilla",

--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -41,6 +41,7 @@
     "downloadJson": "Descarregar JSON",
     "viewJsonTree": "Veure com arbre",
     "viewJsonText": "Veure editor JSON",
+    "jsonViewModeToggle": "Mode de visualització del JSON",
     "downloadPdf": "Descarregar PDF",
     "toolbarAriaLabel": "Accions del PDF",
     "navigationGroup": "Navegació de pàgines",

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -39,6 +39,8 @@
     "copyJson": "Copy JSON",
     "importJson": "Import JSON",
     "downloadJson": "Download JSON",
+    "viewJsonTree": "View tree",
+    "viewJsonText": "View JSON editor",
     "downloadPdf": "Download PDF",
     "toolbarAriaLabel": "PDF actions",
     "navigationGroup": "Page navigation",
@@ -51,6 +53,10 @@
     "importJsonFile": "Import from file",
     "applyJson": "Apply JSON",
     "jsonPlaceholder": "Paste or edit annotation coordinates here...",
+    "jsonTree": {
+      "empty": "The JSON editor is empty.",
+      "invalid": "The content is not valid JSON. Fix the errors to view the tree."
+    },
     "templates": {
       "title": "Reusable templates",
       "placeholder": "Template name",

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -41,6 +41,7 @@
     "downloadJson": "Download JSON",
     "viewJsonTree": "View tree",
     "viewJsonText": "View JSON editor",
+    "jsonViewModeToggle": "JSON view mode",
     "downloadPdf": "Download PDF",
     "toolbarAriaLabel": "PDF actions",
     "navigationGroup": "Page navigation",

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -39,6 +39,8 @@
     "copyJson": "Copiar JSON",
     "importJson": "Importar JSON",
     "downloadJson": "Descargar JSON",
+    "viewJsonTree": "Ver modo árbol",
+    "viewJsonText": "Volver al editor",
     "downloadPdf": "Descargar PDF",
     "toolbarAriaLabel": "Acciones del PDF",
     "navigationGroup": "Navegación de páginas",
@@ -51,6 +53,10 @@
     "importJsonFile": "Importar desde archivo",
     "applyJson": "Aplicar JSON",
     "jsonPlaceholder": "Pega o edita aquí las coordenadas de anotaciones...",
+    "jsonTree": {
+      "empty": "El editor JSON está vacío.",
+      "invalid": "El contenido no es un JSON válido. Corrige los errores para ver el árbol."
+    },
     "templates": {
       "title": "Plantillas reutilizables",
       "placeholder": "Nombre de la plantilla",

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -41,6 +41,7 @@
     "downloadJson": "Descargar JSON",
     "viewJsonTree": "Ver modo árbol",
     "viewJsonText": "Volver al editor",
+    "jsonViewModeToggle": "Modo de visualización del JSON",
     "downloadPdf": "Descargar PDF",
     "toolbarAriaLabel": "Acciones del PDF",
     "navigationGroup": "Navegación de páginas",

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -26,7 +26,7 @@ body {
     "header header"
     "sidebar viewer"
     "footer footer";
-  grid-template-columns: 400px 1fr;
+  grid-template-columns: minmax(360px, 33%) minmax(0, 1fr);
   grid-template-rows: auto 1fr auto;
   min-height: 100vh;
   gap: 12px;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -465,7 +465,7 @@ header .logo {
 
   .json-editor {
     width: 100%;
-    min-height: 220px;
+    min-height: clamp(280px, 45vh, 560px);
     border-radius: 8px;
     border: 1px solid #444;
     background: #1d1d2a;
@@ -485,7 +485,7 @@ header .logo {
   .json-tree-container,
   .json-tree-placeholder {
     width: 100%;
-    min-height: 220px;
+    min-height: clamp(280px, 45vh, 560px);
     border-radius: 8px;
     border: 1px solid #444;
     background: #1d1d2a;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -519,8 +519,54 @@ header .logo {
     gap: 8px;
   }
 
-  .json-toolbar__view-toggle {
+  .json-toolbar__view-toggle-group {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px;
     margin-right: auto;
+    border-radius: 999px;
+    border: 1px solid rgba(94, 234, 212, 0.22);
+    background: linear-gradient(135deg, rgba(32, 32, 52, 0.95), rgba(26, 26, 40, 0.85));
+    box-shadow: 0 12px 24px rgba(4, 6, 20, 0.45);
+  }
+
+  .json-toolbar__view-toggle-option {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 14px;
+    border: none;
+    border-radius: 999px;
+    background: transparent;
+    color: var(--muted);
+    font-weight: 600;
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .json-toolbar__view-toggle-option:hover,
+  .json-toolbar__view-toggle-option:focus-visible {
+    color: var(--accent);
+    background: rgba(94, 234, 212, 0.15);
+    outline: none;
+  }
+
+  .json-toolbar__view-toggle-option:focus-visible {
+    box-shadow: 0 0 0 2px rgba(94, 234, 212, 0.35);
+  }
+
+  .json-toolbar__view-toggle-option--active {
+    background: linear-gradient(135deg, rgba(94, 234, 212, 0.2), rgba(94, 234, 212, 0.05));
+    color: var(--accent);
+    box-shadow: 0 8px 18px rgba(94, 234, 212, 0.25);
+    transform: translateY(-1px);
+  }
+
+  .json-toolbar__view-toggle-icon {
+    font-size: 1rem;
+    line-height: 1;
   }
 
   .sidebar-hint {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -26,7 +26,7 @@ body {
     "header header"
     "sidebar viewer"
     "footer footer";
-  grid-template-columns: 320px 1fr;
+  grid-template-columns: 400px 1fr;
   grid-template-rows: auto 1fr auto;
   min-height: 100vh;
   gap: 12px;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -315,6 +315,18 @@ header .logo {
   background: rgba(255, 77, 77, 0.25);
 }
 
+.btn--ghost {
+  border-color: transparent;
+  background: transparent;
+  color: var(--muted);
+}
+
+.btn--ghost:hover:not(:disabled) {
+  border-color: transparent;
+  background: rgba(94, 234, 212, 0.12);
+  color: var(--accent);
+}
+
 @media (min-width: 960px) {
   header.header {
     grid-template-columns: 1fr;
@@ -470,11 +482,45 @@ header .logo {
     box-shadow: 0 0 0 2px rgba(94, 234, 212, 0.15);
   }
 
+  .json-tree-container,
+  .json-tree-placeholder {
+    width: 100%;
+    min-height: 220px;
+    border-radius: 8px;
+    border: 1px solid #444;
+    background: #1d1d2a;
+    padding: 10px;
+    font-family: 'Fira Code', monospace;
+    font-size: 0.85rem;
+  }
+
+  .json-tree-container {
+    overflow: auto;
+  }
+
+  .json-tree-placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--muted);
+    text-align: center;
+
+    p {
+      margin: 0;
+      line-height: 1.4;
+    }
+  }
+
   .json-toolbar {
     margin-top: 8px;
     display: flex;
     flex-wrap: wrap;
+    align-items: center;
     gap: 8px;
+  }
+
+  .json-toolbar__view-toggle {
+    margin-right: auto;
   }
 
   .sidebar-hint {


### PR DESCRIPTION
## Summary
- add a toggle in the sidebar to switch between the JSON text editor and a tree view of the parsed annotations
- implement a reusable JsonTreeComponent with collapsible nodes and styling consistent with the existing theme
- localize the new controls across supported languages and adjust sidebar styles for the new view mode

## Testing
- npm run build >/tmp/npm-build.log && tail -n 20 /tmp/npm-build.log

------
