### PR TITLE
Keep advanced options dropdown open when disabling guides

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -285,9 +285,7 @@ export class App implements AfterViewChecked, OnDestroy {
     this.guidesFeatureEnabled.set(enabled);
     if (enabled) {
       this.advancedOptionsOpen.set(true);
-    }
-    if (!enabled) {
-      this.advancedOptionsOpen.set(false);
+    } else {
       this.overlayDragRect = null;
       this.overlayGuides = [];
       this.refreshOverlay(null, []);


### PR DESCRIPTION
## Summary
- keep the advanced options section expanded after toggling off guides and snapping
- retain the overlay cleanup when the guides feature is disabled

## Testing
- not run (not requested)

------
