### PR TITLE
Add interactive store map to landing page

### DIFF
--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -12,7 +12,13 @@
       "badge": "Comença a anotar",
       "title": "Maqueta coordenades de qualsevol PDF en segons",
       "description": "Puja el document per afegir anotacions vinculades a JSON, reutilitzar plantilles i exportar fitxers a punt per treballar.",
-      "cta": "Selecciona PDF"
+      "cta": "Selecciona PDF",
+      "storeMap": {
+        "title": "Comerços destacats",
+        "description": "Fes clic a la llista o en un marcador del mapa per obrir la ubicació a Google Maps.",
+        "bubbleHint": "Obre-ho a Google Maps",
+        "listAriaLabel": "Llista de comerços"
+      }
     },
     "upload": {
       "title": "Carrega el teu PDF",

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -12,7 +12,13 @@
       "badge": "Annotate smarter",
       "title": "Lay out coordinates on any PDF in seconds",
       "description": "Upload your document to add JSON-backed annotations, reuse templates and export your work-ready files.",
-      "cta": "Select PDF"
+      "cta": "Select PDF",
+      "storeMap": {
+        "title": "Featured local businesses",
+        "description": "Click a list item or its map marker to open the location in Google Maps.",
+        "bubbleHint": "Open in Google Maps",
+        "listAriaLabel": "Store list"
+      }
     },
     "upload": {
       "title": "Upload your PDF",

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -12,7 +12,13 @@
       "badge": "Empieza a anotar",
       "title": "Maqueta coordenadas de cualquier PDF en segundos",
       "description": "Sube tu documento para añadir anotaciones vinculadas a JSON, reutilizar plantillas y exportar archivos listos para trabajar.",
-      "cta": "Seleccionar PDF"
+      "cta": "Seleccionar PDF",
+      "storeMap": {
+        "title": "Comercios destacados",
+        "description": "Haz clic en la lista o en un marcador del mapa para abrir la ubicación en Google Maps.",
+        "bubbleHint": "Pulsa para abrir en Google Maps",
+        "listAriaLabel": "Listado de comercios"
+      }
     },
     "upload": {
       "title": "Carga tu PDF",

--- a/src/app/pages/landing/components/store-map/store-map.component.html
+++ b/src/app/pages/landing/components/store-map/store-map.component.html
@@ -1,0 +1,64 @@
+<section class="store-map">
+  <header class="store-map__header">
+    <h2>{{ 'app.landing.storeMap.title' | t }}</h2>
+    <p>
+      {{ 'app.landing.storeMap.description' | t }}
+    </p>
+  </header>
+
+  <div class="store-map__content">
+    <ul class="store-map__list" [attr.aria-label]="'app.landing.storeMap.listAriaLabel' | t">
+      <li *ngFor="let view of storeViews(); trackBy: trackStoreView" class="store-map__list-item">
+        <button
+          type="button"
+          class="store-map__list-button"
+          [class.store-map__list-button--active]="selectedStoreId() === view.id"
+          (click)="onStoreOptionClick(view.id)"
+          (keydown)="onListOptionKeydown($event, view.id)"
+        >
+          <span class="store-map__list-name">{{ view.store.name }}</span>
+          <span class="store-map__list-address">{{ view.store.address }}</span>
+        </button>
+      </li>
+    </ul>
+
+    <div class="store-map__map" role="presentation">
+      <div class="store-map__background" aria-hidden="true"></div>
+
+      <ng-container *ngFor="let view of storeViews(); trackBy: trackStoreView">
+        <button
+          type="button"
+          class="store-map__marker"
+          [class.store-map__marker--restaurant]="view.category === 'restaurant'"
+          [class.store-map__marker--shop]="view.category === 'shop'"
+          [class.store-map__marker--service]="view.category === 'service'"
+          (click)="onMarkerClick(view.id)"
+          (focus)="onMarkerFocus(view.id)"
+          (blur)="onMarkerBlur(view.id, $event)"
+          [style.left.%]="view.left"
+          [style.top.%]="view.top"
+          [attr.aria-label]="view.store.name"
+          [attr.data-store-id]="view.id"
+          [class.store-map__marker--active]="selectedStoreId() === view.id"
+        ></button>
+      </ng-container>
+
+      <article
+        *ngIf="selectedStore() as store"
+        class="store-map__bubble"
+        role="button"
+        tabindex="0"
+        (click)="onInfoBubbleClick()"
+        (keydown)="onInfoBubbleKeydown($event)"
+        [style.left.%]="bubblePosition()?.left ?? 0"
+        [style.top.%]="bubblePosition()?.top ?? 0"
+        [attr.data-store-id]="store.id"
+        [attr.aria-label]="store.name + '. ' + ('app.landing.storeMap.bubbleHint' | t)"
+      >
+        <h3>{{ store.name }}</h3>
+        <p>{{ store.address }}</p>
+        <span class="store-map__bubble-hint">{{ 'app.landing.storeMap.bubbleHint' | t }}</span>
+      </article>
+    </div>
+  </div>
+</section>

--- a/src/app/pages/landing/components/store-map/store-map.component.scss
+++ b/src/app/pages/landing/components/store-map/store-map.component.scss
@@ -1,0 +1,179 @@
+.store-map {
+  display: grid;
+  gap: 24px;
+  padding: 32px;
+  background: #0e1321;
+  border-radius: 20px;
+  color: #fff;
+  width: min(960px, 100%);
+  margin: 0 auto;
+  text-align: left;
+
+  &__header {
+    display: grid;
+    gap: 8px;
+
+    h2 {
+      margin: 0;
+      font-size: 1.5rem;
+    }
+
+    p {
+      margin: 0;
+      color: rgba(255, 255, 255, 0.72);
+      font-size: 0.95rem;
+      line-height: 1.6;
+    }
+  }
+
+  &__content {
+    display: grid;
+    gap: 24px;
+
+    @media (min-width: 960px) {
+      grid-template-columns: minmax(260px, 32%) minmax(0, 1fr);
+      align-items: start;
+    }
+  }
+
+  &__list {
+    display: grid;
+    gap: 12px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  &__list-item {
+    margin: 0;
+  }
+
+  &__list-button {
+    width: 100%;
+    display: grid;
+    gap: 4px;
+    text-align: left;
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    border-radius: 16px;
+    padding: 14px 16px;
+    background: rgba(255, 255, 255, 0.04);
+    color: inherit;
+    font: inherit;
+    cursor: pointer;
+    transition: border-color 160ms ease, background 160ms ease, transform 160ms ease;
+
+    &:hover,
+    &:focus {
+      outline: none;
+      border-color: rgba(82, 182, 255, 0.8);
+      background: rgba(82, 182, 255, 0.18);
+      transform: translateY(-2px);
+    }
+
+    &--active {
+      border-color: rgba(82, 182, 255, 0.9);
+      background: rgba(82, 182, 255, 0.25);
+      transform: translateY(-2px);
+      box-shadow: 0 12px 32px rgba(82, 182, 255, 0.22);
+    }
+  }
+
+  &__list-name {
+    font-weight: 600;
+    font-size: 1rem;
+  }
+
+  &__list-address {
+    font-size: 0.9rem;
+    color: rgba(255, 255, 255, 0.68);
+  }
+
+  &__map {
+    position: relative;
+    border-radius: 20px;
+    overflow: hidden;
+    min-height: 360px;
+  }
+
+  &__background {
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 20% 20%, rgba(82, 182, 255, 0.3), transparent 45%),
+      radial-gradient(circle at 80% 30%, rgba(255, 118, 117, 0.3), transparent 40%),
+      radial-gradient(circle at 50% 70%, rgba(255, 234, 167, 0.25), transparent 45%),
+      #08101e;
+  }
+
+  &__marker {
+    position: absolute;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    border: 2px solid rgba(8, 16, 30, 0.88);
+    cursor: pointer;
+    background: #fff;
+    transform: translate(-50%, -50%);
+    transition: transform 160ms ease;
+
+    &:hover,
+    &:focus,
+    &--active {
+      outline: none;
+      transform: translate(-50%, -50%) scale(1.15);
+      box-shadow: 0 0 0 6px rgba(82, 182, 255, 0.18);
+    }
+
+    &--restaurant {
+      background: #ff7675;
+    }
+
+    &--shop {
+      background: #55efc4;
+    }
+
+    &--service {
+      background: #74b9ff;
+    }
+  }
+
+  &__bubble {
+    position: absolute;
+    transform: translate(-50%, calc(-100% - 12px));
+    width: clamp(220px, 32vw, 280px);
+    background: rgba(4, 9, 18, 0.92);
+    border: 1px solid rgba(82, 182, 255, 0.4);
+    border-radius: 16px;
+    padding: 16px;
+    box-shadow: 0 18px 38px rgba(0, 0, 0, 0.35);
+    display: grid;
+    gap: 6px;
+    cursor: pointer;
+    transition: border-color 140ms ease, box-shadow 140ms ease;
+
+    &:hover,
+    &:focus {
+      outline: none;
+      border-color: rgba(82, 182, 255, 0.85);
+      box-shadow: 0 22px 48px rgba(82, 182, 255, 0.18);
+    }
+
+    h3 {
+      margin: 0;
+      font-size: 1.05rem;
+      font-weight: 600;
+    }
+
+    p {
+      margin: 0;
+      color: rgba(255, 255, 255, 0.72);
+      font-size: 0.92rem;
+    }
+  }
+
+  &__bubble-hint {
+    font-size: 0.8rem;
+    color: rgba(82, 182, 255, 0.86);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+}

--- a/src/app/pages/landing/components/store-map/store-map.component.ts
+++ b/src/app/pages/landing/components/store-map/store-map.component.ts
@@ -1,0 +1,215 @@
+import { CommonModule, isPlatformBrowser } from '@angular/common';
+import { Component, PLATFORM_ID, computed, inject, signal } from '@angular/core';
+import { TranslationPipe } from '../../../../i18n/translation.pipe';
+
+type StoreCategory = 'restaurant' | 'shop' | 'service';
+
+interface StoreLocation {
+  readonly id: string;
+  readonly name: string;
+  readonly address: string;
+  readonly category: StoreCategory;
+  readonly latitude: number;
+  readonly longitude: number;
+}
+
+interface MarkerPosition {
+  readonly id: string;
+  readonly left: number;
+  readonly top: number;
+}
+
+interface StoreView {
+  readonly id: string;
+  readonly store: StoreLocation;
+  readonly left: number;
+  readonly top: number;
+  readonly category: StoreCategory;
+}
+
+interface BubblePosition {
+  readonly left: number;
+  readonly top: number;
+}
+
+interface SelectedStore extends StoreLocation {
+  readonly mapsUrl: string;
+}
+
+@Component({
+  selector: 'app-store-map',
+  standalone: true,
+  imports: [CommonModule, TranslationPipe],
+  templateUrl: './store-map.component.html',
+  styleUrls: ['./store-map.component.scss'],
+})
+export class StoreMapComponent {
+  private readonly stores: readonly StoreLocation[] = [
+    {
+      id: 'la-palma',
+      name: 'Bodegón La Palma',
+      address: 'Calle del Comercio 12, Valencia',
+      category: 'restaurant',
+      latitude: 39.46975,
+      longitude: -0.37739,
+    },
+    {
+      id: 'atelier-sarai',
+      name: 'Atelier Sarai',
+      address: 'Av. de Blasco Ibáñez 45, Valencia',
+      category: 'shop',
+      latitude: 39.48066,
+      longitude: -0.35357,
+    },
+    {
+      id: 'libelula-digital',
+      name: 'Libélula Digital',
+      address: 'Carrer de Sant Vicent 88, Valencia',
+      category: 'service',
+      latitude: 39.47097,
+      longitude: -0.37659,
+    },
+  ];
+
+  private readonly markerPositions: readonly MarkerPosition[] = [
+    { id: 'la-palma', left: 48, top: 62 },
+    { id: 'atelier-sarai', left: 78, top: 36 },
+    { id: 'libelula-digital', left: 60, top: 54 },
+  ];
+
+  readonly storesMap: Readonly<Record<string, StoreLocation>> = this.stores.reduce<Record<string, StoreLocation>>((acc, store) => {
+    acc[store.id] = store;
+    return acc;
+  }, {});
+
+  readonly selectedStoreId = signal<string | null>(null);
+  readonly selectedStore = computed<SelectedStore | null>(() => {
+    const currentId = this.selectedStoreId();
+    if (!currentId) {
+      return null;
+    }
+    const store = this.storesMap[currentId];
+    if (!store) {
+      return null;
+    }
+    const mapsUrl = this.buildMapsUrl(store);
+    return { ...store, mapsUrl };
+  });
+
+  readonly storeViews = computed<readonly StoreView[]>(() => {
+    return this.markerPositions
+      .map<StoreView | null>((marker) => {
+        const store = this.storesMap[marker.id];
+        if (!store) {
+          return null;
+        }
+        return {
+          id: marker.id,
+          store,
+          left: marker.left,
+          top: marker.top,
+          category: store.category,
+        };
+      })
+      .filter((view): view is StoreView => view !== null);
+  });
+
+  readonly selectedStoreView = computed<StoreView | null>(() => {
+    const currentId = this.selectedStoreId();
+    if (!currentId) {
+      return null;
+    }
+    return this.storeViews().find((view) => view.id === currentId) ?? null;
+  });
+
+  readonly bubblePosition = computed<BubblePosition | null>(() => {
+    const view = this.selectedStoreView();
+    if (!view) {
+      return null;
+    }
+    const clampedLeft = Math.min(Math.max(view.left, 8), 92);
+    const rawTop = view.top - 12;
+    const clampedTop = Math.max(Math.min(rawTop, 90), 6);
+    return { left: clampedLeft, top: clampedTop };
+  });
+
+  private static readonly MAPS_BASE_URL = 'https://www.google.com/maps/search/?api=1';
+
+  onStoreOptionClick(storeId: string) {
+    const store = this.storesMap[storeId];
+    if (!store) {
+      return;
+    }
+    this.openInMaps(store);
+  }
+
+  onMarkerFocus(storeId: string) {
+    this.selectedStoreId.set(storeId);
+  }
+
+  onMarkerBlur(storeId: string, event: FocusEvent) {
+    if (!event.relatedTarget) {
+      return;
+    }
+    const nextTarget = event.relatedTarget as HTMLElement;
+    const nextStoreId = nextTarget.dataset?.['storeId'];
+    if (nextStoreId === storeId) {
+      return;
+    }
+    this.selectedStoreId.set(null);
+  }
+
+  onMarkerClick(storeId: string) {
+    this.selectedStoreId.set(storeId);
+  }
+
+  onInfoBubbleClick() {
+    const store = this.selectedStore();
+    if (!store) {
+      return;
+    }
+    this.openInMaps(store);
+  }
+
+  onInfoBubbleKeydown(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      this.selectedStoreId.set(null);
+      return;
+    }
+    if (event.key !== 'Enter' && event.key !== ' ') {
+      return;
+    }
+    event.preventDefault();
+    this.onInfoBubbleClick();
+  }
+
+  onListOptionKeydown(event: KeyboardEvent, storeId: string) {
+    if (event.key !== 'Enter' && event.key !== ' ') {
+      return;
+    }
+    event.preventDefault();
+    this.onStoreOptionClick(storeId);
+  }
+
+  trackStoreView(_: number, view: StoreView) {
+    return view.id;
+  }
+
+  private readonly platformId = inject(PLATFORM_ID);
+  private readonly isBrowser = isPlatformBrowser(this.platformId);
+
+  private openInMaps(store: StoreLocation) {
+    if (!this.isBrowser) {
+      return;
+    }
+    const url = this.buildMapsUrl(store);
+    window.open(url, '_blank', 'noopener,noreferrer');
+  }
+
+  private buildMapsUrl(store: StoreLocation) {
+    const query = encodeURIComponent(`${store.latitude},${store.longitude}`);
+    const label = encodeURIComponent(store.name);
+    return `${StoreMapComponent.MAPS_BASE_URL}&query=${query}%20(${label})`;
+  }
+}

--- a/src/app/pages/landing/landing.page.html
+++ b/src/app/pages/landing/landing.page.html
@@ -9,6 +9,8 @@
       (fileUploadKeydown)="onFileUploadKeydown($event)" (fileDragOver)="onFileDragOver($event)"
       (fileDragLeave)="onFileDragLeave($event)" (fileDrop)="onFileDrop($event)"
       (openFilePicker)="openPdfFilePicker()"></app-landing-dropzone>
+
+    <app-store-map></app-store-map>
   </section>
 
   <app-landing-footer [appName]="appName" [version]="version" [currentYear]="currentYear"

--- a/src/app/pages/landing/landing.page.ts
+++ b/src/app/pages/landing/landing.page.ts
@@ -10,6 +10,7 @@ import { LandingDropzoneComponent } from './components/dropzone/landing-dropzone
 import { LandingFooterComponent } from './components/footer/landing-footer.component';
 import { LandingHeroComponent } from './components/hero/landing-hero.component';
 import { LandingLanguageBarComponent } from './components/language-bar/landing-language-bar.component';
+import { StoreMapComponent } from './components/store-map/store-map.component';
 
 @Component({
   selector: 'app-landing-page',
@@ -21,6 +22,7 @@ import { LandingLanguageBarComponent } from './components/language-bar/landing-l
     LandingLanguageBarComponent,
     LandingHeroComponent,
     LandingDropzoneComponent,
+    StoreMapComponent,
     LandingFooterComponent,
   ],
 })


### PR DESCRIPTION
## Summary
- add a landing page store map component that centralizes store data, marker selection, and Google Maps navigation when clicking the info bubble
- render the new component in the landing flow with styling for markers, list, and bubble, plus active-state visuals
- provide localized copy for the store map section in Spanish, English, and Catalan

## Testing
- npm run build

------
