### PR TITLE
feat: auto scroll JSON selection

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -168,12 +168,13 @@
         </ng-template>
       </section>
       <ng-container *ngIf="jsonViewMode() === 'text'; else jsonTreeView">
-        <textarea class="json-editor" [ngModel]="coordsTextModel" (ngModelChange)="onCoordsTextChange($event)"
-          [placeholder]="'sidebar.jsonPlaceholder' | t" spellcheck="false"></textarea>
+        <textarea #jsonEditor class="json-editor" [ngModel]="coordsTextModel"
+          (ngModelChange)="onCoordsTextChange($event)" [placeholder]="'sidebar.jsonPlaceholder' | t"
+          spellcheck="false"></textarea>
       </ng-container>
       <ng-template #jsonTreeView>
         <div *ngIf="jsonTreePreview.status === 'ready'; else jsonTreePlaceholder" class="json-tree-container">
-          <app-json-tree [value]="jsonTreePreview.value"></app-json-tree>
+          <app-json-tree #jsonTree [value]="jsonTreePreview.value"></app-json-tree>
         </div>
         <ng-template #jsonTreePlaceholder>
           <div class="json-tree-placeholder">

--- a/src/app/components/json-tree/json-tree.component.html
+++ b/src/app/components/json-tree/json-tree.component.html
@@ -8,7 +8,11 @@
     role="treeitem"
     [attr.aria-expanded]="node.children?.length ? !isCollapsed(node) : null"
   >
-    <div class="json-tree__row">
+    <div
+      class="json-tree__row"
+      [class.json-tree__row--focused]="isFocused(node)"
+      [attr.data-json-path]="node.path"
+    >
       <button
         *ngIf="node.children?.length"
         type="button"

--- a/src/app/components/json-tree/json-tree.component.scss
+++ b/src/app/components/json-tree/json-tree.component.scss
@@ -21,6 +21,14 @@
   align-items: center;
   gap: 6px;
   line-height: 1.6;
+  padding: 0 4px;
+  border-radius: 6px;
+  scroll-margin: 16px 0;
+  transition: background 0.2s ease;
+}
+
+.json-tree__row--focused {
+  background: rgba(94, 234, 212, 0.16);
 }
 
 .json-tree__toggle {


### PR DESCRIPTION
## Summary
- scroll the JSON editor to the annotation selected on the canvas and preserve the user's current focus
- focus and highlight the matching node when the tree view is active, expanding parent nodes automatically
- expose the necessary template references and styling hooks to support the focused state in the JSON tree

## Testing
- npm run build

------
