### PR TITLE
OLD - Add advanced annotation typography controls

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -167,6 +167,44 @@
           <p class="templates__empty">{{ 'sidebar.templates.empty' | t }}</p>
         </ng-template>
       </section>
+      <section class="custom-fonts">
+        <h5>{{ 'fonts.custom.title' | t }}</h5>
+        <div class="custom-fonts__form">
+          <label>
+            <span>{{ 'fonts.custom.name' | t }}</span>
+            <input type="text" [(ngModel)]="customFontNameModel" [ngModelOptions]="{ standalone: true }"
+              [placeholder]="'fonts.custom.namePlaceholder' | t" />
+          </label>
+          <label>
+            <span>{{ 'fonts.custom.weight' | t }}</span>
+            <select [(ngModel)]="customFontWeightModel" [ngModelOptions]="{ standalone: true }">
+              <option *ngFor="let weight of fontWeightValues" [ngValue]="weight">
+                {{ getFontWeightLabel(weight) }}
+              </option>
+            </select>
+          </label>
+          <label>
+            <span>{{ 'fonts.custom.file' | t }}</span>
+            <input #customFontFileInput type="file" accept=".ttf,.otf,.woff,.woff2"
+              (change)="onCustomFontFileSelected($event)" />
+          </label>
+          <button type="button" class="btn" (click)="registerCustomFont()"
+            [disabled]="!canRegisterCustomFont()">
+            {{ 'fonts.custom.add' | t }}
+          </button>
+        </div>
+        <ul class="custom-fonts__list" *ngIf="customFonts().length; else emptyFonts">
+          <li *ngFor="let font of customFonts()">
+            <span>{{ font.family }} · {{ getFontWeightLabel(font.weight) }}</span>
+            <button type="button" class="btn btn--ghost" (click)="removeCustomFont(font.id)">
+              {{ 'fonts.custom.remove' | t }}
+            </button>
+          </li>
+        </ul>
+        <ng-template #emptyFonts>
+          <p class="custom-fonts__empty">{{ 'fonts.custom.empty' | t }}</p>
+        </ng-template>
+      </section>
       <textarea class="json-editor" [(ngModel)]="coordsTextModel" [placeholder]="'sidebar.jsonPlaceholder' | t"
         spellcheck="false"></textarea>
       <div class="json-toolbar">
@@ -220,6 +258,54 @@
             <span class="field-label">{{ 'annotation.fields.size.label' | t }}</span>
             <input type="number" [(ngModel)]="p.field.fontSize" min="8" max="72" />
           </label>
+          <label class="field">
+            <span class="field-label">{{ 'annotation.fields.font.label' | t }}</span>
+            <select [(ngModel)]="p.field.fontFamily">
+              <option *ngFor="let option of fontFamilyOptions()" [value]="option.value">
+                {{ option.label }}
+              </option>
+            </select>
+          </label>
+          <label class="field field-small">
+            <span class="field-label">{{ 'annotation.fields.weight.label' | t }}</span>
+            <select [(ngModel)]="p.field.fontWeight">
+              <option *ngFor="let option of getFontWeightOptions(p.field.fontFamily)" [ngValue]="option.value">
+                {{ option.label }}
+              </option>
+            </select>
+          </label>
+          <label class="field field-small">
+            <span class="field-label">{{ 'annotation.fields.align.label' | t }}</span>
+            <select [(ngModel)]="p.field.textAlign">
+              <option value="left">{{ 'annotation.fields.align.options.left' | t }}</option>
+              <option value="center">{{ 'annotation.fields.align.options.center' | t }}</option>
+              <option value="right">{{ 'annotation.fields.align.options.right' | t }}</option>
+            </select>
+          </label>
+          <label class="field field-small">
+            <span class="field-label">{{ 'annotation.fields.opacity.label' | t }}</span>
+            <input type="range" min="0" max="1" step="0.05" [ngModel]="p.field.opacity"
+              (ngModelChange)="p.field.opacity = +$event" />
+            <span class="field-hint">{{ p.field.opacity | number:'1.0-2' }}</span>
+          </label>
+          <div class="background-controls">
+            <label class="field field-small">
+              <span class="field-label">{{ 'annotation.fields.background.color' | t }}</span>
+              <input type="color" [ngModel]="p.field.backgroundColor ?? '#000000'"
+                (ngModelChange)="p.field.backgroundColor = $event" />
+            </label>
+            <label class="field field-small">
+              <span class="field-label">{{ 'annotation.fields.background.opacity' | t }}</span>
+              <input type="range" min="0" max="1" step="0.05" [disabled]="!p.field.backgroundColor"
+                [ngModel]="p.field.backgroundOpacity" (ngModelChange)="p.field.backgroundOpacity = +$event" />
+              <span class="field-hint">{{ p.field.backgroundOpacity | number:'1.0-2' }}</span>
+            </label>
+            <button type="button" class="btn btn--ghost"
+              (click)="p.field.backgroundColor = null; p.field.backgroundOpacity = 1"
+              [disabled]="!p.field.backgroundColor">
+              {{ 'annotation.fields.background.clear' | t }}
+            </button>
+          </div>
           <div class="color-section">
             <span class="field-label">{{ 'annotation.fields.color.label' | t }}</span>
             <div class="color-row">
@@ -275,6 +361,54 @@
             <span class="field-label">{{ 'annotation.fields.size.label' | t }}</span>
             <input type="number" [(ngModel)]="e.field.fontSize" min="8" max="72" />
           </label>
+          <label class="field">
+            <span class="field-label">{{ 'annotation.fields.font.label' | t }}</span>
+            <select [(ngModel)]="e.field.fontFamily">
+              <option *ngFor="let option of fontFamilyOptions()" [value]="option.value">
+                {{ option.label }}
+              </option>
+            </select>
+          </label>
+          <label class="field field-small">
+            <span class="field-label">{{ 'annotation.fields.weight.label' | t }}</span>
+            <select [(ngModel)]="e.field.fontWeight">
+              <option *ngFor="let option of getFontWeightOptions(e.field.fontFamily)" [ngValue]="option.value">
+                {{ option.label }}
+              </option>
+            </select>
+          </label>
+          <label class="field field-small">
+            <span class="field-label">{{ 'annotation.fields.align.label' | t }}</span>
+            <select [(ngModel)]="e.field.textAlign">
+              <option value="left">{{ 'annotation.fields.align.options.left' | t }}</option>
+              <option value="center">{{ 'annotation.fields.align.options.center' | t }}</option>
+              <option value="right">{{ 'annotation.fields.align.options.right' | t }}</option>
+            </select>
+          </label>
+          <label class="field field-small">
+            <span class="field-label">{{ 'annotation.fields.opacity.label' | t }}</span>
+            <input type="range" min="0" max="1" step="0.05" [ngModel]="e.field.opacity"
+              (ngModelChange)="e.field.opacity = +$event" />
+            <span class="field-hint">{{ e.field.opacity | number:'1.0-2' }}</span>
+          </label>
+          <div class="background-controls">
+            <label class="field field-small">
+              <span class="field-label">{{ 'annotation.fields.background.color' | t }}</span>
+              <input type="color" [ngModel]="e.field.backgroundColor ?? '#000000'"
+                (ngModelChange)="e.field.backgroundColor = $event" />
+            </label>
+            <label class="field field-small">
+              <span class="field-label">{{ 'annotation.fields.background.opacity' | t }}</span>
+              <input type="range" min="0" max="1" step="0.05" [disabled]="!e.field.backgroundColor"
+                [ngModel]="e.field.backgroundOpacity" (ngModelChange)="e.field.backgroundOpacity = +$event" />
+              <span class="field-hint">{{ e.field.backgroundOpacity | number:'1.0-2' }}</span>
+            </label>
+            <button type="button" class="btn btn--ghost"
+              (click)="e.field.backgroundColor = null; e.field.backgroundOpacity = 1"
+              [disabled]="!e.field.backgroundColor">
+              {{ 'annotation.fields.background.clear' | t }}
+            </button>
+          </div>
           <div class="color-section">
             <span class="field-label">{{ 'annotation.fields.color.label' | t }}</span>
             <div class="color-row">

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -22,6 +22,7 @@ import './array-buffer-transfer.polyfill';
 import { FieldType, PageAnnotations, PageField, TextAlign } from './models/annotation.model';
 import { AnnotationTemplatesService, AnnotationTemplate } from './annotation-templates.service';
 import { LanguageSelectorComponent } from './components/language-selector/language-selector.component';
+import { STANDARD_FONT_FAMILIES, StandardFontDefinition } from './fonts/standard-fonts';
 
 const PDF_WORKER_MODULE_SRC = '/assets/pdfjs/pdf.worker.entry.mjs';
 const PDF_WORKER_TYPE_MODULE = 'module';
@@ -71,18 +72,6 @@ type PreviewState = { page: number; field: PageField } | null;
 type EditState = { pageIndex: number; fieldIndex: number; field: PageField } | null;
 
 type FontVariantSource = 'standard' | 'custom';
-
-interface StandardFontVariant {
-  weight: number;
-  pdfName: string;
-}
-
-interface StandardFontDefinition {
-  id: string;
-  label: string;
-  cssStack: string;
-  variants: StandardFontVariant[];
-}
 
 interface CustomFontResource {
   id: string;
@@ -139,35 +128,7 @@ export class App implements AfterViewChecked, OnDestroy {
   readonly defaultTemplateId = this.templatesService.defaultTemplateId;
   templateNameModel = '';
   selectedTemplateId: string | null = null;
-  private readonly standardFontFamilies: StandardFontDefinition[] = [
-    {
-      id: 'Helvetica',
-      label: 'Helvetica',
-      cssStack: 'Helvetica, Arial, sans-serif',
-      variants: [
-        { weight: 400, pdfName: 'Helvetica' },
-        { weight: 700, pdfName: 'HelveticaBold' },
-      ],
-    },
-    {
-      id: 'TimesRoman',
-      label: 'Times New Roman',
-      cssStack: '"Times New Roman", Times, serif',
-      variants: [
-        { weight: 400, pdfName: 'TimesRoman' },
-        { weight: 700, pdfName: 'TimesBold' },
-      ],
-    },
-    {
-      id: 'Courier',
-      label: 'Courier',
-      cssStack: '"Courier New", Courier, monospace',
-      variants: [
-        { weight: 400, pdfName: 'Courier' },
-        { weight: 700, pdfName: 'CourierBold' },
-      ],
-    },
-  ];
+  private readonly standardFontFamilies: StandardFontDefinition[] = STANDARD_FONT_FAMILIES;
   private readonly customFontStore = new Map<string, CustomFontResource>();
   private readonly loadedFontFaces = new Set<string>();
   readonly customFonts = signal<CustomFontResource[]>([]);

--- a/src/app/fonts/standard-fonts.ts
+++ b/src/app/fonts/standard-fonts.ts
@@ -1,0 +1,41 @@
+export interface StandardFontVariant {
+  weight: number;
+  pdfName: string;
+}
+
+export interface StandardFontDefinition {
+  id: string;
+  label: string;
+  cssStack: string;
+  variants: StandardFontVariant[];
+}
+
+export const STANDARD_FONT_FAMILIES: StandardFontDefinition[] = [
+  {
+    id: 'Helvetica',
+    label: 'Helvetica',
+    cssStack: 'Helvetica, Arial, sans-serif',
+    variants: [
+      { weight: 400, pdfName: 'Helvetica' },
+      { weight: 700, pdfName: 'HelveticaBold' },
+    ],
+  },
+  {
+    id: 'TimesRoman',
+    label: 'Times New Roman',
+    cssStack: '"Times New Roman", Times, serif',
+    variants: [
+      { weight: 400, pdfName: 'TimesRoman' },
+      { weight: 700, pdfName: 'TimesBold' },
+    ],
+  },
+  {
+    id: 'Courier',
+    label: 'Courier',
+    cssStack: '"Courier New", Courier, monospace',
+    variants: [
+      { weight: 400, pdfName: 'Courier' },
+      { weight: 700, pdfName: 'CourierBold' },
+    ],
+  },
+];

--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -74,6 +74,37 @@
       "color": {
         "label": "Color"
       },
+      "font": {
+        "label": "Tipus de lletra"
+      },
+      "weight": {
+        "label": "Pes",
+        "options": {
+          "300": "Lleugera",
+          "400": "Regular",
+          "500": "Mitjana",
+          "600": "Seminegreta",
+          "700": "Negreta",
+          "800": "Extra negreta",
+          "900": "Ultra negreta"
+        }
+      },
+      "align": {
+        "label": "Alineació",
+        "options": {
+          "left": "Esquerra",
+          "center": "Centre",
+          "right": "Dreta"
+        }
+      },
+      "opacity": {
+        "label": "Opacitat"
+      },
+      "background": {
+        "color": "Color de fons",
+        "opacity": "Opacitat del fons",
+        "clear": "Eliminar fons"
+      },
       "type": {
         "label": "Tipus",
         "options": {
@@ -107,6 +138,18 @@
       "duplicate": "Duplicar anotació"
     },
     "editingBadge": "Editant"
+  },
+  "fonts": {
+    "custom": {
+      "title": "Fonts personalitzades",
+      "name": "Nom de la família",
+      "namePlaceholder": "Ex.: Corporate Sans",
+      "weight": "Pes",
+      "file": "Fitxer de font",
+      "add": "Afegir font",
+      "remove": "Eliminar",
+      "empty": "Encara no hi ha fonts personalitzades carregades."
+    }
   },
   "viewer": {
     "emptyMessage": "Puja un PDF i fes clic on vulguis afegir anotacions. Edita-les a la previsualització abans de confirmar ✅."

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -74,6 +74,37 @@
       "color": {
         "label": "Color"
       },
+      "font": {
+        "label": "Font"
+      },
+      "weight": {
+        "label": "Weight",
+        "options": {
+          "300": "Light",
+          "400": "Regular",
+          "500": "Medium",
+          "600": "Semi bold",
+          "700": "Bold",
+          "800": "Extra bold",
+          "900": "Black"
+        }
+      },
+      "align": {
+        "label": "Alignment",
+        "options": {
+          "left": "Left",
+          "center": "Center",
+          "right": "Right"
+        }
+      },
+      "opacity": {
+        "label": "Opacity"
+      },
+      "background": {
+        "color": "Background color",
+        "opacity": "Background opacity",
+        "clear": "Remove background"
+      },
       "type": {
         "label": "Type",
         "options": {
@@ -107,6 +138,18 @@
       "duplicate": "Duplicate annotation"
     },
     "editingBadge": "Editing"
+  },
+  "fonts": {
+    "custom": {
+      "title": "Custom fonts",
+      "name": "Family name",
+      "namePlaceholder": "e.g. Corporate Sans",
+      "weight": "Weight",
+      "file": "Font file",
+      "add": "Add font",
+      "remove": "Remove",
+      "empty": "No custom fonts loaded yet."
+    }
   },
   "viewer": {
     "emptyMessage": "Upload a PDF and click anywhere to add annotations. Edit them in the preview before confirming ✅."

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -74,6 +74,37 @@
       "color": {
         "label": "Color"
       },
+      "font": {
+        "label": "Fuente"
+      },
+      "weight": {
+        "label": "Peso",
+        "options": {
+          "300": "Ligera",
+          "400": "Normal",
+          "500": "Medio",
+          "600": "Seminegrita",
+          "700": "Negrita",
+          "800": "Extra negrita",
+          "900": "Ultra negrita"
+        }
+      },
+      "align": {
+        "label": "Alineación",
+        "options": {
+          "left": "Izquierda",
+          "center": "Centro",
+          "right": "Derecha"
+        }
+      },
+      "opacity": {
+        "label": "Opacidad"
+      },
+      "background": {
+        "color": "Color de fondo",
+        "opacity": "Opacidad de fondo",
+        "clear": "Quitar fondo"
+      },
       "type": {
         "label": "Tipo",
         "options": {
@@ -107,6 +138,18 @@
       "duplicate": "Duplicar anotación"
     },
     "editingBadge": "Editando"
+  },
+  "fonts": {
+    "custom": {
+      "title": "Fuentes personalizadas",
+      "name": "Nombre de la familia",
+      "namePlaceholder": "Ej.: Corporate Sans",
+      "weight": "Peso",
+      "file": "Archivo de fuente",
+      "add": "Añadir fuente",
+      "remove": "Eliminar",
+      "empty": "No hay fuentes personalizadas cargadas."
+    }
   },
   "viewer": {
     "emptyMessage": "Sube un PDF y haz click donde quieras añadir anotaciones. Edítalas en la vista previa antes de confirmar ✅."

--- a/src/app/models/annotation.model.ts
+++ b/src/app/models/annotation.model.ts
@@ -1,5 +1,7 @@
 export type FieldType = 'text' | 'check' | 'radio' | 'number';
 
+export type TextAlign = 'left' | 'center' | 'right';
+
 export interface PageField {
   x: number;
   y: number;
@@ -10,6 +12,12 @@ export interface PageField {
   value?: string;
   appender?: string;
   decimals?: number | null;
+  fontFamily?: string;
+  fontWeight?: number;
+  textAlign?: TextAlign;
+  opacity?: number;
+  backgroundColor?: string | null;
+  backgroundOpacity?: number | null;
 }
 
 export interface PageAnnotations {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -304,6 +304,17 @@ header .logo {
   padding-inline: 14px;
 }
 
+.btn--ghost {
+  border-color: rgba(94, 234, 212, 0.2);
+  background: transparent;
+  color: var(--accent);
+}
+
+.btn--ghost:hover:not(:disabled) {
+  border-color: rgba(94, 234, 212, 0.45);
+  background: rgba(94, 234, 212, 0.08);
+}
+
 .btn--danger {
   border-color: rgba(255, 77, 77, 0.4);
   background: rgba(255, 77, 77, 0.15);
@@ -556,6 +567,71 @@ header .logo {
       color: var(--muted);
     }
   }
+
+  .custom-fonts {
+    margin-top: 16px;
+    padding-top: 12px;
+    border-top: 1px solid #3a3a4f;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+
+    h5 {
+      margin: 0;
+      font-size: 1rem;
+      color: var(--text);
+    }
+
+    &__form {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+
+      label {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        font-size: 0.8rem;
+        color: var(--muted);
+      }
+
+      input,
+      select {
+        border: 1px solid #3a3a4f;
+        border-radius: 6px;
+        padding: 6px 8px;
+        background: #1d1d2a;
+        color: var(--text);
+        font-size: 0.85rem;
+      }
+    }
+
+    &__list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+
+      li {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 8px;
+        padding: 6px 10px;
+        border: 1px solid #34364d;
+        border-radius: 8px;
+        background: rgba(30, 30, 47, 0.6);
+        font-size: 0.85rem;
+      }
+    }
+
+    &__empty {
+      font-size: 0.8rem;
+      color: var(--muted);
+    }
+  }
 }
 
 .templates__delete {
@@ -779,6 +855,27 @@ header .logo {
     text-transform: uppercase;
     letter-spacing: .05em;
     color: var(--accent);
+  }
+
+  .field-hint {
+    font-size: 0.7rem;
+    color: var(--muted);
+  }
+
+  .background-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: flex-end;
+  }
+
+  .background-controls .field {
+    flex: 1 1 150px;
+  }
+
+  .background-controls .btn {
+    height: 36px;
+    padding-inline: 12px;
   }
 
   .color-section {


### PR DESCRIPTION
## Summary
- add font family, weight, alignment, opacity, and background styling options to annotation editors
- support registering custom fonts and embed font/background styling in the exported PDF
- update styles and translations to cover the new typography controls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690465861260832597eeae395b239414