### PR TITLE
Add catalog of field presets with mask and helper defaults

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -337,16 +337,34 @@
           </label>
           <label class="field">
             <span class="field-label">{{ 'annotation.fields.type.label' | t }}</span>
-            <select [(ngModel)]="p.field.type">
+            <select [(ngModel)]="p.field.type" (ngModelChange)="onFieldTypeChange('preview', $event)">
               <option value="text">{{ 'annotation.fields.type.options.text' | t }}</option>
               <option value="check">{{ 'annotation.fields.type.options.check' | t }}</option>
               <option value="radio">{{ 'annotation.fields.type.options.radio' | t }}</option>
               <option value="number">{{ 'annotation.fields.type.options.number' | t }}</option>
             </select>
           </label>
+          <label class="field" *ngIf="showPresetSelector(p.field.type)">
+            <span class="field-label">{{ 'annotation.fields.preset.label' | t }}</span>
+            <select [(ngModel)]="p.field.presetId" (ngModelChange)="onPresetChange('preview', $event)">
+              <option [ngValue]="null">{{ 'annotation.fields.preset.custom' | t }}</option>
+              <option *ngFor="let preset of getPresetsForType(p.field.type)" [ngValue]="preset.id">
+                {{ preset.labelKey | t }}
+              </option>
+            </select>
+          </label>
+          <small class="field-hint"
+            *ngIf="getPresetDescriptionKey(p.field.type, p.field.presetId) as presetDescription">
+            {{ presetDescription | t }}
+          </small>
           <label class="field">
             <span class="field-label">{{ 'annotation.fields.value.label' | t }}</span>
             <input type="text" [(ngModel)]="p.field.value" [placeholder]="'annotation.fields.value.placeholder' | t" />
+          </label>
+          <label class="field" *ngIf="p.field.type === 'text' || p.field.type === 'number'">
+            <span class="field-label">{{ 'annotation.fields.mask.label' | t }}</span>
+            <input type="text" [(ngModel)]="p.field.mask"
+              [placeholder]="'annotation.fields.mask.placeholder' | t" />
           </label>
           <label class="field field-small" *ngIf="p.field.type === 'number'">
             <span class="field-label">{{ 'annotation.fields.number.decimals.label' | t }}</span>
@@ -356,6 +374,11 @@
             <span class="field-label">{{ 'annotation.fields.number.appender.label' | t }}</span>
             <input type="text" [(ngModel)]="p.field.appender"
               [placeholder]="'annotation.fields.number.appender.placeholder' | t" />
+          </label>
+          <label class="field">
+            <span class="field-label">{{ 'annotation.fields.helperText.label' | t }}</span>
+            <input type="text" [(ngModel)]="p.field.helperText"
+              [placeholder]="'annotation.fields.helperText.placeholder' | t" />
           </label>
           <label class="field field-small">
             <span class="field-label">{{ 'annotation.fields.size.label' | t }}</span>
@@ -392,16 +415,34 @@
           </label>
           <label class="field">
             <span class="field-label">{{ 'annotation.fields.type.label' | t }}</span>
-            <select [(ngModel)]="e.field.type">
+            <select [(ngModel)]="e.field.type" (ngModelChange)="onFieldTypeChange('edit', $event)">
               <option value="text">{{ 'annotation.fields.type.options.text' | t }}</option>
               <option value="check">{{ 'annotation.fields.type.options.check' | t }}</option>
               <option value="radio">{{ 'annotation.fields.type.options.radio' | t }}</option>
               <option value="number">{{ 'annotation.fields.type.options.number' | t }}</option>
             </select>
           </label>
+          <label class="field" *ngIf="showPresetSelector(e.field.type)">
+            <span class="field-label">{{ 'annotation.fields.preset.label' | t }}</span>
+            <select [(ngModel)]="e.field.presetId" (ngModelChange)="onPresetChange('edit', $event)">
+              <option [ngValue]="null">{{ 'annotation.fields.preset.custom' | t }}</option>
+              <option *ngFor="let preset of getPresetsForType(e.field.type)" [ngValue]="preset.id">
+                {{ preset.labelKey | t }}
+              </option>
+            </select>
+          </label>
+          <small class="field-hint"
+            *ngIf="getPresetDescriptionKey(e.field.type, e.field.presetId) as editPresetDescription">
+            {{ editPresetDescription | t }}
+          </small>
           <label class="field">
             <span class="field-label">{{ 'annotation.fields.value.label' | t }}</span>
             <input type="text" [(ngModel)]="e.field.value" [placeholder]="'annotation.fields.value.placeholder' | t" />
+          </label>
+          <label class="field" *ngIf="e.field.type === 'text' || e.field.type === 'number'">
+            <span class="field-label">{{ 'annotation.fields.mask.label' | t }}</span>
+            <input type="text" [(ngModel)]="e.field.mask"
+              [placeholder]="'annotation.fields.mask.placeholder' | t" />
           </label>
           <label class="field field-small" *ngIf="e.field.type === 'number'">
             <span class="field-label">{{ 'annotation.fields.number.decimals.label' | t }}</span>
@@ -411,6 +452,11 @@
             <span class="field-label">{{ 'annotation.fields.number.appender.label' | t }}</span>
             <input type="text" [(ngModel)]="e.field.appender"
               [placeholder]="'annotation.fields.number.appender.placeholder' | t" />
+          </label>
+          <label class="field">
+            <span class="field-label">{{ 'annotation.fields.helperText.label' | t }}</span>
+            <input type="text" [(ngModel)]="e.field.helperText"
+              [placeholder]="'annotation.fields.helperText.placeholder' | t" />
           </label>
           <label class="field field-small">
             <span class="field-label">{{ 'annotation.fields.size.label' | t }}</span>

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -7,3 +7,10 @@
 .preview span {
   pointer-events: none;
 }
+
+.field-hint {
+  display: block;
+  margin: 0.25rem 0 0.5rem;
+  font-size: 0.75rem;
+  color: #4b5563;
+}

--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -125,6 +125,18 @@
         "label": "Valor fix",
         "placeholder": "Valor opcional..."
       },
+      "preset": {
+        "label": "Preset",
+        "custom": "Personalitzat"
+      },
+      "mask": {
+        "label": "Màscara",
+        "placeholder": "Ex.: ###-### o patró RegExp"
+      },
+      "helperText": {
+        "label": "Text d'ajuda",
+        "placeholder": "Instruccions visibles a les teves integracions..."
+      },
       "number": {
         "decimals": {
           "label": "Decimals"
@@ -145,6 +157,60 @@
       "duplicate": "Duplicar anotació"
     },
     "editingBadge": "Editant"
+  },
+  "presets": {
+    "text": {
+      "basic": {
+        "label": "Text lliure",
+        "description": "Camp sense restriccions. Ideal per a etiquetes o anotacions genèriques."
+      },
+      "email": {
+        "label": "Correu electrònic",
+        "description": "Aplica una màscara compatible amb adreces de correu.",
+        "helper": "Exemple vàlid: usuari@domini.com"
+      },
+      "phone": {
+        "label": "Telèfon",
+        "description": "Reserva espai per números internacionals amb prefix.",
+        "helper": "Format recomanat: +34 600 000 000"
+      }
+    },
+    "check": {
+      "basic": {
+        "label": "Casella marcada",
+        "description": "Casella amb marca per a passos completats.",
+        "helper": "Fes-la servir per checklists confirmats."
+      },
+      "empty": {
+        "label": "Casella buida",
+        "description": "Casella sense marcar, llesta per reutilitzar.",
+        "helper": "Perfecta per plantilles repetibles."
+      }
+    },
+    "radio": {
+      "basic": {
+        "label": "Opció seleccionada",
+        "description": "Botó d'opció marcat per respostes actives.",
+        "helper": "Indica l'opció predeterminada del grup."
+      },
+      "empty": {
+        "label": "Opció sense seleccionar",
+        "description": "Botó d'opció buit per eleccions pendents.",
+        "helper": "Per grups de radio sense resposta."
+      }
+    },
+    "number": {
+      "integer": {
+        "label": "Nombre enter",
+        "description": "Restringeix el camp a valors sense decimals.",
+        "helper": "Introdueix només enters positius o negatius."
+      },
+      "currency": {
+        "label": "Import monetari",
+        "description": "Dos decimals i sufix de moneda preparats per imports.",
+        "helper": "Canvia el símbol si necessites una altra divisa."
+      }
+    }
   },
   "viewer": {
     "emptyMessage": "Puja un PDF i fes clic on vulguis afegir anotacions. Edita-les a la previsualització abans de confirmar ✅."

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -125,6 +125,18 @@
         "label": "Value override",
         "placeholder": "Optional fixed value..."
       },
+      "preset": {
+        "label": "Preset",
+        "custom": "Custom"
+      },
+      "mask": {
+        "label": "Mask",
+        "placeholder": "e.g. ###-### or RegExp pattern"
+      },
+      "helperText": {
+        "label": "Helper text",
+        "placeholder": "Guidance shown across your integrations..."
+      },
       "number": {
         "decimals": {
           "label": "Decimals"
@@ -145,6 +157,60 @@
       "duplicate": "Duplicate annotation"
     },
     "editingBadge": "Editing"
+  },
+  "presets": {
+    "text": {
+      "basic": {
+        "label": "Free text",
+        "description": "Plain field without constraints. Perfect for notes or labels."
+      },
+      "email": {
+        "label": "Email",
+        "description": "Applies a mask that matches email addresses.",
+        "helper": "Valid sample: user@example.com"
+      },
+      "phone": {
+        "label": "Phone number",
+        "description": "Prepares the field for international phone formats.",
+        "helper": "Suggested format: +1 555 000 0000"
+      }
+    },
+    "check": {
+      "basic": {
+        "label": "Checked box",
+        "description": "Checkbox with a mark for completed steps.",
+        "helper": "Use it for confirmed checklist items."
+      },
+      "empty": {
+        "label": "Empty box",
+        "description": "Blank checkbox ready for reusable lists.",
+        "helper": "Great when you need pending checklist slots."
+      }
+    },
+    "radio": {
+      "basic": {
+        "label": "Selected option",
+        "description": "Radio button rendered as active.",
+        "helper": "Highlights the default choice in single-select groups."
+      },
+      "empty": {
+        "label": "Unselected option",
+        "description": "Radio button without a mark.",
+        "helper": "Use when options start unchecked."
+      }
+    },
+    "number": {
+      "integer": {
+        "label": "Integer",
+        "description": "Restricts the field to whole numbers only.",
+        "helper": "Enter positive or negative integers without decimals."
+      },
+      "currency": {
+        "label": "Currency amount",
+        "description": "Two decimals and a currency suffix for amounts.",
+        "helper": "Adjust the symbol if you need a different currency."
+      }
+    }
   },
   "viewer": {
     "emptyMessage": "Upload a PDF and click anywhere to add annotations. Edit them in the preview before confirming ✅."

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -125,6 +125,18 @@
         "label": "Valor fijo",
         "placeholder": "Valor opcional..."
       },
+      "preset": {
+        "label": "Preset",
+        "custom": "Personalizado"
+      },
+      "mask": {
+        "label": "Máscara",
+        "placeholder": "Ej.: ###-### o patrón RegExp"
+      },
+      "helperText": {
+        "label": "Texto auxiliar",
+        "placeholder": "Instrucciones visibles en tus integraciones..."
+      },
       "number": {
         "decimals": {
           "label": "Decimales"
@@ -145,6 +157,60 @@
       "duplicate": "Duplicar anotación"
     },
     "editingBadge": "Editando"
+  },
+  "presets": {
+    "text": {
+      "basic": {
+        "label": "Texto libre",
+        "description": "Campo sin restricciones. Ideal para etiquetas o anotaciones genéricas."
+      },
+      "email": {
+        "label": "Correo electrónico",
+        "description": "Normaliza el campo con el patrón típico de email.",
+        "helper": "Ejemplo válido: usuario@dominio.com"
+      },
+      "phone": {
+        "label": "Teléfono",
+        "description": "Reserva espacio para teléfonos internacionales con prefijo.",
+        "helper": "Formato recomendado: +34 600 000 000"
+      }
+    },
+    "check": {
+      "basic": {
+        "label": "Casilla marcada",
+        "description": "Casilla con marca para listas de verificación confirmadas.",
+        "helper": "Úsala para pasos completados o estados activos."
+      },
+      "empty": {
+        "label": "Casilla vacía",
+        "description": "Casilla sin marcar, lista para checklists.",
+        "helper": "Perfecta para plantillas reutilizables."
+      }
+    },
+    "radio": {
+      "basic": {
+        "label": "Opción seleccionada",
+        "description": "Botón de opción marcado para respuestas activas.",
+        "helper": "Indica la opción preseleccionada en formularios."
+      },
+      "empty": {
+        "label": "Opción sin seleccionar",
+        "description": "Botón de opción vacío para listas de elección única.",
+        "helper": "Útil para grupos de radio pendientes de respuesta."
+      }
+    },
+    "number": {
+      "integer": {
+        "label": "Número entero",
+        "description": "Limita el campo a valores sin decimales.",
+        "helper": "Introduce solo enteros positivos o negativos."
+      },
+      "currency": {
+        "label": "Importe monetario",
+        "description": "Dos decimales y sufijo de moneda listos para importes.",
+        "helper": "Cambia el símbolo si necesitas otra divisa."
+      }
+    }
   },
   "viewer": {
     "emptyMessage": "Sube un PDF y haz click donde quieras añadir anotaciones. Edítalas en la vista previa antes de confirmar ✅."

--- a/src/app/models/annotation.model.ts
+++ b/src/app/models/annotation.model.ts
@@ -10,6 +10,9 @@ export interface PageField {
   value?: string;
   appender?: string;
   decimals?: number | null;
+  mask?: string | null;
+  helperText?: string | null;
+  presetId?: string | null;
 }
 
 export interface PageAnnotations {

--- a/src/app/models/field-presets.ts
+++ b/src/app/models/field-presets.ts
@@ -1,0 +1,140 @@
+import { FieldType, PageField } from './annotation.model';
+
+export type FieldPresetDefaults = Partial<Omit<PageField, 'x' | 'y' | 'type'>>;
+
+export interface FieldPreset {
+  id: string;
+  type: FieldType;
+  labelKey: string;
+  descriptionKey?: string;
+  defaults: FieldPresetDefaults;
+  helperTextKey?: string;
+  isDefault?: boolean;
+}
+
+const FIELD_PRESETS: readonly FieldPreset[] = [
+  {
+    id: 'text-basic',
+    type: 'text',
+    labelKey: 'annotation.presets.text.basic.label',
+    descriptionKey: 'annotation.presets.text.basic.description',
+    defaults: {
+      mask: null,
+    },
+    isDefault: true,
+  },
+  {
+    id: 'text-email',
+    type: 'text',
+    labelKey: 'annotation.presets.text.email.label',
+    descriptionKey: 'annotation.presets.text.email.description',
+    defaults: {
+      mask: '[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$',
+    },
+    helperTextKey: 'annotation.presets.text.email.helper',
+  },
+  {
+    id: 'text-phone',
+    type: 'text',
+    labelKey: 'annotation.presets.text.phone.label',
+    descriptionKey: 'annotation.presets.text.phone.description',
+    defaults: {
+      mask: '+## ### ### ###',
+    },
+    helperTextKey: 'annotation.presets.text.phone.helper',
+  },
+  {
+    id: 'check-basic',
+    type: 'check',
+    labelKey: 'annotation.presets.check.basic.label',
+    descriptionKey: 'annotation.presets.check.basic.description',
+    defaults: {
+      value: '☑',
+    },
+    helperTextKey: 'annotation.presets.check.basic.helper',
+    isDefault: true,
+  },
+  {
+    id: 'check-empty',
+    type: 'check',
+    labelKey: 'annotation.presets.check.empty.label',
+    descriptionKey: 'annotation.presets.check.empty.description',
+    defaults: {
+      value: '☐',
+    },
+    helperTextKey: 'annotation.presets.check.empty.helper',
+  },
+  {
+    id: 'radio-basic',
+    type: 'radio',
+    labelKey: 'annotation.presets.radio.basic.label',
+    descriptionKey: 'annotation.presets.radio.basic.description',
+    defaults: {
+      value: '◉',
+    },
+    helperTextKey: 'annotation.presets.radio.basic.helper',
+    isDefault: true,
+  },
+  {
+    id: 'radio-empty',
+    type: 'radio',
+    labelKey: 'annotation.presets.radio.empty.label',
+    descriptionKey: 'annotation.presets.radio.empty.description',
+    defaults: {
+      value: '◯',
+    },
+    helperTextKey: 'annotation.presets.radio.empty.helper',
+  },
+  {
+    id: 'number-integer',
+    type: 'number',
+    labelKey: 'annotation.presets.number.integer.label',
+    descriptionKey: 'annotation.presets.number.integer.description',
+    defaults: {
+      decimals: 0,
+      mask: '#####',
+    },
+    helperTextKey: 'annotation.presets.number.integer.helper',
+    isDefault: true,
+  },
+  {
+    id: 'number-currency',
+    type: 'number',
+    labelKey: 'annotation.presets.number.currency.label',
+    descriptionKey: 'annotation.presets.number.currency.description',
+    defaults: {
+      decimals: 2,
+      appender: '€',
+      mask: '###,###.##',
+    },
+    helperTextKey: 'annotation.presets.number.currency.helper',
+  },
+];
+
+const PRESETS_BY_TYPE: Record<FieldType, readonly FieldPreset[]> = {
+  text: FIELD_PRESETS.filter((preset) => preset.type === 'text'),
+  check: FIELD_PRESETS.filter((preset) => preset.type === 'check'),
+  radio: FIELD_PRESETS.filter((preset) => preset.type === 'radio'),
+  number: FIELD_PRESETS.filter((preset) => preset.type === 'number'),
+};
+
+export function getFieldPresets(type: FieldType): readonly FieldPreset[] {
+  return PRESETS_BY_TYPE[type] ?? [];
+}
+
+export function findFieldPreset(type: FieldType, presetId: string | null | undefined): FieldPreset | null {
+  if (!presetId) {
+    return null;
+  }
+  const presets = getFieldPresets(type);
+  return presets.find((preset) => preset.id === presetId) ?? null;
+}
+
+export function getDefaultFieldPreset(type: FieldType): FieldPreset | null {
+  const presets = getFieldPresets(type);
+  return presets.find((preset) => preset.isDefault) ?? presets[0] ?? null;
+}
+
+export function hasPresetsForType(type: FieldType): boolean {
+  return getFieldPresets(type).length > 0;
+}


### PR DESCRIPTION
## Summary
- add reusable field preset catalog with localized labels and descriptions
- extend annotation editor with preset picker, mask and helper text inputs
- persist new field metadata through storage/import flows

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69047ddcced88325a8783267bdbb8de8