### PR TITLE
Add highlight and underline annotation support

### DIFF
--- a/src/app/components/workspace/workspace.component.html
+++ b/src/app/components/workspace/workspace.component.html
@@ -330,14 +330,17 @@
           </label>
           <label class="field">
             <span class="field-label">{{ 'annotation.fields.type.label' | t }}</span>
-            <select [(ngModel)]="p.field.type">
+            <select [ngModel]="p.field.type"
+              (ngModelChange)="vm.onFieldTypeChange('preview', $event)">
               <option value="text">{{ 'annotation.fields.type.options.text' | t }}</option>
               <option value="check">{{ 'annotation.fields.type.options.check' | t }}</option>
               <option value="radio">{{ 'annotation.fields.type.options.radio' | t }}</option>
               <option value="number">{{ 'annotation.fields.type.options.number' | t }}</option>
+              <option value="highlight">{{ 'annotation.fields.type.options.highlight' | t }}</option>
+              <option value="underline">{{ 'annotation.fields.type.options.underline' | t }}</option>
             </select>
           </label>
-          <label class="field">
+          <label class="field" *ngIf="p.field.type !== 'highlight' && p.field.type !== 'underline'">
             <span class="field-label">{{ 'annotation.fields.value.label' | t }}</span>
             <input type="text" [(ngModel)]="p.field.value" [placeholder]="'annotation.fields.value.placeholder' | t" />
           </label>
@@ -350,6 +353,39 @@
             <input type="text" [(ngModel)]="p.field.appender"
               [placeholder]="'annotation.fields.number.appender.placeholder' | t" />
           </label>
+          <div class="field-row field-row--metrics" *ngIf="p.field.type === 'highlight'">
+            <label class="field field-small field-size">
+              <span class="field-label">{{ 'annotation.fields.shape.width.label' | t }}</span>
+              <input type="number" min="4" step="1"
+                [ngModel]="p.field.width ?? vm.defaultShapeWidth"
+                (ngModelChange)="vm.setFieldWidth('preview', $event)" />
+            </label>
+            <label class="field field-inline opacity-field field-opacity">
+              <span class="field-label">{{ 'annotation.fields.highlight.opacity.label' | t }}</span>
+              <div class="opacity-controls">
+                <input type="range" min="0" max="1" step="0.05"
+                  [ngModel]="p.field.backgroundOpacity ?? vm.defaultHighlightOpacity"
+                  (ngModelChange)="vm.setFieldBackgroundOpacity('preview', $event)" />
+                <input type="number" min="0" max="1" step="0.05"
+                  [ngModel]="p.field.backgroundOpacity ?? vm.defaultHighlightOpacity"
+                  (ngModelChange)="vm.setFieldBackgroundOpacity('preview', $event)" />
+              </div>
+            </label>
+          </div>
+          <div class="field-row field-row--metrics" *ngIf="p.field.type === 'underline'">
+            <label class="field field-small field-size">
+              <span class="field-label">{{ 'annotation.fields.shape.width.label' | t }}</span>
+              <input type="number" min="4" step="1"
+                [ngModel]="p.field.width ?? vm.defaultShapeWidth"
+                (ngModelChange)="vm.setFieldWidth('preview', $event)" />
+            </label>
+            <label class="field field-small field-size">
+              <span class="field-label">{{ 'annotation.fields.underline.thickness.label' | t }}</span>
+              <input type="number" min="0.25" step="0.25"
+                [ngModel]="p.field.strokeWidth ?? vm.defaultStrokeWidth"
+                (ngModelChange)="vm.setFieldStrokeWidth('preview', $event)" />
+            </label>
+          </div>
           <div class="field-row field-row--metrics">
             <label class="field field-small field-size">
               <span class="field-label">{{ 'annotation.fields.size.label' | t }}</span>
@@ -365,7 +401,8 @@
               </div>
             </label>
           </div>
-          <div class="field field-small font-field">
+          <div class="field field-small font-field"
+            *ngIf="p.field.type !== 'highlight' && p.field.type !== 'underline'">
             <span class="field-label" id="preview-font-label">{{ 'annotation.fields.font.label' | t }}</span>
             <div class="font-dropdown" #previewFontDropdown
               [class.font-dropdown--open]="vm.fontDropdownOpen('preview')">
@@ -405,7 +442,7 @@
               </div>
             </div>
           </div>
-          <div class="background-section">
+          <div class="background-section" *ngIf="p.field.type !== 'underline'">
             <span class="field-label">{{ 'annotation.fields.background.label' | t }}</span>
             <div class="background-row">
               <input type="color" [value]="p.field.backgroundColor ?? '#ffffff'"
@@ -415,7 +452,7 @@
               </button>
             </div>
           </div>
-          <div class="color-section">
+          <div class="color-section" *ngIf="p.field.type !== 'highlight'">
             <span class="field-label">{{ 'annotation.fields.color.label' | t }}</span>
             <div class="color-row">
               <input type="color" [(ngModel)]="p.field.color" (ngModelChange)="vm.onPreviewColorPicker($event)" />
@@ -426,7 +463,7 @@
                   [ngModelOptions]="{ standalone: true }" [placeholder]="'annotation.color.rgbPlaceholder' | t" />
               </div>
             </div>
-            <small class="color-hint">{{ 'annotation.color.hintPreview' | t }}</small>
+          <small class="color-hint">{{ 'annotation.color.hintPreview' | t }}</small>
           </div>
           <div class="editor-actions">
             <button class="action-primary" (click)="vm.confirmPreview()">✅</button>
@@ -446,14 +483,17 @@
           </label>
           <label class="field">
             <span class="field-label">{{ 'annotation.fields.type.label' | t }}</span>
-            <select [(ngModel)]="e.field.type">
+            <select [ngModel]="e.field.type"
+              (ngModelChange)="vm.onFieldTypeChange('edit', $event)">
               <option value="text">{{ 'annotation.fields.type.options.text' | t }}</option>
               <option value="check">{{ 'annotation.fields.type.options.check' | t }}</option>
               <option value="radio">{{ 'annotation.fields.type.options.radio' | t }}</option>
               <option value="number">{{ 'annotation.fields.type.options.number' | t }}</option>
+              <option value="highlight">{{ 'annotation.fields.type.options.highlight' | t }}</option>
+              <option value="underline">{{ 'annotation.fields.type.options.underline' | t }}</option>
             </select>
           </label>
-          <label class="field">
+          <label class="field" *ngIf="e.field.type !== 'highlight' && e.field.type !== 'underline'">
             <span class="field-label">{{ 'annotation.fields.value.label' | t }}</span>
             <input type="text" [(ngModel)]="e.field.value" [placeholder]="'annotation.fields.value.placeholder' | t" />
           </label>
@@ -466,6 +506,39 @@
             <input type="text" [(ngModel)]="e.field.appender"
               [placeholder]="'annotation.fields.number.appender.placeholder' | t" />
           </label>
+          <div class="field-row field-row--metrics" *ngIf="e.field.type === 'highlight'">
+            <label class="field field-small field-size">
+              <span class="field-label">{{ 'annotation.fields.shape.width.label' | t }}</span>
+              <input type="number" min="4" step="1"
+                [ngModel]="e.field.width ?? vm.defaultShapeWidth"
+                (ngModelChange)="vm.setFieldWidth('edit', $event)" />
+            </label>
+            <label class="field field-inline opacity-field field-opacity">
+              <span class="field-label">{{ 'annotation.fields.highlight.opacity.label' | t }}</span>
+              <div class="opacity-controls">
+                <input type="range" min="0" max="1" step="0.05"
+                  [ngModel]="e.field.backgroundOpacity ?? vm.defaultHighlightOpacity"
+                  (ngModelChange)="vm.setFieldBackgroundOpacity('edit', $event)" />
+                <input type="number" min="0" max="1" step="0.05"
+                  [ngModel]="e.field.backgroundOpacity ?? vm.defaultHighlightOpacity"
+                  (ngModelChange)="vm.setFieldBackgroundOpacity('edit', $event)" />
+              </div>
+            </label>
+          </div>
+          <div class="field-row field-row--metrics" *ngIf="e.field.type === 'underline'">
+            <label class="field field-small field-size">
+              <span class="field-label">{{ 'annotation.fields.shape.width.label' | t }}</span>
+              <input type="number" min="4" step="1"
+                [ngModel]="e.field.width ?? vm.defaultShapeWidth"
+                (ngModelChange)="vm.setFieldWidth('edit', $event)" />
+            </label>
+            <label class="field field-small field-size">
+              <span class="field-label">{{ 'annotation.fields.underline.thickness.label' | t }}</span>
+              <input type="number" min="0.25" step="0.25"
+                [ngModel]="e.field.strokeWidth ?? vm.defaultStrokeWidth"
+                (ngModelChange)="vm.setFieldStrokeWidth('edit', $event)" />
+            </label>
+          </div>
           <div class="field-row field-row--metrics">
             <label class="field field-small field-size">
               <span class="field-label">{{ 'annotation.fields.size.label' | t }}</span>
@@ -481,7 +554,8 @@
               </div>
             </label>
           </div>
-          <div class="field field-small font-field">
+          <div class="field field-small font-field"
+            *ngIf="e.field.type !== 'highlight' && e.field.type !== 'underline'">
             <span class="field-label" id="edit-font-label">{{ 'annotation.fields.font.label' | t }}</span>
             <div class="font-dropdown" #editFontDropdown
               [class.font-dropdown--open]="vm.fontDropdownOpen('edit')">
@@ -521,7 +595,7 @@
               </div>
             </div>
           </div>
-          <div class="background-section">
+          <div class="background-section" *ngIf="e.field.type !== 'underline'">
             <span class="field-label">{{ 'annotation.fields.background.label' | t }}</span>
             <div class="background-row">
               <input type="color" [value]="e.field.backgroundColor ?? '#ffffff'"
@@ -531,7 +605,7 @@
               </button>
             </div>
           </div>
-          <div class="color-section">
+          <div class="color-section" *ngIf="e.field.type !== 'highlight'">
             <span class="field-label">{{ 'annotation.fields.color.label' | t }}</span>
             <div class="color-row">
               <input type="color" [(ngModel)]="e.field.color" (ngModelChange)="vm.onEditColorPicker($event)" />
@@ -542,7 +616,7 @@
                   [ngModelOptions]="{ standalone: true }" [placeholder]="'annotation.color.rgbPlaceholder' | t" />
               </div>
             </div>
-            <small class="color-hint">{{ 'annotation.color.hintEdit' | t }}</small>
+          <small class="color-hint">{{ 'annotation.color.hintEdit' | t }}</small>
           </div>
           <div class="editor-actions">
             <button type="button" (click)="vm.duplicateAnnotation()" [title]="'annotation.actions.duplicate' | t"

--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -131,7 +131,9 @@
           "text": "Text",
           "check": "Casella",
           "radio": "Botó d'opció",
-          "number": "Nombre"
+          "number": "Nombre",
+          "highlight": "Ressaltat",
+          "underline": "Subratllat"
         }
       },
       "value": {
@@ -145,6 +147,21 @@
         "appender": {
           "label": "Sufix",
           "placeholder": "Ex.: %"
+        }
+      },
+      "shape": {
+        "width": {
+          "label": "Amplada (pt)"
+        }
+      },
+      "highlight": {
+        "opacity": {
+          "label": "Opacitat del fons"
+        }
+      },
+      "underline": {
+        "thickness": {
+          "label": "Gruix de línia (pt)"
         }
       }
     },

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -131,7 +131,9 @@
           "text": "Text",
           "check": "Checkbox",
           "radio": "Radio button",
-          "number": "Number"
+          "number": "Number",
+          "highlight": "Highlight",
+          "underline": "Underline"
         }
       },
       "value": {
@@ -145,6 +147,21 @@
         "appender": {
           "label": "Suffix",
           "placeholder": "E.g. %"
+        }
+      },
+      "shape": {
+        "width": {
+          "label": "Width (pt)"
+        }
+      },
+      "highlight": {
+        "opacity": {
+          "label": "Background opacity"
+        }
+      },
+      "underline": {
+        "thickness": {
+          "label": "Line thickness (pt)"
         }
       }
     },

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -131,7 +131,9 @@
           "text": "Texto",
           "check": "Casilla",
           "radio": "Botón de opción",
-          "number": "Número"
+          "number": "Número",
+          "highlight": "Resaltado",
+          "underline": "Subrayado"
         }
       },
       "value": {
@@ -145,6 +147,21 @@
         "appender": {
           "label": "Sufijo",
           "placeholder": "Ej.: %"
+        }
+      },
+      "shape": {
+        "width": {
+          "label": "Ancho (pt)"
+        }
+      },
+      "highlight": {
+        "opacity": {
+          "label": "Opacidad del fondo"
+        }
+      },
+      "underline": {
+        "thickness": {
+          "label": "Grosor de línea (pt)"
         }
       }
     },

--- a/src/app/models/annotation.model.ts
+++ b/src/app/models/annotation.model.ts
@@ -1,4 +1,4 @@
-export type FieldType = 'text' | 'check' | 'radio' | 'number';
+export type FieldType = 'text' | 'check' | 'radio' | 'number' | 'highlight' | 'underline';
 
 export interface PageField {
   x: number;
@@ -13,6 +13,9 @@ export interface PageField {
   fontFamily?: string;
   opacity?: number;
   backgroundColor?: string | null;
+  backgroundOpacity?: number;
+  strokeWidth?: number;
+  width?: number;
 }
 
 export interface PageAnnotations {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1116,6 +1116,16 @@ header .logo {
   outline: 1px solid transparent;
 }
 
+.annotation--highlight {
+  border-radius: 2px;
+}
+
+.annotation--underline {
+  border-radius: 0;
+  padding: 0;
+  background: transparent !important;
+}
+
 .annotation:hover {
   outline: 1px dashed var(--accent);
   background: rgba(94, 234, 212, 0.15);


### PR DESCRIPTION
## Summary
- extend annotation model types with highlight and underline metadata for width, stroke, and background opacity
- update workspace controls to configure new annotation shapes with conditional inputs and localization
- render highlight rectangles and underline strokes in the canvas preview and PDF export using pdf-lib helpers

## Testing
- npm run build

------
