### PR TITLE
Add support for locking and hiding annotations

### DIFF
--- a/src/app/components/workspace/workspace.component.html
+++ b/src/app/components/workspace/workspace.component.html
@@ -350,6 +350,19 @@
             <input type="text" [(ngModel)]="p.field.appender"
               [placeholder]="'annotation.fields.number.appender.placeholder' | t" />
           </label>
+          <div class="field field-toggle-group">
+            <span class="field-label">{{ 'annotation.fields.behavior.label' | t }}</span>
+            <div class="field-toggle-options">
+              <label class="field-toggle-option">
+                <input type="checkbox" [(ngModel)]="p.field.hidden" />
+                <span>{{ 'annotation.fields.behavior.hidden' | t }}</span>
+              </label>
+              <label class="field-toggle-option">
+                <input type="checkbox" [(ngModel)]="p.field.locked" />
+                <span>{{ 'annotation.fields.behavior.locked' | t }}</span>
+              </label>
+            </div>
+          </div>
           <div class="field-row field-row--metrics">
             <label class="field field-small field-size">
               <span class="field-label">{{ 'annotation.fields.size.label' | t }}</span>
@@ -466,6 +479,19 @@
             <input type="text" [(ngModel)]="e.field.appender"
               [placeholder]="'annotation.fields.number.appender.placeholder' | t" />
           </label>
+          <div class="field field-toggle-group">
+            <span class="field-label">{{ 'annotation.fields.behavior.label' | t }}</span>
+            <div class="field-toggle-options">
+              <label class="field-toggle-option">
+                <input type="checkbox" [(ngModel)]="e.field.hidden" />
+                <span>{{ 'annotation.fields.behavior.hidden' | t }}</span>
+              </label>
+              <label class="field-toggle-option">
+                <input type="checkbox" [(ngModel)]="e.field.locked" />
+                <span>{{ 'annotation.fields.behavior.locked' | t }}</span>
+              </label>
+            </div>
+          </div>
           <div class="field-row field-row--metrics">
             <label class="field field-small field-size">
               <span class="field-label">{{ 'annotation.fields.size.label' | t }}</span>

--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -136,12 +136,17 @@
       },
       "value": {
         "label": "Valor fix",
-        "placeholder": "Valor opcional..."
-      },
-      "number": {
-        "decimals": {
-          "label": "Decimals"
-        },
+    "placeholder": "Valor opcional..."
+  },
+  "behavior": {
+    "label": "Comportament",
+    "hidden": "Amaga al llenç",
+    "locked": "Bloqueja l'anotació"
+  },
+  "number": {
+    "decimals": {
+      "label": "Decimals"
+    },
         "appender": {
           "label": "Sufix",
           "placeholder": "Ex.: %"

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -136,12 +136,17 @@
       },
       "value": {
         "label": "Value override",
-        "placeholder": "Optional fixed value..."
-      },
-      "number": {
-        "decimals": {
-          "label": "Decimals"
-        },
+    "placeholder": "Optional fixed value..."
+  },
+  "behavior": {
+    "label": "Behavior",
+    "hidden": "Hide on canvas",
+    "locked": "Lock annotation"
+  },
+  "number": {
+    "decimals": {
+      "label": "Decimals"
+    },
         "appender": {
           "label": "Suffix",
           "placeholder": "E.g. %"

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -136,12 +136,17 @@
       },
       "value": {
         "label": "Valor fijo",
-        "placeholder": "Valor opcional..."
-      },
-      "number": {
-        "decimals": {
-          "label": "Decimales"
-        },
+    "placeholder": "Valor opcional..."
+  },
+  "behavior": {
+    "label": "Comportamiento",
+    "hidden": "Ocultar en el lienzo",
+    "locked": "Bloquear anotación"
+  },
+  "number": {
+    "decimals": {
+      "label": "Decimales"
+    },
         "appender": {
           "label": "Sufijo",
           "placeholder": "Ej.: %"

--- a/src/app/models/annotation.model.ts
+++ b/src/app/models/annotation.model.ts
@@ -13,6 +13,8 @@ export interface PageField {
   fontFamily?: string;
   opacity?: number;
   backgroundColor?: string | null;
+  locked?: boolean;
+  hidden?: boolean;
 }
 
 export interface PageAnnotations {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1125,6 +1125,16 @@ header .logo {
   cursor: grabbing;
 }
 
+.annotation--locked {
+  cursor: not-allowed;
+  outline: 1px solid rgba(148, 163, 184, 0.45);
+}
+
+.annotation--locked:hover {
+  outline-style: solid;
+  background: rgba(148, 163, 184, 0.18);
+}
+
 .annotation-editor {
   position: absolute;
   z-index: 20;
@@ -1249,6 +1259,29 @@ header .logo {
     text-transform: uppercase;
     letter-spacing: .05em;
     color: var(--accent);
+  }
+
+  .field-toggle-group {
+    gap: 6px;
+  }
+
+  .field-toggle-options {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+
+  .field-toggle-option {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: .85rem;
+  }
+
+  .field-toggle-option input[type='checkbox'] {
+    width: 16px;
+    height: 16px;
+    accent-color: var(--accent);
   }
 
   .font-dropdown {


### PR DESCRIPTION
## Summary
- add `locked` and `hidden` flags to page fields with normalized defaults in the app state
- expose lock/visibility toggles in the workspace editor and skip hidden annotations while styling locked ones
- update translations and styling to cover the new controls and locked annotation appearance

## Testing
- npm run i18n:check
- npm run build

------
