### PR TITLE
Add page thumbnails sidebar

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1368,7 +1368,7 @@ export class App implements AfterViewChecked, OnDestroy {
       return 0.25;
     }
 
-    const targetWidth = 160;
+    const targetWidth = 120;
     const rawScale = targetWidth / pageWidth;
     return Math.min(1, Math.max(rawScale, 0.15));
   }

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1418,10 +1418,13 @@ export class App implements AfterViewChecked, OnDestroy {
 
         ctx.clearRect(0, 0, width, height);
 
-        await page.render({
-          canvasContext: ctx as unknown as CanvasRenderingContext2D,
-          viewport,
-        }).promise;
+        await page
+          .render({
+            canvasContext: ctx as unknown as CanvasRenderingContext2D,
+            canvas: null,
+            viewport,
+          })
+          .promise;
 
         const blob = await canvas.convertToBlob({ type: 'image/png' });
         const url = URL.createObjectURL(blob);

--- a/src/app/components/page-thumbnails/page-thumbnails.component.html
+++ b/src/app/components/page-thumbnails/page-thumbnails.component.html
@@ -7,8 +7,10 @@
     [class.thumbnails__item--active]="thumbnail.pageNumber === activePage"
     [attr.aria-current]="thumbnail.pageNumber === activePage ? 'page' : null"
     [attr.aria-label]="'sidebar.thumbnails.pageLabel' | t : { index: thumbnail.pageNumber }"
+    [attr.title]="'sidebar.thumbnails.pageLabel' | t : { index: thumbnail.pageNumber }"
     role="listitem"
   >
+    <span class="thumbnails__badge" aria-hidden="true">{{ thumbnail.pageNumber }}</span>
     <img
       class="thumbnails__image"
       [src]="thumbnail.imageUrl"
@@ -18,8 +20,5 @@
       loading="lazy"
       decoding="async"
     />
-    <span class="thumbnails__label">
-      {{ 'sidebar.thumbnails.pageLabel' | t : { index: thumbnail.pageNumber } }}
-    </span>
   </button>
 </div>

--- a/src/app/components/page-thumbnails/page-thumbnails.component.html
+++ b/src/app/components/page-thumbnails/page-thumbnails.component.html
@@ -1,0 +1,25 @@
+<div class="thumbnails" role="list">
+  <button
+    type="button"
+    class="thumbnails__item"
+    *ngFor="let thumbnail of thumbnails"
+    (click)="onSelect(thumbnail.pageNumber)"
+    [class.thumbnails__item--active]="thumbnail.pageNumber === activePage"
+    [attr.aria-current]="thumbnail.pageNumber === activePage ? 'page' : null"
+    [attr.aria-label]="'sidebar.thumbnails.pageLabel' | t : { index: thumbnail.pageNumber }"
+    role="listitem"
+  >
+    <img
+      class="thumbnails__image"
+      [src]="thumbnail.imageUrl"
+      [attr.alt]="'sidebar.thumbnails.pageLabel' | t : { index: thumbnail.pageNumber }"
+      [attr.width]="thumbnail.width"
+      [attr.height]="thumbnail.height"
+      loading="lazy"
+      decoding="async"
+    />
+    <span class="thumbnails__label">
+      {{ 'sidebar.thumbnails.pageLabel' | t : { index: thumbnail.pageNumber } }}
+    </span>
+  </button>
+</div>

--- a/src/app/components/page-thumbnails/page-thumbnails.component.scss
+++ b/src/app/components/page-thumbnails/page-thumbnails.component.scss
@@ -4,30 +4,31 @@
 
 .thumbnails {
   display: grid;
-  gap: 12px;
+  grid-template-columns: repeat(auto-fill, minmax(72px, 1fr));
+  gap: 10px;
+  align-content: start;
 }
 
 .thumbnails__item {
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  gap: 8px;
+  position: relative;
   width: 100%;
-  padding: 10px;
-  border-radius: 12px;
-  border: 1px solid rgba(94, 234, 212, 0.18);
-  background: rgba(32, 32, 48, 0.85);
+  padding: 4px;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  background: rgba(15, 18, 28, 0.6);
   color: inherit;
   cursor: pointer;
-  text-align: left;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .thumbnails__item:hover,
 .thumbnails__item:focus-visible {
-  border-color: rgba(94, 234, 212, 0.5);
-  background: rgba(42, 55, 68, 0.9);
-  box-shadow: 0 8px 24px rgba(5, 10, 20, 0.35);
+  border-color: rgba(94, 234, 212, 0.6);
+  background: rgba(28, 34, 48, 0.85);
+  box-shadow: 0 6px 18px rgba(5, 10, 20, 0.3);
   outline: none;
 }
 
@@ -37,27 +38,34 @@
   box-shadow: 0 0 0 1px rgba(94, 234, 212, 0.25);
 }
 
+.thumbnails__badge {
+  position: absolute;
+  inset: 6px auto auto 6px;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: rgba(15, 23, 42, 0.9);
+  color: var(--accent);
+  font-size: 0.7rem;
+  font-weight: 600;
+  box-shadow: 0 0 0 1px rgba(94, 234, 212, 0.4);
+}
+
 .thumbnails__image {
   display: block;
   width: 100%;
   height: auto;
-  border-radius: 8px;
-  background: #0b0b14;
+  border-radius: 6px;
+  background: #070915;
   box-shadow: inset 0 0 0 1px rgba(94, 234, 212, 0.08);
-}
-
-.thumbnails__label {
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: var(--muted);
 }
 
 @media (min-width: 1200px) {
   .thumbnails {
-    gap: 14px;
-  }
-
-  .thumbnails__item {
-    padding: 12px;
+    gap: 12px;
   }
 }

--- a/src/app/components/page-thumbnails/page-thumbnails.component.scss
+++ b/src/app/components/page-thumbnails/page-thumbnails.component.scss
@@ -1,0 +1,63 @@
+:host {
+  display: block;
+}
+
+.thumbnails {
+  display: grid;
+  gap: 12px;
+}
+
+.thumbnails__item {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
+  width: 100%;
+  padding: 10px;
+  border-radius: 12px;
+  border: 1px solid rgba(94, 234, 212, 0.18);
+  background: rgba(32, 32, 48, 0.85);
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.thumbnails__item:hover,
+.thumbnails__item:focus-visible {
+  border-color: rgba(94, 234, 212, 0.5);
+  background: rgba(42, 55, 68, 0.9);
+  box-shadow: 0 8px 24px rgba(5, 10, 20, 0.35);
+  outline: none;
+}
+
+.thumbnails__item--active {
+  border-color: var(--accent);
+  background: rgba(94, 234, 212, 0.12);
+  box-shadow: 0 0 0 1px rgba(94, 234, 212, 0.25);
+}
+
+.thumbnails__image {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: 8px;
+  background: #0b0b14;
+  box-shadow: inset 0 0 0 1px rgba(94, 234, 212, 0.08);
+}
+
+.thumbnails__label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+@media (min-width: 1200px) {
+  .thumbnails {
+    gap: 14px;
+  }
+
+  .thumbnails__item {
+    padding: 12px;
+  }
+}

--- a/src/app/components/page-thumbnails/page-thumbnails.component.ts
+++ b/src/app/components/page-thumbnails/page-thumbnails.component.ts
@@ -1,0 +1,28 @@
+import { CommonModule } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
+import { PageThumbnail } from '../../models/page-thumbnail.model';
+import { TranslationPipe } from '../../i18n/translation.pipe';
+
+@Component({
+  selector: 'app-page-thumbnails',
+  standalone: true,
+  imports: [CommonModule, TranslationPipe],
+  templateUrl: './page-thumbnails.component.html',
+  styleUrls: ['./page-thumbnails.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PageThumbnailsComponent {
+  @Input({ required: true }) thumbnails: readonly PageThumbnail[] = [];
+  @Input() activePage = 1;
+  @Output() pageSelected = new EventEmitter<number>();
+
+  onSelect(pageNumber: number) {
+    this.pageSelected.emit(pageNumber);
+  }
+}

--- a/src/app/components/workspace/workspace.component.html
+++ b/src/app/components/workspace/workspace.component.html
@@ -91,6 +91,16 @@
           {{ 'sidebar.applyJson' | t }}
         </button>
       </div>
+      <section class="sidebar-thumbnails" *ngIf="vm.pageThumbnails().length">
+        <h5 class="sidebar-thumbnails__title">{{ 'sidebar.thumbnails.title' | t }}</h5>
+        <div class="sidebar-thumbnails__list">
+          <app-page-thumbnails
+            [thumbnails]="vm.pageThumbnails()"
+            [activePage]="vm.pageIndex()"
+            (pageSelected)="vm.setPageIndex($event)"
+          ></app-page-thumbnails>
+        </div>
+      </section>
       <section class="templates">
         <h5>{{ 'sidebar.templates.title' | t }}</h5>
         <div class="templates__save">

--- a/src/app/components/workspace/workspace.component.scss
+++ b/src/app/components/workspace/workspace.component.scss
@@ -6,7 +6,7 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
-  margin-bottom: 16px;
+  margin: 18px 0;
 }
 
 .sidebar-thumbnails__title {
@@ -17,9 +17,12 @@
 }
 
 .sidebar-thumbnails__list {
-  max-height: clamp(200px, 35vh, 420px);
+  max-height: clamp(180px, 32vh, 360px);
   overflow-y: auto;
-  padding-right: 4px;
+  padding: 6px 4px 6px 0;
+  border-radius: 12px;
+  border: 1px solid rgba(94, 234, 212, 0.12);
+  background: rgba(11, 15, 24, 0.65);
   scroll-behavior: smooth;
 }
 
@@ -29,6 +32,6 @@
 
 @media (max-width: 1024px) {
   .sidebar-thumbnails__list {
-    max-height: clamp(160px, 30vh, 360px);
+    max-height: clamp(140px, 28vh, 300px);
   }
 }

--- a/src/app/components/workspace/workspace.component.scss
+++ b/src/app/components/workspace/workspace.component.scss
@@ -1,3 +1,34 @@
 :host {
   display: contents;
 }
+
+.sidebar-thumbnails {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.sidebar-thumbnails__title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.sidebar-thumbnails__list {
+  max-height: clamp(200px, 35vh, 420px);
+  overflow-y: auto;
+  padding-right: 4px;
+  scroll-behavior: smooth;
+}
+
+.sidebar-thumbnails__list app-page-thumbnails {
+  display: block;
+}
+
+@media (max-width: 1024px) {
+  .sidebar-thumbnails__list {
+    max-height: clamp(160px, 30vh, 360px);
+  }
+}

--- a/src/app/components/workspace/workspace.component.ts
+++ b/src/app/components/workspace/workspace.component.ts
@@ -5,13 +5,21 @@ import type { App } from '../../app';
 import { TranslationPipe } from '../../i18n/translation.pipe';
 import { LanguageSelectorComponent } from '../language-selector/language-selector.component';
 import { JsonTreeComponent } from '../json-tree/json-tree.component';
+import { PageThumbnailsComponent } from '../page-thumbnails/page-thumbnails.component';
 
 @Component({
   selector: 'app-workspace',
   standalone: true,
   templateUrl: './workspace.component.html',
   styleUrls: ['./workspace.component.scss'],
-  imports: [CommonModule, FormsModule, TranslationPipe, LanguageSelectorComponent, JsonTreeComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    TranslationPipe,
+    LanguageSelectorComponent,
+    JsonTreeComponent,
+    PageThumbnailsComponent,
+  ],
 })
 export class WorkspaceComponent {
   @Input({ required: true }) vm!: App;

--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -67,6 +67,10 @@
       "deleteButton": "Elimina",
       "empty": "Encara no tens cap plantilla desada."
     },
+    "thumbnails": {
+      "title": "Miniatures",
+      "pageLabel": "Pàgina {{index}}"
+    },
     "jsonHint": "Enganxa les coordenades o importa-les des d'un fitxer JSON amb el mateix format que l'exportat.",
     "advancedTitle": "Opcions avançades",
     "advancedHint": "Activa les guies i el snapping només quan necessitis més precisió."

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -67,6 +67,10 @@
       "deleteButton": "Delete",
       "empty": "You haven't saved any templates yet."
     },
+    "thumbnails": {
+      "title": "Thumbnails",
+      "pageLabel": "Page {{index}}"
+    },
     "jsonHint": "Paste coordinates or import them from a JSON file following the same format as the exported data.",
     "advancedTitle": "Advanced options",
     "advancedHint": "Toggle guides and snapping helpers when you need extra precision."

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -67,6 +67,10 @@
       "deleteButton": "Eliminar",
       "empty": "Aún no tienes plantillas guardadas."
     },
+    "thumbnails": {
+      "title": "Miniaturas",
+      "pageLabel": "Página {{index}}"
+    },
     "jsonHint": "Pega las coordenadas o impórtalas desde un JSON con el mismo formato que el archivo exportado.",
     "advancedTitle": "Opciones avanzadas",
     "advancedHint": "Activa las guías y el snapping solo cuando necesites más precisión."

--- a/src/app/models/page-thumbnail.model.ts
+++ b/src/app/models/page-thumbnail.model.ts
@@ -1,0 +1,6 @@
+export interface PageThumbnail {
+  readonly pageNumber: number;
+  readonly imageUrl: string;
+  readonly width: number;
+  readonly height: number;
+}


### PR DESCRIPTION
## Summary
- generate PDF page thumbnails with OffscreenCanvas and expose page selection through the App view model
- add a reusable page thumbnails component and render it inside the workspace sidebar with responsive styling
- localize thumbnail labels for all supported languages

## Testing
- npm run i18n:check

------
