### PR TITLE
Add lock and hide controls for workspace annotations

### DIFF
--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -150,6 +150,14 @@
           "label": "Sufix",
           "placeholder": "Ex.: %"
         }
+      },
+      "locked": {
+        "label": "Bloqueja l'anotació",
+        "toggle": "Evita canvis i arrossegaments"
+      },
+      "hidden": {
+        "label": "Oculta l'anotació",
+        "toggle": "No mostrar en exportacions"
       }
     },
     "color": {

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -150,6 +150,14 @@
           "label": "Suffix",
           "placeholder": "E.g. %"
         }
+      },
+      "locked": {
+        "label": "Lock annotation",
+        "toggle": "Prevent edits and dragging"
+      },
+      "hidden": {
+        "label": "Hidden",
+        "toggle": "Hide when exporting"
       }
     },
     "color": {

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -150,6 +150,14 @@
           "label": "Sufijo",
           "placeholder": "Ej.: %"
         }
+      },
+      "locked": {
+        "label": "Bloquear anotación",
+        "toggle": "Evitar ediciones y arrastre"
+      },
+      "hidden": {
+        "label": "Ocultar anotación",
+        "toggle": "No mostrar al exportar"
       }
     },
     "color": {

--- a/src/app/models/annotation.model.ts
+++ b/src/app/models/annotation.model.ts
@@ -13,6 +13,8 @@ export interface PageField {
   fontFamily?: string;
   opacity?: number;
   backgroundColor?: string | null;
+  locked?: boolean;
+  hidden?: boolean;
 }
 
 export interface PageAnnotations {

--- a/src/app/pages/workspace/components/viewer/workspace-viewer.component.html
+++ b/src/app/pages/workspace/components/viewer/workspace-viewer.component.html
@@ -22,6 +22,22 @@
           <option value="number">{{ 'annotation.fields.type.options.number' | t }}</option>
         </select>
       </label>
+      <div class="field-row field-row--toggles">
+        <div class="field field-toggle">
+          <span class="field-label">{{ 'annotation.fields.locked.label' | t }}</span>
+          <label class="toggle-control">
+            <input type="checkbox" [(ngModel)]="p.field.locked" />
+            <span>{{ 'annotation.fields.locked.toggle' | t }}</span>
+          </label>
+        </div>
+        <div class="field field-toggle">
+          <span class="field-label">{{ 'annotation.fields.hidden.label' | t }}</span>
+          <label class="toggle-control">
+            <input type="checkbox" [(ngModel)]="p.field.hidden" />
+            <span>{{ 'annotation.fields.hidden.toggle' | t }}</span>
+          </label>
+        </div>
+      </div>
       <label class="field">
         <span class="field-label">{{ 'annotation.fields.value.label' | t }}</span>
         <input type="text" [(ngModel)]="p.field.value" [placeholder]="'annotation.fields.value.placeholder' | t" />
@@ -125,43 +141,62 @@
       <span class="editor-badge">{{ 'annotation.editingBadge' | t }}</span>
       <label class="field">
         <span class="field-label">{{ 'annotation.fields.text.label' | t }}</span>
-        <input type="text" [(ngModel)]="e.field.mapField"
+        <input type="text" [(ngModel)]="e.field.mapField" [disabled]="!!e.field.locked"
           [placeholder]="'annotation.fields.text.placeholder' | t" />
       </label>
       <label class="field">
         <span class="field-label">{{ 'annotation.fields.type.label' | t }}</span>
-        <select [(ngModel)]="e.field.type">
+        <select [(ngModel)]="e.field.type" [disabled]="!!e.field.locked">
           <option value="text">{{ 'annotation.fields.type.options.text' | t }}</option>
           <option value="check">{{ 'annotation.fields.type.options.check' | t }}</option>
           <option value="radio">{{ 'annotation.fields.type.options.radio' | t }}</option>
           <option value="number">{{ 'annotation.fields.type.options.number' | t }}</option>
         </select>
       </label>
+      <div class="field-row field-row--toggles">
+        <div class="field field-toggle">
+          <span class="field-label">{{ 'annotation.fields.locked.label' | t }}</span>
+          <label class="toggle-control">
+            <input type="checkbox" [(ngModel)]="e.field.locked" />
+            <span>{{ 'annotation.fields.locked.toggle' | t }}</span>
+          </label>
+        </div>
+        <div class="field field-toggle">
+          <span class="field-label">{{ 'annotation.fields.hidden.label' | t }}</span>
+          <label class="toggle-control">
+            <input type="checkbox" [(ngModel)]="e.field.hidden" [disabled]="!!e.field.locked" />
+            <span>{{ 'annotation.fields.hidden.toggle' | t }}</span>
+          </label>
+        </div>
+      </div>
       <label class="field">
         <span class="field-label">{{ 'annotation.fields.value.label' | t }}</span>
-        <input type="text" [(ngModel)]="e.field.value" [placeholder]="'annotation.fields.value.placeholder' | t" />
+        <input type="text" [(ngModel)]="e.field.value" [disabled]="!!e.field.locked"
+          [placeholder]="'annotation.fields.value.placeholder' | t" />
       </label>
       <label class="field field-small" *ngIf="e.field.type === 'number'">
         <span class="field-label">{{ 'annotation.fields.number.decimals.label' | t }}</span>
-        <input type="number" [(ngModel)]="e.field.decimals" min="0" />
+        <input type="number" [(ngModel)]="e.field.decimals" min="0" [disabled]="!!e.field.locked" />
       </label>
       <label class="field field-small" *ngIf="e.field.type === 'number'">
         <span class="field-label">{{ 'annotation.fields.number.appender.label' | t }}</span>
-        <input type="text" [(ngModel)]="e.field.appender"
+        <input type="text" [(ngModel)]="e.field.appender" [disabled]="!!e.field.locked"
           [placeholder]="'annotation.fields.number.appender.placeholder' | t" />
       </label>
       <div class="field-row field-row--metrics">
         <label class="field field-small field-size">
           <span class="field-label">{{ 'annotation.fields.size.label' | t }}</span>
-          <input type="number" [(ngModel)]="e.field.fontSize" min="8" max="72" />
+          <input type="number" [(ngModel)]="e.field.fontSize" min="8" max="72" [disabled]="!!e.field.locked" />
         </label>
         <label class="field field-inline opacity-field field-opacity">
           <span class="field-label">{{ 'annotation.fields.opacity.label' | t }}</span>
           <div class="opacity-controls">
             <input type="range" min="0.1" max="1" step="0.05"
-              [ngModel]="e.field.opacity ?? 1" (ngModelChange)="vm.setFieldOpacity('edit', $event)" />
+              [ngModel]="e.field.opacity ?? 1" (ngModelChange)="vm.setFieldOpacity('edit', $event)"
+              [disabled]="!!e.field.locked" />
             <input type="number" min="0.1" max="1" step="0.05"
-              [ngModel]="e.field.opacity ?? 1" (ngModelChange)="vm.setFieldOpacity('edit', $event)" />
+              [ngModel]="e.field.opacity ?? 1" (ngModelChange)="vm.setFieldOpacity('edit', $event)"
+              [disabled]="!!e.field.locked" />
           </div>
         </label>
       </div>
@@ -171,6 +206,7 @@
           [class.font-dropdown--open]="vm.fontDropdownOpen('edit')">
           <button type="button" class="font-dropdown__trigger" (click)="vm.toggleFontDropdown('edit')"
             aria-haspopup="listbox" [attr.aria-expanded]="vm.fontDropdownOpen('edit')"
+            [disabled]="!!e.field.locked"
             [attr.aria-labelledby]="'edit-font-label'">
             <ng-container *ngIf="vm.fontSummaryOption(e.field.fontFamily) as selectedFont">
               <span class="font-dropdown__value">{{ selectedFont.label }}</span>
@@ -209,8 +245,10 @@
         <span class="field-label">{{ 'annotation.fields.background.label' | t }}</span>
         <div class="background-row">
           <input type="color" [value]="e.field.backgroundColor ?? '#ffffff'"
-            (input)="vm.setFieldBackground('edit', $any($event.target).value)" />
-          <button type="button" class="background-clear" (click)="vm.clearFieldBackground('edit')">
+            (input)="vm.setFieldBackground('edit', $any($event.target).value)"
+            [disabled]="!!e.field.locked" />
+          <button type="button" class="background-clear" (click)="vm.clearFieldBackground('edit')"
+            [disabled]="!!e.field.locked">
             {{ 'annotation.fields.background.clear' | t }}
           </button>
         </div>
@@ -218,12 +256,15 @@
       <div class="color-section">
         <span class="field-label">{{ 'annotation.fields.color.label' | t }}</span>
         <div class="color-row">
-          <input type="color" [(ngModel)]="e.field.color" (ngModelChange)="vm.onEditColorPicker($event)" />
+          <input type="color" [(ngModel)]="e.field.color" (ngModelChange)="vm.onEditColorPicker($event)"
+            [disabled]="!!e.field.locked" />
           <div class="color-inputs">
             <input type="text" [ngModel]="vm.editHexInput()" (ngModelChange)="vm.setEditColorFromHex($event)"
-              [ngModelOptions]="{ standalone: true }" [placeholder]="'annotation.color.hexPlaceholder' | t" />
+              [ngModelOptions]="{ standalone: true }" [placeholder]="'annotation.color.hexPlaceholder' | t"
+              [disabled]="!!e.field.locked" />
             <input type="text" [ngModel]="vm.editRgbInput()" (ngModelChange)="vm.setEditColorFromRgb($event)"
-              [ngModelOptions]="{ standalone: true }" [placeholder]="'annotation.color.rgbPlaceholder' | t" />
+              [ngModelOptions]="{ standalone: true }" [placeholder]="'annotation.color.rgbPlaceholder' | t"
+              [disabled]="!!e.field.locked" />
           </div>
         </div>
         <small class="color-hint">{{ 'annotation.color.hintEdit' | t }}</small>

--- a/src/app/pages/workspace/workspace.page.ts
+++ b/src/app/pages/workspace/workspace.page.ts
@@ -3533,6 +3533,9 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
 
         for (const field of fields) {
           const styledField = this.ensureFieldStyle(field);
+          if (styledField.hidden) {
+            continue;
+          }
           const text = this.getFieldRenderValue(styledField);
           const fontOption = this.getFontOptionById(styledField.fontFamily ?? DEFAULT_FONT_ID);
           const embeddedFont = await getFontFromDescriptor(fontOption.descriptor);

--- a/src/app/pages/workspace/workspace.page.ts
+++ b/src/app/pages/workspace/workspace.page.ts
@@ -348,6 +348,12 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
   }
 
   setFieldFont(mode: EditorMode, fontId: string) {
+    if (mode === 'edit') {
+      const editState = this.editing();
+      if (editState?.field.locked) {
+        return;
+      }
+    }
     const normalized = this.normalizeFontFamily(fontId);
     this.updateWorkingField(mode, (field) =>
       this.ensureFieldStyle({ ...field, fontFamily: normalized })
@@ -360,6 +366,12 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
   }
 
   toggleFontDropdown(mode: EditorMode) {
+    if (mode === 'edit') {
+      const editState = this.editing();
+      if (editState?.field.locked) {
+        return;
+      }
+    }
     let opened = false;
     this.fontDropdownState.update((state) => {
       const nextOpen = !state[mode].open;
@@ -473,6 +485,12 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
   }
 
   setFieldOpacity(mode: EditorMode, value: string | number) {
+    if (mode === 'edit') {
+      const editState = this.editing();
+      if (editState?.field.locked) {
+        return;
+      }
+    }
     const normalized = this.normalizeOpacityValue(value);
     this.updateWorkingField(mode, (field) =>
       this.ensureFieldStyle({
@@ -485,6 +503,12 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
   }
 
   setFieldBackground(mode: EditorMode, value: string) {
+    if (mode === 'edit') {
+      const editState = this.editing();
+      if (editState?.field.locked) {
+        return;
+      }
+    }
     const normalized = this.normalizeBackgroundColor(value);
     if (!normalized) {
       this.clearFieldBackground(mode);
@@ -497,6 +521,12 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
   }
 
   clearFieldBackground(mode: EditorMode) {
+    if (mode === 'edit') {
+      const editState = this.editing();
+      if (editState?.field.locked) {
+        return;
+      }
+    }
     this.updateWorkingField(mode, (field) =>
       this.ensureFieldStyle({ ...field, backgroundColor: null })
     );
@@ -1465,6 +1495,8 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
       fontFamily: DEFAULT_FONT_ID,
       opacity: DEFAULT_OPACITY,
       backgroundColor: null,
+      locked: false,
+      hidden: false,
     };
     const styledField = this.ensureFieldStyle(baseField);
     this.preview.set({
@@ -1607,24 +1639,51 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
   }
 
   setEditColorFromHex(value: string) {
+    const editState = this.editing();
+    if (editState?.field.locked) {
+      return;
+    }
     this.editHexInput.set(value);
     const normalized = this.normalizeHexInput(value);
     if (!normalized) return;
-    this.editing.update((e) => (e ? { ...e, field: { ...e.field, color: normalized } } : e));
+    this.editing.update((e) => {
+      if (!e || e.field.locked) {
+        return e;
+      }
+      return { ...e, field: { ...e.field, color: normalized } };
+    });
     this.updateEditingColorState(normalized);
   }
 
   setEditColorFromRgb(value: string) {
+    const editState = this.editing();
+    if (editState?.field.locked) {
+      return;
+    }
     this.editRgbInput.set(value);
     const rgb = this.parseRgbText(value);
     if (!rgb) return;
     const hex = this.rgbToHex(rgb);
-    this.editing.update((e) => (e ? { ...e, field: { ...e.field, color: hex } } : e));
+    this.editing.update((e) => {
+      if (!e || e.field.locked) {
+        return e;
+      }
+      return { ...e, field: { ...e.field, color: hex } };
+    });
     this.updateEditingColorState(hex);
   }
 
   onEditColorPicker(value: string) {
-    this.editing.update((e) => (e ? { ...e, field: { ...e.field, color: value } } : e));
+    const editState = this.editing();
+    if (editState?.field.locked) {
+      return;
+    }
+    this.editing.update((e) => {
+      if (!e || e.field.locked) {
+        return e;
+      }
+      return { ...e, field: { ...e.field, color: value } };
+    });
     this.updateEditingColorState(value);
   }
 
@@ -1868,6 +1927,8 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
       fontFamily: styled.fontFamily ?? DEFAULT_FONT_ID,
       opacity: styled.opacity ?? DEFAULT_OPACITY,
       backgroundColor: styled.backgroundColor ?? null,
+      locked: !!styled.locked,
+      hidden: !!styled.hidden,
     };
 
     const value = this.sanitizeTextPreservingSpacing(styled.value);
@@ -1901,6 +1962,8 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
       value: typeof styled.value === 'string' ? styled.value : '',
       appender: typeof styled.appender === 'string' ? styled.appender : '',
       decimals,
+      locked: !!styled.locked,
+      hidden: !!styled.hidden,
     };
   }
 
@@ -1947,6 +2010,9 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
 
     this.editing.update((state) => {
       if (!state) {
+        return state;
+      }
+      if (mode === 'edit' && state.field.locked) {
         return state;
       }
       const nextField = mutator(state.field);
@@ -2306,6 +2372,8 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
     const fontFamily = this.normalizeFontFamily(field.fontFamily);
     const opacity = this.normalizeOpacityValue(field.opacity) ?? DEFAULT_OPACITY;
     const background = this.normalizeBackgroundColor(field.backgroundColor) ?? null;
+    const locked = !!field.locked;
+    const hidden = !!field.hidden;
     const legacyField = field as PageField & {
       fontWeight?: unknown;
       textAlign?: unknown;
@@ -2317,6 +2385,8 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
       field.fontFamily === fontFamily &&
       (field.opacity ?? DEFAULT_OPACITY) === opacity &&
       (field.backgroundColor ?? null) === background &&
+      (field.locked ?? false) === locked &&
+      (field.hidden ?? false) === hidden &&
       !hasLegacyWeight &&
       !hasLegacyAlign
     ) {
@@ -2330,6 +2400,8 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
       fontFamily,
       opacity,
       backgroundColor: background,
+      locked,
+      hidden,
     };
   }
 
@@ -2875,6 +2947,8 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
           const styledField = this.ensureFieldStyle(field);
           const left = styledField.x * scale;
           const top = pdfCanvas.height - styledField.y * scale;
+          const isLocked = styledField.locked ?? false;
+          const isHidden = styledField.hidden ?? false;
 
           const el = document.createElement('div');
           el.className = 'annotation';
@@ -2889,8 +2963,21 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
           el.style.opacity = `${styledField.opacity ?? DEFAULT_OPACITY}`;
           el.style.backgroundColor = styledField.backgroundColor ?? 'transparent';
           el.style.width = 'auto';
-
-          el.onpointerdown = (evt) => this.handleAnnotationPointerDown(evt, pageIndex, fieldIndex);
+          if (isLocked) {
+            el.dataset['locked'] = 'true';
+          } else {
+            delete el.dataset['locked'];
+          }
+          if (isHidden) {
+            el.dataset['hidden'] = 'true';
+          } else {
+            delete el.dataset['hidden'];
+          }
+          el.classList.toggle('annotation--locked', isLocked);
+          el.classList.toggle('annotation--hidden', isHidden);
+          el.onpointerdown = isLocked
+            ? (evt) => this.handleLockedAnnotationPointerDown(evt, pageIndex, fieldIndex)
+            : (evt) => this.handleAnnotationPointerDown(evt, pageIndex, fieldIndex);
           layer.appendChild(el);
 
           this.runAfterRender(() => this.updateAnnotationLeft(el, styledField, scale));
@@ -2898,6 +2985,21 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
       });
 
     this.refreshOverlay();
+  }
+
+  private handleLockedAnnotationPointerDown(
+    evt: PointerEvent,
+    pageIndex: number,
+    fieldIndex: number
+  ) {
+    evt.preventDefault();
+    evt.stopPropagation();
+    const page = this.coords()[pageIndex];
+    const field = page?.fields[fieldIndex];
+    if (!field) {
+      return;
+    }
+    this.startEditing(pageIndex, fieldIndex, field);
   }
 
   private handleAnnotationPointerDown(evt: PointerEvent, pageIndex: number, fieldIndex: number) {
@@ -2909,7 +3011,14 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
     const computedFontSize = parseFloat(getComputedStyle(el).fontSize || '0');
     const page = this.coords()[pageIndex];
     const field = page?.fields[fieldIndex];
-    const styledField = field ? this.ensureFieldStyle(field) : null;
+    if (!field || field.locked) {
+      return;
+    }
+    const styledField = this.ensureFieldStyle(field);
+    if (styledField?.locked) {
+      this.handleLockedAnnotationPointerDown(evt, pageIndex, fieldIndex);
+      return;
+    }
     this.dragInfo = {
       pageIndex,
       fieldIndex,
@@ -3060,7 +3169,9 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
     const scale = this.scale();
     const page = this.coords()[pageIndex];
     const field = page?.fields[fieldIndex];
-    const styledField = field ? this.ensureFieldStyle(field) : null;
+    if (!field || field.locked) {
+      return;
+    }
     const bounds = this.computeHorizontalBounds(widthPx, pdfCanvas.width);
     const boundedLeft = Math.min(Math.max(leftPx, bounds.minLeft), bounds.maxLeft);
     const boundedTop = Math.min(Math.max(topPx, -fontSizePx), pdfCanvas.height - fontSizePx);
@@ -3617,7 +3728,9 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
       (sanitizedA.decimals ?? undefined) === (sanitizedB.decimals ?? undefined) &&
       (sanitizedA.fontFamily ?? DEFAULT_FONT_ID) === (sanitizedB.fontFamily ?? DEFAULT_FONT_ID) &&
       (sanitizedA.opacity ?? DEFAULT_OPACITY) === (sanitizedB.opacity ?? DEFAULT_OPACITY) &&
-      (sanitizedA.backgroundColor ?? null) === (sanitizedB.backgroundColor ?? null)
+      (sanitizedA.backgroundColor ?? null) === (sanitizedB.backgroundColor ?? null) &&
+      (sanitizedA.locked ?? false) === (sanitizedB.locked ?? false) &&
+      (sanitizedA.hidden ?? false) === (sanitizedB.hidden ?? false)
     );
   }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1121,6 +1121,55 @@ header .logo {
   background: rgba(94, 234, 212, 0.15);
 }
 
+.annotation--locked {
+  cursor: pointer;
+  outline-color: rgba(94, 234, 212, 0.4);
+}
+
+.annotation--locked:hover {
+  background: rgba(94, 234, 212, 0.12);
+  outline-style: solid;
+}
+
+.annotation--hidden {
+  position: relative;
+  color: transparent !important;
+  outline: 1px dashed rgba(148, 163, 184, 0.6);
+  min-width: 18px;
+  min-height: 18px;
+}
+
+.annotation--hidden::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: repeating-linear-gradient(
+    135deg,
+    rgba(94, 234, 212, 0.2) 0,
+    rgba(94, 234, 212, 0.2) 8px,
+    transparent 8px,
+    transparent 16px
+  );
+  pointer-events: none;
+}
+
+.annotation--hidden::after {
+  content: '👁';
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: .9rem;
+  color: rgba(255, 255, 255, 0.85);
+  pointer-events: none;
+}
+
+.annotation--hidden.annotation--locked {
+  outline-style: dashed;
+}
+
 .annotation.dragging {
   cursor: grabbing;
 }
@@ -1220,6 +1269,42 @@ header .logo {
 
   .field-row .field {
     flex: 1 1 140px;
+  }
+
+  .field-row--toggles {
+    gap: 16px;
+  }
+
+  .field-toggle {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .field-row--toggles .field-toggle {
+    flex: 1 1 150px;
+  }
+
+  .toggle-control {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: .85rem;
+    color: var(--text);
+  }
+
+  .toggle-control input[type='checkbox'] {
+    width: 18px;
+    height: 18px;
+    accent-color: var(--accent);
+  }
+
+  .toggle-control span {
+    font-weight: 500;
+  }
+
+  .toggle-control input[disabled] + span {
+    opacity: .6;
   }
 
   .field-row--metrics .field-size {


### PR DESCRIPTION
## Summary
- add locked and hidden metadata to page fields with defaults when creating annotations
- expose lock/visibility toggles in the workspace editor and disable edits when fields are locked
- update annotation rendering, pointer handlers, styles, and translations to reflect locked/hidden states

## Testing
- npm run i18n:check

------
