### PR TITLE
Add cloud template sync and session-aware workspace UI

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -59,9 +59,15 @@
               ],
               "allowedCommonJsDependencies": [
                 "pako"
+              ],
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
               ]
             },
-            "pre": {
+            "test": {
               "optimization": true,
               "outputHashing": "all",
               "sourceMap": false,
@@ -81,7 +87,7 @@
               "fileReplacements": [
                 {
                   "replace": "src/environments/environment.ts",
-                  "with": "src/environments/environment.pre.ts"
+                  "with": "src/environments/environment.test.ts"
                 }
               ]
             },
@@ -101,12 +107,6 @@
               ],
               "allowedCommonJsDependencies": [
                 "pako"
-              ],
-              "fileReplacements": [
-                {
-                  "replace": "src/environments/environment.ts",
-                  "with": "src/environments/environment.development.ts"
-                }
               ]
             }
           },
@@ -118,8 +118,8 @@
             "production": {
               "buildTarget": "pdf-annotator:build:production"
             },
-            "pre": {
-              "buildTarget": "pdf-annotator:build:pre"
+            "test": {
+              "buildTarget": "pdf-annotator:build:test"
             },
             "development": {
               "buildTarget": "pdf-annotator:build:development"

--- a/angular.json
+++ b/angular.json
@@ -61,6 +61,30 @@
                 "pako"
               ]
             },
+            "pre": {
+              "optimization": true,
+              "outputHashing": "all",
+              "sourceMap": false,
+              "namedChunks": false,
+              "aot": true,
+              "extractLicenses": true,
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "2mb",
+                  "maximumError": "3mb"
+                }
+              ],
+              "allowedCommonJsDependencies": [
+                "pako"
+              ],
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.pre.ts"
+                }
+              ]
+            },
             "development": {
               "optimization": true,
               "outputHashing": "all",
@@ -77,6 +101,12 @@
               ],
               "allowedCommonJsDependencies": [
                 "pako"
+              ],
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.development.ts"
+                }
               ]
             }
           },
@@ -87,6 +117,9 @@
           "configurations": {
             "production": {
               "buildTarget": "pdf-annotator:build:production"
+            },
+            "pre": {
+              "buildTarget": "pdf-annotator:build:pre"
             },
             "development": {
               "buildTarget": "pdf-annotator:build:development"

--- a/docs/cloud-templates-api.md
+++ b/docs/cloud-templates-api.md
@@ -1,0 +1,306 @@
+# API REST de plantillas en la nube
+
+## Visión general
+
+- **Base URL**: `https://api.pdf-annotator.example.com/api/v1`
+- **Versionado**: todas las rutas se versionan con el prefijo `/v1`. Cambios incompatibles crearán nuevas versiones (`/v2`, `/v3`, ...).
+- **Formato**: JSON UTF-8. Las marcas de tiempo se serializan en ISO 8601 (`2025-01-10T12:00:00Z`).
+- **Autenticación**: Bearer JWT generado por el endpoint de sesión. Todos los endpoints protegidos exigen `Authorization: Bearer <token>`.
+- **Seguridad**: los tokens expiran en 15 minutos. Se entrega un `refreshToken` con caducidad de 30 días para renovar la sesión.
+
+## Autenticación
+
+### POST `/auth/sessions`
+
+Inicia una sesión de usuario.
+
+**Request**
+```json
+{
+  "email": "editor@acme.com",
+  "password": "StrongPassw0rd!",
+  "projectKey": "pdf-annotator"
+}
+```
+
+**Response** `201 Created`
+```json
+{
+  "accessToken": "jwt-access-token",
+  "refreshToken": "jwt-refresh-token",
+  "expiresIn": 900,
+  "user": {
+    "id": "usr_123",
+    "name": "Ana Campos",
+    "email": "editor@acme.com",
+    "avatarUrl": "https://cdn.example.com/avatars/usr_123.png"
+  },
+  "workspaces": [
+    {
+      "id": "wrk_001",
+      "name": "Demo",
+      "role": "editor"
+    }
+  ],
+  "defaultWorkspaceId": "wrk_001"
+}
+```
+
+### POST `/auth/refresh`
+
+Renueva el `accessToken` usando un `refreshToken` válido.
+
+**Request**
+```json
+{ "refreshToken": "jwt-refresh-token" }
+```
+
+**Response** `200 OK`
+```json
+{
+  "accessToken": "new-access-token",
+  "refreshToken": "new-refresh-token",
+  "expiresIn": 900
+}
+```
+
+### DELETE `/auth/sessions/current`
+
+Revoca la sesión activa. Invalida el `refreshToken` asociado.
+
+**Response** `204 No Content`
+
+## Espacios de trabajo / Proyectos
+
+Los espacios de trabajo representan proyectos colaborativos. Cada plantilla pertenece a un único workspace.
+
+### GET `/workspaces`
+
+Lista los espacios accesibles para el usuario autenticado.
+
+**Response** `200 OK`
+```json
+[
+  {
+    "id": "wrk_001",
+    "name": "Demo",
+    "role": "owner",
+    "updatedAt": "2025-01-05T10:15:00Z"
+  },
+  {
+    "id": "wrk_002",
+    "name": "Marketing",
+    "role": "viewer",
+    "updatedAt": "2024-12-18T09:02:00Z"
+  }
+]
+```
+
+### POST `/workspaces`
+
+Crea un nuevo workspace. Solo disponible para usuarios con rol `owner`.
+
+**Request**
+```json
+{
+  "name": "Cliente ACME",
+  "slug": "cliente-acme"
+}
+```
+
+**Response** `201 Created`
+```json
+{
+  "id": "wrk_010",
+  "name": "Cliente ACME",
+  "slug": "cliente-acme",
+  "role": "owner"
+}
+```
+
+### POST `/workspaces/{workspaceId}/members`
+
+Invita a un miembro utilizando su correo electrónico y rol deseado.
+
+```json
+{
+  "email": "designer@acme.com",
+  "role": "editor"
+}
+```
+
+## Plantillas de anotación
+
+### Modelo `AnnotationTemplate`
+
+```json
+{
+  "id": "tpl_001",
+  "name": "Facturas",
+  "version": 3,
+  "workspaceId": "wrk_001",
+  "createdAt": "2024-11-30T08:00:00Z",
+  "updatedAt": "2025-01-09T17:41:00Z",
+  "guidesEnabled": true,
+  "guideSettings": {
+    "showGrid": true,
+    "snapToGrid": true,
+    "gridSize": 12
+  },
+  "pages": [
+    {
+      "num": 1,
+      "fields": [
+        {
+          "id": "fld_1",
+          "type": "text",
+          "x": 120,
+          "y": 250,
+          "width": 320,
+          "height": 48,
+          "rotation": 0,
+          "fontFamily": "Helvetica",
+          "fontSize": 14,
+          "opacity": 1,
+          "textAlign": "left",
+          "content": "Nombre del cliente"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### GET `/workspaces/{workspaceId}/templates`
+
+Devuelve todas las plantillas accesibles para el workspace. El servidor siempre devuelve la última versión persistida.
+
+**Response** `200 OK`
+```json
+[
+  { "id": "tpl_001", "name": "Facturas", "version": 3, "workspaceId": "wrk_001", "createdAt": "2024-11-30T08:00:00Z", "updatedAt": "2025-01-09T17:41:00Z", "guidesEnabled": true, "guideSettings": {"showGrid": true, "snapToGrid": true, "gridSize": 12}, "pages": [] }
+]
+```
+
+### PUT `/workspaces/{workspaceId}/templates/{templateId}`
+
+Crea o sustituye una plantilla. El cliente debe enviar siempre la versión esperada.
+
+**Headers**
+- `If-Match: W/"3"` para realizar control de concurrencia optimista (el valor debe coincidir con `version`).
+
+**Request**
+```json
+{
+  "name": "Facturas",
+  "version": 3,
+  "guidesEnabled": true,
+  "guideSettings": {
+    "showGrid": true,
+    "snapToGrid": true,
+    "gridSize": 12
+  },
+  "pages": [
+    {
+      "num": 1,
+      "fields": []
+    }
+  ]
+}
+```
+
+**Response** `200 OK`
+```json
+{
+  "id": "tpl_001",
+  "name": "Facturas",
+  "version": 4,
+  "workspaceId": "wrk_001",
+  "createdAt": "2024-11-30T08:00:00Z",
+  "updatedAt": "2025-01-09T17:42:10Z",
+  "guidesEnabled": true,
+  "guideSettings": {
+    "showGrid": true,
+    "snapToGrid": true,
+    "gridSize": 12
+  },
+  "pages": [
+    {
+      "num": 1,
+      "fields": []
+    }
+  ]
+}
+```
+
+Si el `If-Match` no coincide el servidor responderá `409 Conflict` con la versión actual:
+```json
+{
+  "error": "version_conflict",
+  "message": "La plantilla fue modificada por otro usuario.",
+  "currentVersion": 5
+}
+```
+
+### DELETE `/workspaces/{workspaceId}/templates/{templateId}`
+
+Elimina la plantilla indicada. Devuelve `204 No Content` si la operación tiene éxito.
+
+### POST `/workspaces/{workspaceId}/templates/{templateId}/versions`
+
+Crea una rama histórica adicional sin afectar a la versión publicada. Útil para auditoría o restauración.
+
+```json
+{
+  "sourceVersion": 5,
+  "label": "Pre-ajustes 2025-01"
+}
+```
+
+**Response** `201 Created`
+```json
+{
+  "id": "tpl_001:v6",
+  "templateId": "tpl_001",
+  "version": 6,
+  "label": "Pre-ajustes 2025-01",
+  "createdAt": "2025-01-10T09:10:00Z"
+}
+```
+
+### Sincronización en tiempo real (opcional)
+
+Para colaboración simultánea puede abrirse un canal WebSocket en `wss://api.pdf-annotator.example.com/ws/templates`. El cliente debe enviar el token JWT en la query (`?token=...`). Eventos relevantes:
+
+- `template.updated`: notifica cambios en una plantilla (`id`, `workspaceId`, `version`).
+- `template.deleted`: notifica eliminaciones.
+- `workspace.joined` / `workspace.left`: eventos de miembros.
+
+## Esquema `PageAnnotations`
+
+Un `PageAnnotations` replica el modelo de la app:
+
+```json
+{
+  "num": 1,
+  "fields": [
+    {
+      "id": "fld_1",
+      "type": "text",
+      "x": 120,
+      "y": 250,
+      "width": 320,
+      "height": 48,
+      "rotation": 0,
+      "fontFamily": "Helvetica",
+      "fontSize": 14,
+      "opacity": 1,
+      "textAlign": "left",
+      "content": "Nombre del cliente",
+      "backgroundColor": "rgba(255,255,255,0)"
+    }
+  ]
+}
+```
+
+Los clientes deben enviar la estructura completa para garantizar consistencia entre dispositivos. Cada actualización incrementa el campo `version` en el backend.

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,3 +1,4 @@
+import { provideHttpClient, withFetch } from '@angular/common/http';
 import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 
@@ -10,5 +11,6 @@ export const appConfig: ApplicationConfig = {
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes),
     provideClientHydration(withEventReplay()),
+    provideHttpClient(withFetch()),
   ]
 };

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,4 +1,5 @@
 import { Routes } from '@angular/router';
+import { workspaceAccessGuard } from './guards/workspace-access.guard';
 
 export const routes: Routes = [
   { path: '', pathMatch: 'full', redirectTo: 'landing' },
@@ -9,6 +10,7 @@ export const routes: Routes = [
   },
   {
     path: 'workspace',
+    canActivate: [workspaceAccessGuard],
     loadComponent: () =>
       import('./pages/workspace/workspace.page').then((m) => m.WorkspacePageComponent),
   },

--- a/src/app/config/api.config.ts
+++ b/src/app/config/api.config.ts
@@ -1,0 +1,16 @@
+import { InjectionToken } from '@angular/core';
+
+import { environment } from '../../environments/environment';
+
+function normalizeBaseUrl(value: string): string {
+  if (!value) {
+    return '';
+  }
+
+  return value.endsWith('/') ? value.slice(0, -1) : value;
+}
+
+export const API_BASE_URL = new InjectionToken<string>('API_BASE_URL', {
+  providedIn: 'root',
+  factory: () => normalizeBaseUrl(environment.apiBaseUrl),
+});

--- a/src/app/guards/workspace-access.guard.ts
+++ b/src/app/guards/workspace-access.guard.ts
@@ -1,0 +1,14 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { PendingFileService } from '../services/pending-file.service';
+
+export const workspaceAccessGuard: CanActivateFn = () => {
+  const pendingFileService = inject(PendingFileService);
+  const router = inject(Router);
+
+  if (pendingFileService.hasActiveDocument() || pendingFileService.hasPendingFile()) {
+    return true;
+  }
+
+  return router.createUrlTree(['/landing']);
+};

--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -50,6 +50,26 @@
     "exportGroup": "Opcions d'exportació"
   },
   "sidebar": {
+    "session": {
+      "title": "Sessions al núvol",
+      "description": "Inicia sessió per sincronitzar plantilles i compartir-les amb el teu equip.",
+      "email": "Correu electrònic",
+      "password": "Contrasenya",
+      "login": "Inicia sessió",
+      "loading": "Connectant...",
+      "logout": "Tanca la sessió",
+      "workspaceLabel": "Espais compartits",
+      "workspacePlaceholder": "Tria un espai",
+      "refresh": "Actualitza els espais",
+      "emptyWorkspaces": "Encara no formes part de cap espai compartit.",
+      "emailError": "Introdueix un correu electrònic vàlid.",
+      "passwordError": "La contrasenya és obligatòria.",
+      "role": {
+        "owner": "Propietari",
+        "editor": "Editor",
+        "viewer": "Lector"
+      }
+    },
     "title": "Anotacions (JSON)",
     "importJsonFile": "Importa des d'un fitxer",
     "applyJson": "Aplica el JSON",

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -50,6 +50,26 @@
     "exportGroup": "Export options"
   },
   "sidebar": {
+    "session": {
+      "title": "Cloud sessions",
+      "description": "Sign in to sync templates and collaborate with your team.",
+      "email": "Email",
+      "password": "Password",
+      "login": "Sign in",
+      "loading": "Signing in...",
+      "logout": "Sign out",
+      "workspaceLabel": "Shared workspaces",
+      "workspacePlaceholder": "Choose a workspace",
+      "refresh": "Refresh workspaces",
+      "emptyWorkspaces": "You haven't joined any shared workspace yet.",
+      "emailError": "Please enter a valid email address.",
+      "passwordError": "Password is required.",
+      "role": {
+        "owner": "Owner",
+        "editor": "Editor",
+        "viewer": "Viewer"
+      }
+    },
     "title": "Annotations (JSON)",
     "importJsonFile": "Import from file",
     "applyJson": "Apply JSON",

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -50,6 +50,26 @@
     "exportGroup": "Opciones de exportación"
   },
   "sidebar": {
+    "session": {
+      "title": "Sesiones en la nube",
+      "description": "Inicia sesión para sincronizar plantillas y compartirlas con tu equipo.",
+      "email": "Correo electrónico",
+      "password": "Contraseña",
+      "login": "Iniciar sesión",
+      "loading": "Conectando...",
+      "logout": "Cerrar sesión",
+      "workspaceLabel": "Espacios compartidos",
+      "workspacePlaceholder": "Selecciona un espacio",
+      "refresh": "Actualizar espacios",
+      "emptyWorkspaces": "Todavía no perteneces a ningún espacio compartido.",
+      "emailError": "Introduce un correo válido.",
+      "passwordError": "La contraseña es obligatoria.",
+      "role": {
+        "owner": "Propietario",
+        "editor": "Editor",
+        "viewer": "Lector"
+      }
+    },
     "title": "Anotaciones (JSON)",
     "importJsonFile": "Importar desde archivo",
     "applyJson": "Aplicar JSON",

--- a/src/app/models/annotation-template.model.ts
+++ b/src/app/models/annotation-template.model.ts
@@ -1,0 +1,18 @@
+import { PageAnnotations } from './annotation.model';
+import { GuideSettings } from './guide-settings.model';
+
+export type AnnotationTemplateOrigin = 'local' | 'remote' | 'hybrid' | 'system';
+
+export interface AnnotationTemplate {
+  id: string;
+  name: string;
+  createdAt: number;
+  updatedAt?: number;
+  version?: number;
+  workspaceId?: string | null;
+  origin?: AnnotationTemplateOrigin;
+  syncedAt?: number | null;
+  pages: PageAnnotations[];
+  guidesEnabled: boolean;
+  guideSettings: GuideSettings;
+}

--- a/src/app/pages/landing/components/footer/landing-footer.component.html
+++ b/src/app/pages/landing/components/footer/landing-footer.component.html
@@ -9,5 +9,6 @@
   <div class="footer__details">
     <span>© {{ currentYear }} {{ appName }}</span>
     <span>Desarrollado por {{ appAuthor }}</span>
+    <span class="footer__environment">Entorno: {{ environmentLabel }}</span>
   </div>
 </footer>

--- a/src/app/pages/landing/components/footer/landing-footer.component.ts
+++ b/src/app/pages/landing/components/footer/landing-footer.component.ts
@@ -12,4 +12,5 @@ export class LandingFooterComponent {
   @Input({ required: true }) version = '';
   @Input({ required: true }) currentYear!: number;
   @Input({ required: true }) appAuthor = '';
+  @Input({ required: true }) environmentLabel = '';
 }

--- a/src/app/pages/landing/landing.page.html
+++ b/src/app/pages/landing/landing.page.html
@@ -12,5 +12,5 @@
   </section>
 
   <app-landing-footer [appName]="appName" [version]="version" [currentYear]="currentYear"
-    [appAuthor]="appAuthor"></app-landing-footer>
+    [appAuthor]="appAuthor" [environmentLabel]="environmentLabel"></app-landing-footer>
 </div>

--- a/src/app/pages/landing/landing.page.ts
+++ b/src/app/pages/landing/landing.page.ts
@@ -10,6 +10,7 @@ import { LandingDropzoneComponent } from './components/dropzone/landing-dropzone
 import { LandingFooterComponent } from './components/footer/landing-footer.component';
 import { LandingHeroComponent } from './components/hero/landing-hero.component';
 import { LandingLanguageBarComponent } from './components/language-bar/landing-language-bar.component';
+import { environment } from '../../../environments/environment';
 
 @Component({
   selector: 'app-landing-page',
@@ -34,6 +35,7 @@ export class LandingPageComponent {
   readonly version = APP_VERSION;
   readonly currentYear = new Date().getFullYear();
   readonly appAuthor = APP_AUTHOR;
+  readonly environmentLabel = environment.name.toUpperCase();
   readonly languages: readonly Language[] = this.translationService.supportedLanguages;
   languageModel: Language = this.translationService.getCurrentLanguage();
   readonly fileDropActive = signal(false);

--- a/src/app/pages/workspace/components/footer/workspace-footer.component.html
+++ b/src/app/pages/workspace/components/footer/workspace-footer.component.html
@@ -9,5 +9,6 @@
   <div class="footer__details">
     <span>© {{ vm.currentYear }} {{ vm.appName }}</span>
     <span>Desarrollado por {{ vm.appAuthor }}</span>
+    <span class="footer__environment">Entorno: {{ vm.environmentLabel }}</span>
   </div>
 </footer>

--- a/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.html
+++ b/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.html
@@ -62,7 +62,8 @@
             <select
               id="workspace-select"
               [value]="session.activeWorkspaceId ?? ''"
-              (change)="vm.onWorkspaceSelected($event.target.value)"
+              #workspaceSelect
+              (change)="vm.onWorkspaceSelected(workspaceSelect.value)"
               [disabled]="vm.sessionLoading()"
             >
               <option value="" disabled>{{ 'sidebar.session.workspacePlaceholder' | t }}</option>

--- a/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.html
+++ b/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.html
@@ -1,4 +1,93 @@
 <aside class="sidebar">
+  <section class="session-panel">
+    <h5 class="session-panel__title">{{ 'sidebar.session.title' | t }}</h5>
+    <p class="session-panel__description">{{ 'sidebar.session.description' | t }}</p>
+    <ng-container *ngIf="vm.sessionState() as session">
+      <form
+        *ngIf="session.status !== 'authenticated'; else sessionInfo"
+        class="session-panel__form"
+        [formGroup]="vm.loginForm"
+        (ngSubmit)="vm.submitLogin()"
+      >
+        <div class="session-panel__field">
+          <label for="session-email">{{ 'sidebar.session.email' | t }}</label>
+          <input
+            id="session-email"
+            type="email"
+            formControlName="email"
+            [disabled]="vm.sessionLoading()"
+            [attr.aria-invalid]="vm.loginForm.controls.email.invalid && vm.loginForm.controls.email.touched"
+          />
+          <small
+            class="session-panel__field-error"
+            *ngIf="vm.loginForm.controls.email.invalid && vm.loginForm.controls.email.touched"
+          >
+            {{ 'sidebar.session.emailError' | t }}
+          </small>
+        </div>
+        <div class="session-panel__field">
+          <label for="session-password">{{ 'sidebar.session.password' | t }}</label>
+          <input
+            id="session-password"
+            type="password"
+            formControlName="password"
+            [disabled]="vm.sessionLoading()"
+            [attr.aria-invalid]="vm.loginForm.controls.password.invalid && vm.loginForm.controls.password.touched"
+          />
+          <small
+            class="session-panel__field-error"
+            *ngIf="vm.loginForm.controls.password.invalid && vm.loginForm.controls.password.touched"
+          >
+            {{ 'sidebar.session.passwordError' | t }}
+          </small>
+        </div>
+        <button type="submit" class="btn session-panel__submit" [disabled]="vm.sessionLoading()">
+          {{ vm.sessionLoading() ? ('sidebar.session.loading' | t) : ('sidebar.session.login' | t) }}
+        </button>
+      </form>
+      <ng-template #sessionInfo>
+        <div class="session-panel__user" *ngIf="session.user as user">
+          <span class="session-panel__avatar" aria-hidden="true">{{ vm.sessionAvatar(user) }}</span>
+          <div class="session-panel__details">
+            <span class="session-panel__name">{{ vm.sessionUserName(user) }}</span>
+            <span class="session-panel__email">{{ vm.sessionUserEmail(user) }}</span>
+          </div>
+          <button type="button" class="btn btn--ghost session-panel__logout" (click)="vm.logoutSession()">
+            {{ 'sidebar.session.logout' | t }}
+          </button>
+        </div>
+        <div class="session-panel__workspaces" *ngIf="session.workspaces.length; else emptyWorkspaces">
+          <label for="workspace-select">{{ 'sidebar.session.workspaceLabel' | t }}</label>
+          <div class="session-panel__workspace-controls">
+            <select
+              id="workspace-select"
+              [value]="session.activeWorkspaceId ?? ''"
+              (change)="vm.onWorkspaceSelected($event.target.value)"
+              [disabled]="vm.sessionLoading()"
+            >
+              <option value="" disabled>{{ 'sidebar.session.workspacePlaceholder' | t }}</option>
+              <option *ngFor="let workspace of vm.availableWorkspaces()" [value]="workspace.id">
+                {{ vm.sessionWorkspaceLabel(workspace) }}
+              </option>
+            </select>
+            <button
+              type="button"
+              class="btn btn--icon session-panel__refresh"
+              (click)="vm.refreshSharedWorkspaces()"
+              [disabled]="vm.sessionLoading()"
+              [title]="'sidebar.session.refresh' | t"
+            >
+              🔄
+            </button>
+          </div>
+        </div>
+        <ng-template #emptyWorkspaces>
+          <p class="session-panel__hint">{{ 'sidebar.session.emptyWorkspaces' | t }}</p>
+        </ng-template>
+      </ng-template>
+      <p class="session-panel__error-message" *ngIf="session.error">{{ session.error }}</p>
+    </ng-container>
+  </section>
   <section class="sidebar-upload" role="button" tabindex="0" (click)="vm.openPdfFilePicker()"
     (keydown)="vm.onFileUploadKeydown($event)" (dragover)="vm.onFileDragOver($event)"
     (dragleave)="vm.onFileDragLeave($event)" (drop)="vm.onFileDrop($event)"

--- a/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.scss
+++ b/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.scss
@@ -2,6 +2,147 @@
   display: contents;
 }
 
+.session-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 24px;
+  padding: 16px;
+  border-radius: 18px;
+  border: 1px solid rgba(94, 234, 212, 0.18);
+  background: rgba(15, 23, 42, 0.72);
+  backdrop-filter: blur(14px);
+}
+
+.session-panel__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.session-panel__description {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.session-panel__form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.session-panel__field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.session-panel__field label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.session-panel__field input,
+.session-panel__workspace-controls select {
+  width: 100%;
+  padding: 8px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(94, 234, 212, 0.18);
+  background: rgba(26, 26, 40, 0.85);
+  color: var(--text);
+  font-size: 0.9rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.session-panel__field input:focus,
+.session-panel__workspace-controls select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(94, 234, 212, 0.15);
+}
+
+.session-panel__field input:disabled,
+.session-panel__workspace-controls select:disabled {
+  opacity: 0.65;
+}
+
+.session-panel__field-error {
+  margin: 0;
+  font-size: 0.75rem;
+  color: #ff8a8a;
+}
+
+.session-panel__submit {
+  width: 100%;
+  justify-content: center;
+}
+
+.session-panel__user {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.session-panel__avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: rgba(94, 234, 212, 0.16);
+  color: var(--accent);
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.session-panel__details {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.session-panel__name {
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.session-panel__email {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.session-panel__workspaces {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.session-panel__workspace-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.session-panel__hint {
+  margin: 0;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.session-panel__error-message {
+  margin: 0;
+  font-size: 0.8rem;
+  color: #ff8a8a;
+}
+
+.session-panel__refresh {
+  flex-shrink: 0;
+}
+
 .sidebar-thumbnails {
   display: flex;
   flex-direction: column;

--- a/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.ts
+++ b/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { Component, ElementRef, Input, ViewChild } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import type { WorkspacePageComponent } from '../../workspace.page';
 import { TranslationPipe } from '../../../../i18n/translation.pipe';
 import { JsonTreeComponent } from '../json-tree/json-tree.component';
@@ -11,7 +11,7 @@ import { PageThumbnailsComponent } from '../page-thumbnails/page-thumbnails.comp
   standalone: true,
   templateUrl: './workspace-sidebar.component.html',
   styleUrls: ['./workspace-sidebar.component.scss'],
-  imports: [CommonModule, FormsModule, TranslationPipe, JsonTreeComponent, PageThumbnailsComponent],
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, TranslationPipe, JsonTreeComponent, PageThumbnailsComponent],
 })
 export class WorkspaceSidebarComponent {
   @Input({ required: true }) vm!: WorkspacePageComponent;

--- a/src/app/pages/workspace/workspace.page.ts
+++ b/src/app/pages/workspace/workspace.page.ts
@@ -45,6 +45,7 @@ import { AppMetadataService } from '../../services/app-metadata.service';
 import { isPdfFile } from '../../utils/pdf-file.utils';
 import { SessionService, SessionState, WorkspaceSummary, CloudUser } from '../../services/session.service';
 import { take } from 'rxjs';
+import { environment } from '../../../environments/environment';
 
 const PDF_WORKER_MODULE_SRC = '/assets/pdfjs/pdf.worker.entry.mjs';
 const PDF_WORKER_TYPE_MODULE = 'module';
@@ -204,6 +205,7 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
   readonly appName = APP_NAME;
   readonly appAuthor = APP_AUTHOR;
   readonly currentYear = new Date().getFullYear();
+  readonly environmentLabel = environment.name.toUpperCase();
   readonly languages: readonly Language[] = this.translationService.supportedLanguages;
   languageModel: Language = this.translationService.getCurrentLanguage();
   readonly sessionState = signal<SessionState>(this.sessionService.getSnapshot());
@@ -363,6 +365,7 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
   }
 
   ngOnDestroy() {
+    this.pendingFileService.clearActiveDocument();
     this.revokeThumbnailUrls();
     if (!this.document) {
       return;
@@ -1411,6 +1414,7 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
       return;
     }
 
+    this.pendingFileService.clearActiveDocument();
     this.pdfByteSources.clear();
     const buf = await file.arrayBuffer();
     const typed = new Uint8Array(buf);
@@ -1446,6 +1450,7 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
       console.error('No se pudieron generar las miniaturas del documento.', error)
     );
     this.fileDropActive.set(false);
+    this.pendingFileService.markActiveDocumentLoaded();
   }
 
   async render() {

--- a/src/app/services/cloud-templates.service.ts
+++ b/src/app/services/cloud-templates.service.ts
@@ -1,0 +1,117 @@
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable, of, throwError } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import { PageAnnotations, PageField } from '../models/annotation.model';
+import { AnnotationTemplate } from '../models/annotation-template.model';
+import { GuideSettings, cloneGuideSettings } from '../models/guide-settings.model';
+import { SessionService } from './session.service';
+
+interface CloudAnnotationTemplateDto {
+  id: string;
+  name: string;
+  version: number;
+  workspaceId: string;
+  createdAt: string;
+  updatedAt: string;
+  guidesEnabled: boolean;
+  guideSettings: GuideSettings;
+  pages: PageAnnotations[];
+}
+
+interface CloudTemplatePayload {
+  name: string;
+  version: number;
+  guidesEnabled: boolean;
+  guideSettings: GuideSettings;
+  pages: PageAnnotations[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class CloudTemplatesService {
+  private readonly baseUrl = '/api/v1';
+
+  constructor(private readonly http: HttpClient, private readonly sessionService: SessionService) {}
+
+  listTemplates(workspaceId?: string): Observable<AnnotationTemplate[]> {
+    const targetWorkspace = workspaceId ?? this.sessionService.getActiveWorkspaceId();
+    if (!targetWorkspace) {
+      return of([]);
+    }
+
+    return this.http
+      .get<CloudAnnotationTemplateDto[]>(
+        `${this.baseUrl}/workspaces/${encodeURIComponent(targetWorkspace)}/templates`,
+        { headers: this.buildHeaders() }
+      )
+      .pipe(map((items) => items.map((item) => this.mapFromDto(item))));
+  }
+
+  saveTemplate(template: AnnotationTemplate, workspaceId?: string): Observable<AnnotationTemplate> {
+    const targetWorkspace = workspaceId ?? template.workspaceId ?? this.sessionService.getActiveWorkspaceId();
+    if (!targetWorkspace) {
+      return throwError(() => new Error('No hay un espacio de trabajo seleccionado.'));
+    }
+
+    const payload = this.mapToPayload(template);
+    const url = `${this.baseUrl}/workspaces/${encodeURIComponent(targetWorkspace)}/templates/${encodeURIComponent(template.id)}`;
+
+    return this.http
+      .put<CloudAnnotationTemplateDto>(url, payload, { headers: this.buildHeaders() })
+      .pipe(map((item) => this.mapFromDto(item)));
+  }
+
+  deleteTemplate(id: string, workspaceId?: string): Observable<void> {
+    const targetWorkspace = workspaceId ?? this.sessionService.getActiveWorkspaceId();
+    if (!targetWorkspace) {
+      return throwError(() => new Error('No hay un espacio de trabajo seleccionado.'));
+    }
+
+    const url = `${this.baseUrl}/workspaces/${encodeURIComponent(targetWorkspace)}/templates/${encodeURIComponent(id)}`;
+    return this.http.delete<void>(url, { headers: this.buildHeaders() });
+  }
+
+  private buildHeaders(): HttpHeaders {
+    const token = this.sessionService.getToken();
+    let headers = new HttpHeaders({ 'Content-Type': 'application/json' });
+    if (token) {
+      headers = headers.set('Authorization', `Bearer ${token}`);
+    }
+    return headers;
+  }
+
+  private mapFromDto(dto: CloudAnnotationTemplateDto): AnnotationTemplate {
+    return {
+      id: dto.id,
+      name: dto.name,
+      createdAt: new Date(dto.createdAt).getTime(),
+      updatedAt: new Date(dto.updatedAt).getTime(),
+      version: dto.version,
+      workspaceId: dto.workspaceId,
+      origin: 'remote',
+      syncedAt: Date.now(),
+      guidesEnabled: dto.guidesEnabled,
+      guideSettings: cloneGuideSettings(dto.guideSettings),
+      pages: this.clonePages(dto.pages),
+    };
+  }
+
+  private mapToPayload(template: AnnotationTemplate): CloudTemplatePayload {
+    const version = template.version ?? 1;
+    return {
+      name: template.name,
+      version,
+      guidesEnabled: template.guidesEnabled,
+      guideSettings: cloneGuideSettings(template.guideSettings),
+      pages: this.clonePages(template.pages),
+    };
+  }
+
+  private clonePages(pages: readonly PageAnnotations[]): PageAnnotations[] {
+    return pages.map((page) => ({
+      num: page.num,
+      fields: page.fields.map((field): PageField => ({ ...field })),
+    }));
+  }
+}

--- a/src/app/services/pending-file.service.ts
+++ b/src/app/services/pending-file.service.ts
@@ -3,14 +3,32 @@ import { Injectable, signal } from '@angular/core';
 @Injectable({ providedIn: 'root' })
 export class PendingFileService {
   private readonly pendingFile = signal<File | null>(null);
+  private readonly activeDocumentLoaded = signal(false);
 
   setPendingFile(file: File): void {
     this.pendingFile.set(file);
+    this.activeDocumentLoaded.set(false);
   }
 
   consumePendingFile(): File | null {
     const file = this.pendingFile();
     this.pendingFile.set(null);
     return file;
+  }
+
+  hasPendingFile(): boolean {
+    return this.pendingFile() !== null;
+  }
+
+  markActiveDocumentLoaded(): void {
+    this.activeDocumentLoaded.set(true);
+  }
+
+  clearActiveDocument(): void {
+    this.activeDocumentLoaded.set(false);
+  }
+
+  hasActiveDocument(): boolean {
+    return this.activeDocumentLoaded();
   }
 }

--- a/src/app/services/session.service.ts
+++ b/src/app/services/session.service.ts
@@ -70,8 +70,10 @@ export class SessionService {
   login(payload: LoginPayload): Observable<void> {
     this.stateSubject.next({ ...this.stateSubject.value, status: 'authenticating', error: null });
 
+    const body: LoginPayload = { ...payload, projectKey: 'pdf-annotator' };
+
     return this.http
-      .post<LoginResponse>(this.buildUrl('/auth/sessions'), payload, { headers: this.buildHeaders(false) })
+      .post<LoginResponse>(this.buildUrl('/auth/sessions'), body, { headers: this.buildHeaders(false) })
       .pipe(
         tap((response) => {
           const activeWorkspaceId = this.ensureWorkspace(

--- a/src/app/services/session.service.ts
+++ b/src/app/services/session.service.ts
@@ -1,0 +1,288 @@
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable, catchError, map, of, tap, throwError } from 'rxjs';
+
+export interface CloudUser {
+  id: string;
+  name: string;
+  email: string;
+  avatarUrl?: string | null;
+}
+
+export type WorkspaceRole = 'owner' | 'editor' | 'viewer';
+
+export interface WorkspaceSummary {
+  id: string;
+  name: string;
+  role: WorkspaceRole;
+  updatedAt?: string;
+}
+
+export type SessionStatus = 'signed-out' | 'authenticating' | 'authenticated';
+
+export interface SessionState {
+  status: SessionStatus;
+  user: CloudUser | null;
+  token: string | null;
+  workspaces: WorkspaceSummary[];
+  activeWorkspaceId: string | null;
+  error: string | null;
+}
+
+interface LoginPayload {
+  email: string;
+  password: string;
+  projectKey?: string;
+}
+
+interface LoginResponse {
+  accessToken: string;
+  user: CloudUser;
+  workspaces: WorkspaceSummary[];
+  defaultWorkspaceId?: string | null;
+}
+
+interface PersistedSession {
+  token: string;
+  user: CloudUser;
+  workspaces: WorkspaceSummary[];
+  activeWorkspaceId: string | null;
+}
+
+@Injectable({ providedIn: 'root' })
+export class SessionService {
+  private readonly baseUrl = '/api/v1';
+  private readonly storageKey = 'pdf-annotator.session';
+  private readonly stateSubject = new BehaviorSubject<SessionState>(this.createSignedOutState());
+
+  readonly session$ = this.stateSubject.asObservable();
+  readonly activeWorkspace$ = this.session$.pipe(map((state) => state.activeWorkspaceId));
+
+  constructor(private readonly http: HttpClient) {
+    this.restoreFromStorage();
+  }
+
+  login(payload: LoginPayload): Observable<void> {
+    this.stateSubject.next({ ...this.stateSubject.value, status: 'authenticating', error: null });
+
+    return this.http
+      .post<LoginResponse>(`${this.baseUrl}/auth/sessions`, payload, { headers: this.buildHeaders(false) })
+      .pipe(
+        tap((response) => {
+          const activeWorkspaceId = this.ensureWorkspace(
+            response.defaultWorkspaceId ?? null,
+            response.workspaces
+          );
+          const nextState: SessionState = {
+            status: 'authenticated',
+            user: response.user,
+            token: response.accessToken,
+            workspaces: response.workspaces,
+            activeWorkspaceId,
+            error: null,
+          };
+          this.stateSubject.next(nextState);
+          this.persistSession(nextState);
+        }),
+        map(() => void 0),
+        catchError((error) => {
+          const message = this.resolveErrorMessage(error);
+          const fallback = { ...this.createSignedOutState(), error: message };
+          this.stateSubject.next(fallback);
+          this.clearSession();
+          return throwError(() => error);
+        })
+      );
+  }
+
+  logout(): void {
+    this.stateSubject.next(this.createSignedOutState());
+    this.clearSession();
+  }
+
+  selectWorkspace(workspaceId: string | null): void {
+    const current = this.stateSubject.value;
+    if (current.status !== 'authenticated') {
+      return;
+    }
+
+    const normalized = this.ensureWorkspace(workspaceId, current.workspaces);
+    const nextState: SessionState = { ...current, activeWorkspaceId: normalized };
+    this.stateSubject.next(nextState);
+    this.persistSession(nextState);
+  }
+
+  refreshWorkspaces(): Observable<WorkspaceSummary[]> {
+    const token = this.getToken();
+    if (!token) {
+      return of([]);
+    }
+
+    return this.http
+      .get<WorkspaceSummary[]>(`${this.baseUrl}/workspaces`, { headers: this.buildHeaders(true) })
+      .pipe(
+        tap((workspaces) => {
+          const current = this.stateSubject.value;
+          if (current.status !== 'authenticated') {
+            return;
+          }
+
+          const activeWorkspaceId = this.ensureWorkspace(current.activeWorkspaceId, workspaces);
+          const nextState: SessionState = {
+            ...current,
+            workspaces,
+            activeWorkspaceId,
+            error: null,
+          };
+          this.stateSubject.next(nextState);
+          this.persistSession(nextState);
+        })
+      );
+  }
+
+  getToken(): string | null {
+    return this.stateSubject.value.token;
+  }
+
+  getActiveWorkspaceId(): string | null {
+    return this.stateSubject.value.activeWorkspaceId;
+  }
+
+  getSnapshot(): SessionState {
+    const state = this.stateSubject.value;
+    return {
+      ...state,
+      user: state.user ? { ...state.user } : null,
+      workspaces: state.workspaces.map((workspace) => ({ ...workspace })),
+    };
+  }
+
+  private restoreFromStorage(): void {
+    const persisted = this.readFromStorage();
+    if (!persisted) {
+      return;
+    }
+
+    const nextState: SessionState = {
+      status: 'authenticated',
+      user: persisted.user,
+      token: persisted.token,
+      workspaces: persisted.workspaces,
+      activeWorkspaceId: this.ensureWorkspace(persisted.activeWorkspaceId, persisted.workspaces),
+      error: null,
+    };
+
+    this.stateSubject.next(nextState);
+  }
+
+  private ensureWorkspace(
+    preferredWorkspaceId: string | null,
+    workspaces: readonly WorkspaceSummary[]
+  ): string | null {
+    if (preferredWorkspaceId && workspaces.some((workspace) => workspace.id === preferredWorkspaceId)) {
+      return preferredWorkspaceId;
+    }
+
+    const firstWorkspace = workspaces[0];
+    return firstWorkspace ? firstWorkspace.id : null;
+  }
+
+  private createSignedOutState(): SessionState {
+    return {
+      status: 'signed-out',
+      user: null,
+      token: null,
+      workspaces: [],
+      activeWorkspaceId: null,
+      error: null,
+    };
+  }
+
+  private persistSession(state: SessionState): void {
+    if (state.status !== 'authenticated' || !state.token || !state.user) {
+      this.clearSession();
+      return;
+    }
+
+    const payload: PersistedSession = {
+      token: state.token,
+      user: state.user,
+      workspaces: state.workspaces,
+      activeWorkspaceId: state.activeWorkspaceId,
+    };
+
+    this.writeToStorage(payload);
+  }
+
+  private clearSession(): void {
+    const storage = this.getStorage();
+    storage?.removeItem(this.storageKey);
+  }
+
+  private buildHeaders(includeAuth: boolean): HttpHeaders {
+    let headers = new HttpHeaders({ 'Content-Type': 'application/json' });
+    if (includeAuth) {
+      const token = this.getToken();
+      if (token) {
+        headers = headers.set('Authorization', `Bearer ${token}`);
+      }
+    }
+    return headers;
+  }
+
+  private resolveErrorMessage(error: unknown): string {
+    if (!error || typeof error !== 'object') {
+      return 'No se pudo iniciar sesión, intenta nuevamente.';
+    }
+
+    if ('error' in error && typeof (error as { error?: unknown }).error === 'object') {
+      const payload = (error as { error?: { message?: string } }).error;
+      if (payload?.message) {
+        return payload.message;
+      }
+    }
+
+    return 'Credenciales inválidas o servicio no disponible.';
+  }
+
+  private readFromStorage(): PersistedSession | null {
+    const storage = this.getStorage();
+    if (!storage) {
+      return null;
+    }
+
+    try {
+      const raw = storage.getItem(this.storageKey);
+      if (!raw) {
+        return null;
+      }
+      return JSON.parse(raw) as PersistedSession;
+    } catch {
+      return null;
+    }
+  }
+
+  private writeToStorage(value: PersistedSession): void {
+    const storage = this.getStorage();
+    if (!storage) {
+      return;
+    }
+
+    try {
+      storage.setItem(this.storageKey, JSON.stringify(value));
+    } catch {
+      // Evitamos romper el flujo por problemas de almacenamiento.
+    }
+  }
+
+  private getStorage(): Storage | null {
+    try {
+      if (typeof window === 'undefined' || !window.localStorage) {
+        return null;
+      }
+      return window.localStorage;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -1,4 +1,0 @@
-export const environment = {
-  name: 'development',
-  apiBaseUrl: 'http://localhost:5300/api/v1',
-} as const;

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  name: 'development',
+  apiBaseUrl: 'http://localhost:5300/api/v1',
+} as const;

--- a/src/environments/environment.pre.ts
+++ b/src/environments/environment.pre.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  name: 'pre',
+  apiBaseUrl: 'https://test-pdf-annotator-api.alvaromaxter.es/api/v1',
+} as const;

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  name: 'prod',
+  apiBaseUrl: 'https://pdf-annotator-api.alvaromaxter.es/api/v1',
+} as const;

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -1,4 +1,4 @@
 export const environment = {
-  name: 'pre',
+  name: 'test',
   apiBaseUrl: 'https://test-pdf-annotator-api.alvaromaxter.es/api/v1',
 } as const;

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,4 +1,4 @@
 export const environment = {
-  name: 'production',
-  apiBaseUrl: 'https://pdf-annotator-api.alvaromaxter.es/api/v1',
+  name: 'dev',
+  apiBaseUrl: 'http://localhost:5300/api/v1',
 } as const;

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  name: 'production',
+  apiBaseUrl: 'https://pdf-annotator-api.alvaromaxter.es/api/v1',
+} as const;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1068,6 +1068,13 @@ header .logo {
     text-align: right;
     color: var(--muted);
   }
+
+  &__environment {
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--accent);
+  }
 }
 
 .canvas-container {


### PR DESCRIPTION
## Summary
- document the REST API covering authentication, workspace management, and template versioning for the cloud service
- add session and cloud template services and refactor the annotation template store to sync local cache with remote workspaces
- expose login/workspace controls in the workspace sidebar with new styling and translations for supported languages

## Testing
- npm run test -- --watch=false *(fails: Chrome binary not available in container)*

------
