### PR TITLE
Improve font import compatibility and dropdown UX

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -424,7 +424,7 @@
               </button>
               <div class="font-dropdown__panel" *ngIf="fontDropdownOpen('preview')" role="listbox"
                 [attr.aria-labelledby]="'preview-font-label'">
-                <input type="search" class="font-dropdown__search"
+                <input #previewFontSearch type="search" class="font-dropdown__search"
                   [placeholder]="'annotation.fields.font.searchPlaceholder' | t"
                   [value]="fontSearchQuery('preview')"
                   (input)="onFontSearch('preview', $any($event.target).value)"
@@ -540,7 +540,7 @@
               </button>
               <div class="font-dropdown__panel" *ngIf="fontDropdownOpen('edit')" role="listbox"
                 [attr.aria-labelledby]="'edit-font-label'">
-                <input type="search" class="font-dropdown__search"
+                <input #editFontSearch type="search" class="font-dropdown__search"
                   [placeholder]="'annotation.fields.font.searchPlaceholder' | t"
                   [value]="fontSearchQuery('edit')"
                   (input)="onFontSearch('edit', $any($event.target).value)"


### PR DESCRIPTION
## Summary
- broaden font normalization to recognise additional JSON structures and CSS-style names when importing annotations
- automatically focus the font search field when opening the font dropdown in the create/edit annotation modals

## Testing
- npm run build

------
