### PR TITLE
Persist guide profiles with templates

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -24,6 +24,7 @@ import {
   DEFAULT_GUIDE_SETTINGS,
   GuideSettings,
   cloneGuideSettings,
+  differsFromDefaultGuideSettings,
 } from './models/guide-settings.model';
 import { LanguageSelectorComponent } from './components/language-selector/language-selector.component';
 import { JsonTreeComponent } from './components/json-tree/json-tree.component';
@@ -1969,6 +1970,9 @@ export class App implements AfterViewChecked, OnDestroy {
     this.snapPointsXText.set(nextGuideSettings.snapPointsX.join(', '));
     this.snapPointsYText.set(nextGuideSettings.snapPointsY.join(', '));
     this.guidesFeatureEnabled.set(template.guidesEnabled);
+    if (template.guidesEnabled || differsFromDefaultGuideSettings(nextGuideSettings)) {
+      this.advancedOptionsOpen.set(true);
+    }
     this.syncCoordsTextModel();
     this.preview.set(null);
     this.editing.set(null);

--- a/src/app/models/guide-settings.model.ts
+++ b/src/app/models/guide-settings.model.ts
@@ -37,3 +37,31 @@ export function cloneGuideSettings(settings: GuideSettings): GuideSettings {
     snapPointsY: [...settings.snapPointsY],
   };
 }
+
+function arraysEqual(a: readonly number[], b: readonly number[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  return a.every((value, index) => value === b[index]);
+}
+
+export function differsFromDefaultGuideSettings(settings: GuideSettings): boolean {
+  const defaults = DEFAULT_GUIDE_SETTINGS;
+
+  return (
+    settings.showGrid !== defaults.showGrid ||
+    settings.gridSize !== defaults.gridSize ||
+    settings.showRulers !== defaults.showRulers ||
+    settings.showAlignment !== defaults.showAlignment ||
+    settings.snapToGrid !== defaults.snapToGrid ||
+    settings.snapToMargins !== defaults.snapToMargins ||
+    settings.snapToCenters !== defaults.snapToCenters ||
+    settings.snapToCustom !== defaults.snapToCustom ||
+    settings.marginSize !== defaults.marginSize ||
+    settings.snapTolerance !== defaults.snapTolerance ||
+    settings.usePdfCoordinates !== defaults.usePdfCoordinates ||
+    !arraysEqual(settings.snapPointsX, defaults.snapPointsX) ||
+    !arraysEqual(settings.snapPointsY, defaults.snapPointsY)
+  );
+}

--- a/src/app/models/guide-settings.model.ts
+++ b/src/app/models/guide-settings.model.ts
@@ -1,0 +1,39 @@
+export interface GuideSettings {
+  showGrid: boolean;
+  gridSize: number;
+  showRulers: boolean;
+  showAlignment: boolean;
+  snapToGrid: boolean;
+  snapToMargins: boolean;
+  snapToCenters: boolean;
+  snapToCustom: boolean;
+  marginSize: number;
+  snapTolerance: number;
+  snapPointsX: readonly number[];
+  snapPointsY: readonly number[];
+  usePdfCoordinates: boolean;
+}
+
+export const DEFAULT_GUIDE_SETTINGS: GuideSettings = {
+  showGrid: true,
+  gridSize: 10,
+  showRulers: true,
+  showAlignment: true,
+  snapToGrid: true,
+  snapToMargins: true,
+  snapToCenters: true,
+  snapToCustom: false,
+  marginSize: 18,
+  snapTolerance: 8,
+  snapPointsX: [],
+  snapPointsY: [],
+  usePdfCoordinates: false,
+};
+
+export function cloneGuideSettings(settings: GuideSettings): GuideSettings {
+  return {
+    ...settings,
+    snapPointsX: [...settings.snapPointsX],
+    snapPointsY: [...settings.snapPointsY],
+  };
+}


### PR DESCRIPTION
## Summary
- add a shared guide settings model with defaults and cloning helpers
- persist guide preferences with annotation templates and restore them on load

## Testing
- npm run build

------
