### PR TITLE
Load fontkit via CDN at runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@angular/ssr": "^20.2.1",
     "@vercel/analytics": "^1.5.0",
     "@vercel/speed-insights": "^1.2.0",
+    "@pdf-lib/fontkit": "1.1.1",
     "express": "^5.1.0",
     "pdf-lib": "1.17.1",
     "pdfjs-dist": "5.4.296",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@angular/platform-server": "^20.2.0",
     "@angular/router": "^20.2.0",
     "@angular/ssr": "^20.2.1",
-    "@pdf-lib/fontkit": "^1.1.1",
     "@vercel/analytics": "^1.5.0",
     "@vercel/speed-insights": "^1.2.0",
     "express": "^5.1.0",

--- a/src/types/pdf-lib-fontkit.d.ts
+++ b/src/types/pdf-lib-fontkit.d.ts
@@ -1,7 +1,12 @@
 export {};
 
-declare global {
-  interface Window {
-    fontkit?: unknown;
-  }
+declare module '@pdf-lib/fontkit' {
+  export type PdfLibFontkit = {
+    create: (...args: unknown[]) => unknown;
+    logErrors: (enable?: boolean) => void;
+    registerFormat: (...args: unknown[]) => void;
+  };
+
+  const fontkit: PdfLibFontkit;
+  export default fontkit;
 }

--- a/src/types/pdf-lib-fontkit.d.ts
+++ b/src/types/pdf-lib-fontkit.d.ts
@@ -1,1 +1,7 @@
-declare module '@pdf-lib/fontkit';
+export {};
+
+declare global {
+  interface Window {
+    fontkit?: unknown;
+  }
+}


### PR DESCRIPTION
## Summary
- load fontkit lazily from the jsDelivr CDN and reuse the script element when embedding custom fonts
- add defensive handling for browsers/SSR and expose the global fontkit type so the compiler knows about it
- remove the unused npm dependency on @pdf-lib/fontkit to avoid failed module resolution during dev builds

## Testing
- npm run build

------

