### PR TITLE
Add French, Italian, Portuguese, and German translations

### DIFF
--- a/src/app/components/language-selector/language-selector.component.ts
+++ b/src/app/components/language-selector/language-selector.component.ts
@@ -10,6 +10,10 @@ const LANGUAGE_FLAGS: Record<Language, string> = {
   'es-ES': '🇪🇸',
   en: '🇬🇧',
   ca: '🏴',
+  fr: '🇫🇷',
+  it: '🇮🇹',
+  pt: '🇵🇹',
+  de: '🇩🇪',
 };
 
 function getLanguageFlag(language: Language): string {

--- a/src/app/i18n/translation.service.ts
+++ b/src/app/i18n/translation.service.ts
@@ -3,10 +3,14 @@ import { isPlatformBrowser } from '@angular/common';
 import { PLATFORM_ID } from '@angular/core';
 
 import ca from './translations/ca.json';
+import de from './translations/de.json';
 import en from './translations/en.json';
 import es from './translations/es-ES.json';
+import fr from './translations/fr.json';
+import it from './translations/it.json';
+import pt from './translations/pt.json';
 
-export const LANGUAGES = ['es-ES', 'en', 'ca'] as const;
+export const LANGUAGES = ['es-ES', 'en', 'ca', 'fr', 'it', 'pt', 'de'] as const;
 export type Language = (typeof LANGUAGES)[number];
 
 type TranslationRecord = typeof es;
@@ -15,6 +19,10 @@ const TRANSLATIONS: Record<Language, TranslationRecord> = {
   'es-ES': es,
   en,
   ca,
+  fr,
+  it,
+  pt,
+  de,
 };
 
 const LANGUAGE_STORAGE_KEY = 'pdf-annotator.language';

--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -6,7 +6,11 @@
     "languages": {
       "es-ES": "Espanyol",
       "en": "Anglès",
-      "ca": "Català"
+      "ca": "Català",
+      "fr": "Francès",
+      "it": "Italià",
+      "pt": "Portuguès",
+      "de": "Alemany"
     },
     "landing": {
       "badge": "Comença a anotar",

--- a/src/app/i18n/translations/de.json
+++ b/src/app/i18n/translations/de.json
@@ -1,0 +1,194 @@
+{
+  "app": {
+    "title": "PDF Annotator",
+    "languageLabel": "Sprache",
+    "languageAriaLabel": "Wählen Sie die Anwendungssprache aus",
+    "languages": {
+      "es-ES": "Spanisch",
+      "en": "Englisch",
+      "ca": "Katalanisch",
+      "fr": "Französisch",
+      "it": "Italienisch",
+      "pt": "Portugiesisch",
+      "de": "Deutsch"
+    },
+    "landing": {
+      "badge": "Schneller annotieren",
+      "title": "Platzieren Sie in Sekunden Koordinaten auf jedem PDF",
+      "description": "Laden Sie Ihr Dokument hoch, um JSON-gestützte Anmerkungen hinzuzufügen, Vorlagen wiederzuverwenden und exportfertige Dateien zu erstellen.",
+      "cta": "PDF auswählen"
+    },
+    "upload": {
+      "title": "Laden Sie Ihr PDF hoch",
+      "subtitle": "Ziehen Sie die Datei hierher oder klicken Sie, um zu durchsuchen",
+      "hint": "Nur PDF",
+      "invalidFormat": "Es werden nur PDF-Dateien unterstützt."
+    },
+    "workspaceUpload": {
+      "title": "Projekt zurücksetzen?",
+      "subtitle": "Legen Sie ein anderes PDF ab oder klicken Sie, um das aktuelle Dokument zu ersetzen.",
+      "ariaLabel": "Neues PDF hochladen, um den Arbeitsbereich zurückzusetzen"
+    }
+  },
+  "controls": {
+    "prev": "Zurück",
+    "next": "Weiter",
+    "pageIndicator": "Seite {{current}} / {{total}}",
+    "zoomLabel": "Zoom",
+    "zoomIn": "Vergrößern",
+    "zoomOut": "Verkleinern",
+    "undo": "Rückgängig",
+    "redo": "Wiederholen",
+    "clear": "Leeren",
+    "copyJson": "JSON kopieren",
+    "importJson": "JSON importieren",
+    "downloadJson": "JSON herunterladen",
+    "viewJsonTree": "Baumansicht",
+    "viewJsonText": "JSON-Editor",
+    "jsonViewModeToggle": "JSON-Ansicht",
+    "downloadPdf": "PDF herunterladen",
+    "toolbarAriaLabel": "PDF-Aktionen",
+    "navigationGroup": "Seitennavigation",
+    "zoomGroup": "Zoom-Steuerung",
+    "historyGroup": "Verlauf",
+    "exportGroup": "Exportoptionen"
+  },
+  "sidebar": {
+    "title": "Anmerkungen (JSON)",
+    "importJsonFile": "Aus Datei importieren",
+    "applyJson": "JSON anwenden",
+    "jsonPlaceholder": "Fügen Sie hier Koordinaten ein oder bearbeiten Sie diese...",
+    "jsonTree": {
+      "empty": "Der JSON-Editor ist leer.",
+      "invalid": "Der Inhalt ist kein gültiges JSON. Beheben Sie die Fehler, um die Baumansicht zu sehen."
+    },
+    "templates": {
+      "title": "Wiederverwendbare Vorlagen",
+      "placeholder": "Vorlagenname",
+      "saveButton": "Vorlage speichern",
+      "selectLabel": "Gespeicherte Vorlagen",
+      "loadButton": "Laden",
+      "deleteButton": "Löschen",
+      "empty": "Sie haben noch keine Vorlagen gespeichert."
+    },
+    "thumbnails": {
+      "title": "Miniaturen",
+      "pageLabel": "Seite {{index}}"
+    },
+    "jsonHint": "Fügen Sie Koordinaten ein oder importieren Sie sie aus einer JSON-Datei mit demselben Format wie die exportierten Daten.",
+    "advancedTitle": "Erweiterte Optionen",
+    "advancedHint": "Aktivieren Sie Hilfslinien und Einrast-Hilfen nur bei Bedarf für mehr Präzision."
+  },
+  "guides": {
+    "enableFeature": "Hilfslinien & Einrasten aktivieren",
+    "title": "Hilfslinien & Einrasten",
+    "showGrid": "Raster anzeigen",
+    "showRulers": "Lineale anzeigen",
+    "showAlignment": "Aktive Ausrichtungen hervorheben",
+    "snapGrid": "Am Raster einrasten",
+    "snapMargins": "An Rändern einrasten",
+    "snapCenters": "An Mittelachsen einrasten",
+    "snapCustom": "An benutzerdefinierten Koordinaten einrasten",
+    "gridSize": "Rasterabstand (pt)",
+    "marginSize": "Rand (pt)",
+    "tolerance": "Toleranz (px)",
+    "customX": "X-Koordinaten (pt)",
+    "customY": {
+      "canvas": "Y-Koordinaten (pt ab Oberkante)",
+      "pdf": "Y-Koordinaten (pt ab Unterkante)"
+    },
+    "customPlaceholder": "z. B. 24, 48, 120",
+    "customHint": {
+      "canvas": "Geben Sie Punktwerte getrennt durch Kommas oder Leerzeichen ein. Y wird ab der Oberkante des PDFs gemessen.",
+      "pdf": "Geben Sie Punktwerte getrennt durch Kommas oder Leerzeichen ein. Y wird ab der Unterkante des PDFs gemessen."
+    },
+    "coordinateMode": {
+      "label": "Koordinatenursprung",
+      "canvas": "Oben links (Canvas)",
+      "pdf": "Unten links (PDF)"
+    }
+  },
+  "annotation": {
+    "fields": {
+      "text": {
+        "label": "Text",
+        "placeholder": "Text..."
+      },
+      "size": {
+        "label": "Größe"
+      },
+      "font": {
+        "label": "Schriftart",
+        "customTag": "Benutzerdefiniert",
+        "searchPlaceholder": "Schriften suchen...",
+        "noResults": "Keine Schrift stimmt mit Ihrer Suche überein."
+      },
+      "opacity": {
+        "label": "Deckkraft"
+      },
+      "color": {
+        "label": "Farbe"
+      },
+      "background": {
+        "label": "Hintergrund",
+        "clear": "Hintergrund entfernen"
+      },
+      "type": {
+        "label": "Typ",
+        "options": {
+          "text": "Text",
+          "check": "Kontrollkästchen",
+          "radio": "Optionsfeld",
+          "number": "Zahl"
+        }
+      },
+      "value": {
+        "label": "Fester Wert",
+        "placeholder": "Optionaler fixer Wert..."
+      },
+      "number": {
+        "decimals": {
+          "label": "Dezimalstellen"
+        },
+        "appender": {
+          "label": "Suffix",
+          "placeholder": "Z. B. %"
+        }
+      },
+      "locked": {
+        "label": "Anmerkung sperren",
+        "toggle": "Bearbeitung und Verschieben verhindern"
+      },
+      "hidden": {
+        "label": "Anmerkung ausblenden",
+        "toggle": "Beim Export ausblenden"
+      }
+    },
+    "color": {
+      "hintPreview": "Wählen Sie eine Farbe, geben Sie HEX oder RGB ein. Der JSON-Export verwendet immer HEX.",
+      "hintEdit": "Fügen Sie einen vorhandenen HEX- oder RGB-Wert ein, um identische Farben zu verwenden.",
+      "hexPlaceholder": "#5eead4",
+      "rgbPlaceholder": "rgb(94, 234, 212)"
+    },
+    "actions": {
+      "duplicate": "Anmerkung duplizieren"
+    },
+    "editingBadge": "Bearbeitung"
+  },
+  "fonts": {
+    "custom": {
+      "enableFeature": "Benutzerdefinierte Schriften aktivieren",
+      "hint": "Aktivieren Sie diese Option, um eigene Schriftdateien über das erweiterte Menü zu laden.",
+      "title": "Benutzerdefinierte Schriften",
+      "description": "Laden Sie .ttf-, .otf-, .woff- oder .woff2-Dateien hoch, um sie in Ihren Anmerkungen zu verwenden.",
+      "add": "Schrift hinzufügen",
+      "remove": "Entfernen",
+      "empty": "Sie haben noch keine benutzerdefinierten Schriften hinzugefügt.",
+      "unsupported": "Ihr Browser unterstützt das Laden benutzerdefinierter Schriften nicht.",
+      "error": "Die Schriftdatei konnte nicht geladen werden. Versuchen Sie es mit einer anderen."
+    }
+  },
+  "viewer": {
+    "emptyMessage": "Laden Sie ein PDF hoch und klicken Sie irgendwo, um Anmerkungen hinzuzufügen. Bearbeiten Sie sie in der Vorschau, bevor Sie bestätigen ✅."
+  }
+}

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -6,7 +6,11 @@
     "languages": {
       "es-ES": "Spanish",
       "en": "English",
-      "ca": "Catalan"
+      "ca": "Catalan",
+      "fr": "French",
+      "it": "Italian",
+      "pt": "Portuguese",
+      "de": "German"
     },
     "landing": {
       "badge": "Annotate smarter",

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -6,7 +6,11 @@
     "languages": {
       "es-ES": "Español",
       "en": "Inglés",
-      "ca": "Catalán"
+      "ca": "Catalán",
+      "fr": "Francés",
+      "it": "Italiano",
+      "pt": "Portugués",
+      "de": "Alemán"
     },
     "landing": {
       "badge": "Empieza a anotar",

--- a/src/app/i18n/translations/fr.json
+++ b/src/app/i18n/translations/fr.json
@@ -1,0 +1,194 @@
+{
+  "app": {
+    "title": "PDF Annotator",
+    "languageLabel": "Langue",
+    "languageAriaLabel": "Sélectionnez la langue de l'application",
+    "languages": {
+      "es-ES": "Espagnol",
+      "en": "Anglais",
+      "ca": "Catalan",
+      "fr": "Français",
+      "it": "Italien",
+      "pt": "Portugais",
+      "de": "Allemand"
+    },
+    "landing": {
+      "badge": "Annotez plus vite",
+      "title": "Placez des coordonnées sur n'importe quel PDF en quelques secondes",
+      "description": "Téléversez votre document pour ajouter des annotations reliées à du JSON, réutiliser des modèles et exporter vos fichiers prêts à l'emploi.",
+      "cta": "Sélectionner un PDF"
+    },
+    "upload": {
+      "title": "Téléversez votre PDF",
+      "subtitle": "Glissez-déposez le fichier ici ou cliquez pour parcourir",
+      "hint": "PDF uniquement",
+      "invalidFormat": "Seuls les fichiers PDF sont pris en charge."
+    },
+    "workspaceUpload": {
+      "title": "Envie de repartir de zéro ?",
+      "subtitle": "Déposez un autre PDF ou cliquez pour remplacer le document actuel.",
+      "ariaLabel": "Téléverser un nouveau PDF pour réinitialiser l'espace de travail"
+    }
+  },
+  "controls": {
+    "prev": "Précédent",
+    "next": "Suivant",
+    "pageIndicator": "Page {{current}} / {{total}}",
+    "zoomLabel": "Zoom",
+    "zoomIn": "Agrandir",
+    "zoomOut": "Réduire",
+    "undo": "Annuler",
+    "redo": "Rétablir",
+    "clear": "Effacer",
+    "copyJson": "Copier le JSON",
+    "importJson": "Importer du JSON",
+    "downloadJson": "Télécharger le JSON",
+    "viewJsonTree": "Voir l'arbre",
+    "viewJsonText": "Voir l'éditeur JSON",
+    "jsonViewModeToggle": "Mode d'affichage du JSON",
+    "downloadPdf": "Télécharger le PDF",
+    "toolbarAriaLabel": "Actions PDF",
+    "navigationGroup": "Navigation des pages",
+    "zoomGroup": "Contrôles du zoom",
+    "historyGroup": "Actions d'historique",
+    "exportGroup": "Options d'export"
+  },
+  "sidebar": {
+    "title": "Annotations (JSON)",
+    "importJsonFile": "Importer depuis un fichier",
+    "applyJson": "Appliquer le JSON",
+    "jsonPlaceholder": "Collez ou modifiez ici les coordonnées des annotations...",
+    "jsonTree": {
+      "empty": "L'éditeur JSON est vide.",
+      "invalid": "Le contenu n'est pas un JSON valide. Corrigez les erreurs pour afficher l'arbre."
+    },
+    "templates": {
+      "title": "Modèles réutilisables",
+      "placeholder": "Nom du modèle",
+      "saveButton": "Enregistrer le modèle",
+      "selectLabel": "Modèles enregistrés",
+      "loadButton": "Charger",
+      "deleteButton": "Supprimer",
+      "empty": "Vous n'avez pas encore enregistré de modèles."
+    },
+    "thumbnails": {
+      "title": "Vignettes",
+      "pageLabel": "Page {{index}}"
+    },
+    "jsonHint": "Collez les coordonnées ou importez-les depuis un JSON en suivant le même format que les données exportées.",
+    "advancedTitle": "Options avancées",
+    "advancedHint": "Activez les guides et les aides d'alignement uniquement lorsque vous avez besoin de plus de précision."
+  },
+  "guides": {
+    "enableFeature": "Activer guides et aimantation",
+    "title": "Guides et aimantation",
+    "showGrid": "Afficher la grille",
+    "showRulers": "Afficher les règles",
+    "showAlignment": "Mettre en évidence les alignements actifs",
+    "snapGrid": "Aimanter à la grille",
+    "snapMargins": "Aimanter aux marges",
+    "snapCenters": "Aimanter aux axes centraux",
+    "snapCustom": "Aimanter aux coordonnées personnalisées",
+    "gridSize": "Espacement de grille (pt)",
+    "marginSize": "Marge (pt)",
+    "tolerance": "Tolérance (px)",
+    "customX": "Coordonnées X (pt)",
+    "customY": {
+      "canvas": "Coordonnées Y (pt depuis le bord supérieur)",
+      "pdf": "Coordonnées Y (pt depuis le bord inférieur)"
+    },
+    "customPlaceholder": "ex. 24, 48, 120",
+    "customHint": {
+      "canvas": "Saisissez des valeurs en points séparées par des virgules ou des espaces. Les valeurs Y sont mesurées depuis le bord supérieur du PDF.",
+      "pdf": "Saisissez des valeurs en points séparées par des virgules ou des espaces. Les valeurs Y sont mesurées depuis le bord inférieur du PDF."
+    },
+    "coordinateMode": {
+      "label": "Origine des coordonnées",
+      "canvas": "Coin supérieur gauche (Canvas)",
+      "pdf": "Coin inférieur gauche (PDF)"
+    }
+  },
+  "annotation": {
+    "fields": {
+      "text": {
+        "label": "Texte",
+        "placeholder": "Texte..."
+      },
+      "size": {
+        "label": "Taille"
+      },
+      "font": {
+        "label": "Police",
+        "customTag": "Personnalisée",
+        "searchPlaceholder": "Rechercher des polices...",
+        "noResults": "Aucune police ne correspond à votre recherche."
+      },
+      "opacity": {
+        "label": "Opacité"
+      },
+      "color": {
+        "label": "Couleur"
+      },
+      "background": {
+        "label": "Arrière-plan",
+        "clear": "Supprimer l'arrière-plan"
+      },
+      "type": {
+        "label": "Type",
+        "options": {
+          "text": "Texte",
+          "check": "Case à cocher",
+          "radio": "Bouton radio",
+          "number": "Nombre"
+        }
+      },
+      "value": {
+        "label": "Valeur forcée",
+        "placeholder": "Valeur fixe optionnelle..."
+      },
+      "number": {
+        "decimals": {
+          "label": "Décimales"
+        },
+        "appender": {
+          "label": "Suffixe",
+          "placeholder": "Ex. %"
+        }
+      },
+      "locked": {
+        "label": "Verrouiller l'annotation",
+        "toggle": "Empêcher les modifications et le déplacement"
+      },
+      "hidden": {
+        "label": "Masquer l'annotation",
+        "toggle": "Masquer lors de l'export"
+      }
+    },
+    "color": {
+      "hintPreview": "Choisissez une couleur, saisissez un HEX ou un RGB. Le JSON exportera toujours la couleur en HEX.",
+      "hintEdit": "Collez un HEX ou un RGB existant pour réutiliser des couleurs exactes.",
+      "hexPlaceholder": "#5eead4",
+      "rgbPlaceholder": "rgb(94, 234, 212)"
+    },
+    "actions": {
+      "duplicate": "Dupliquer l'annotation"
+    },
+    "editingBadge": "Édition"
+  },
+  "fonts": {
+    "custom": {
+      "enableFeature": "Activer les polices personnalisées",
+      "hint": "Activez cette option pour charger vos propres fichiers de police depuis le menu avancé.",
+      "title": "Polices personnalisées",
+      "description": "Téléversez des fichiers .ttf, .otf, .woff ou .woff2 pour les réutiliser dans vos annotations.",
+      "add": "Ajouter une police",
+      "remove": "Supprimer",
+      "empty": "Vous n'avez pas encore ajouté de polices personnalisées.",
+      "unsupported": "Votre navigateur ne permet pas de charger des polices personnalisées.",
+      "error": "Impossible de charger ce fichier de police. Essayez avec un autre."
+    }
+  },
+  "viewer": {
+    "emptyMessage": "Téléversez un PDF et cliquez n'importe où pour ajouter des annotations. Modifiez-les dans l'aperçu avant de valider ✅."
+  }
+}

--- a/src/app/i18n/translations/it.json
+++ b/src/app/i18n/translations/it.json
@@ -1,0 +1,194 @@
+{
+  "app": {
+    "title": "PDF Annotator",
+    "languageLabel": "Lingua",
+    "languageAriaLabel": "Seleziona la lingua dell'applicazione",
+    "languages": {
+      "es-ES": "Spagnolo",
+      "en": "Inglese",
+      "ca": "Catalano",
+      "fr": "Francese",
+      "it": "Italiano",
+      "pt": "Portoghese",
+      "de": "Tedesco"
+    },
+    "landing": {
+      "badge": "Annota più velocemente",
+      "title": "Posiziona coordinate su qualsiasi PDF in pochi secondi",
+      "description": "Carica il documento per aggiungere annotazioni collegate a JSON, riutilizzare modelli ed esportare file pronti all'uso.",
+      "cta": "Seleziona PDF"
+    },
+    "upload": {
+      "title": "Carica il tuo PDF",
+      "subtitle": "Trascina il file qui oppure fai clic per sfogliare",
+      "hint": "Solo PDF",
+      "invalidFormat": "Sono supportati solo i file PDF."
+    },
+    "workspaceUpload": {
+      "title": "Vuoi ricominciare da capo?",
+      "subtitle": "Trascina un altro PDF oppure fai clic per sostituire il documento attuale.",
+      "ariaLabel": "Carica un nuovo PDF per reimpostare l'area di lavoro"
+    }
+  },
+  "controls": {
+    "prev": "Precedente",
+    "next": "Successivo",
+    "pageIndicator": "Pagina {{current}} / {{total}}",
+    "zoomLabel": "Zoom",
+    "zoomIn": "Aumenta zoom",
+    "zoomOut": "Riduci zoom",
+    "undo": "Annulla",
+    "redo": "Ripeti",
+    "clear": "Pulisci",
+    "copyJson": "Copia JSON",
+    "importJson": "Importa JSON",
+    "downloadJson": "Scarica JSON",
+    "viewJsonTree": "Visualizza ad albero",
+    "viewJsonText": "Visualizza editor JSON",
+    "jsonViewModeToggle": "Modalità di visualizzazione JSON",
+    "downloadPdf": "Scarica PDF",
+    "toolbarAriaLabel": "Azioni PDF",
+    "navigationGroup": "Navigazione pagine",
+    "zoomGroup": "Controlli zoom",
+    "historyGroup": "Azioni cronologia",
+    "exportGroup": "Opzioni di esportazione"
+  },
+  "sidebar": {
+    "title": "Annotazioni (JSON)",
+    "importJsonFile": "Importa da file",
+    "applyJson": "Applica JSON",
+    "jsonPlaceholder": "Incolla o modifica qui le coordinate delle annotazioni...",
+    "jsonTree": {
+      "empty": "L'editor JSON è vuoto.",
+      "invalid": "Il contenuto non è un JSON valido. Correggi gli errori per visualizzare l'albero."
+    },
+    "templates": {
+      "title": "Modelli riutilizzabili",
+      "placeholder": "Nome del modello",
+      "saveButton": "Salva modello",
+      "selectLabel": "Modelli salvati",
+      "loadButton": "Carica",
+      "deleteButton": "Elimina",
+      "empty": "Non hai ancora salvato alcun modello."
+    },
+    "thumbnails": {
+      "title": "Miniature",
+      "pageLabel": "Pagina {{index}}"
+    },
+    "jsonHint": "Incolla le coordinate o importale da un JSON seguendo lo stesso formato dei dati esportati.",
+    "advancedTitle": "Opzioni avanzate",
+    "advancedHint": "Attiva guide e agganci solo quando ti serve maggiore precisione."
+  },
+  "guides": {
+    "enableFeature": "Attiva guide e agganci",
+    "title": "Guide e agganci",
+    "showGrid": "Mostra griglia",
+    "showRulers": "Mostra righelli",
+    "showAlignment": "Evidenzia allineamenti attivi",
+    "snapGrid": "Aggancia alla griglia",
+    "snapMargins": "Aggancia ai margini",
+    "snapCenters": "Aggancia agli assi centrali",
+    "snapCustom": "Aggancia a coordinate personalizzate",
+    "gridSize": "Passo griglia (pt)",
+    "marginSize": "Margine (pt)",
+    "tolerance": "Tolleranza (px)",
+    "customX": "Coordinate X (pt)",
+    "customY": {
+      "canvas": "Coordinate Y (pt dal bordo superiore)",
+      "pdf": "Coordinate Y (pt dal bordo inferiore)"
+    },
+    "customPlaceholder": "es. 24, 48, 120",
+    "customHint": {
+      "canvas": "Inserisci valori in punti separati da virgole o spazi. Le Y sono misurate dal bordo superiore del PDF.",
+      "pdf": "Inserisci valori in punti separati da virgole o spazi. Le Y sono misurate dal bordo inferiore del PDF."
+    },
+    "coordinateMode": {
+      "label": "Origine delle coordinate",
+      "canvas": "Angolo superiore sinistro (Canvas)",
+      "pdf": "Angolo inferiore sinistro (PDF)"
+    }
+  },
+  "annotation": {
+    "fields": {
+      "text": {
+        "label": "Testo",
+        "placeholder": "Testo..."
+      },
+      "size": {
+        "label": "Dimensione"
+      },
+      "font": {
+        "label": "Font",
+        "customTag": "Personalizzato",
+        "searchPlaceholder": "Cerca font...",
+        "noResults": "Nessun font corrisponde alla ricerca."
+      },
+      "opacity": {
+        "label": "Opacità"
+      },
+      "color": {
+        "label": "Colore"
+      },
+      "background": {
+        "label": "Sfondo",
+        "clear": "Rimuovi sfondo"
+      },
+      "type": {
+        "label": "Tipo",
+        "options": {
+          "text": "Testo",
+          "check": "Checkbox",
+          "radio": "Radio button",
+          "number": "Numero"
+        }
+      },
+      "value": {
+        "label": "Valore fisso",
+        "placeholder": "Valore opzionale..."
+      },
+      "number": {
+        "decimals": {
+          "label": "Decimali"
+        },
+        "appender": {
+          "label": "Suffisso",
+          "placeholder": "Es. %"
+        }
+      },
+      "locked": {
+        "label": "Blocca annotazione",
+        "toggle": "Impedisci modifiche e trascinamento"
+      },
+      "hidden": {
+        "label": "Nascondi annotazione",
+        "toggle": "Nascondi durante l'esportazione"
+      }
+    },
+    "color": {
+      "hintPreview": "Scegli un colore, inserisci un HEX o un RGB. Il JSON esporterà sempre il colore in HEX.",
+      "hintEdit": "Incolla un HEX o un RGB esistente per riutilizzare colori identici.",
+      "hexPlaceholder": "#5eead4",
+      "rgbPlaceholder": "rgb(94, 234, 212)"
+    },
+    "actions": {
+      "duplicate": "Duplica annotazione"
+    },
+    "editingBadge": "Modifica in corso"
+  },
+  "fonts": {
+    "custom": {
+      "enableFeature": "Attiva font personalizzati",
+      "hint": "Attiva questa opzione per caricare i tuoi file di font dal pannello avanzato.",
+      "title": "Font personalizzati",
+      "description": "Carica file .ttf, .otf, .woff o .woff2 per riutilizzarli nelle annotazioni.",
+      "add": "Aggiungi font",
+      "remove": "Rimuovi",
+      "empty": "Non hai ancora aggiunto font personalizzati.",
+      "unsupported": "Il tuo browser non supporta il caricamento di font personalizzati.",
+      "error": "Impossibile caricare il file del font. Prova con un altro."
+    }
+  },
+  "viewer": {
+    "emptyMessage": "Carica un PDF e fai clic in qualsiasi punto per aggiungere annotazioni. Modificale nell'anteprima prima di confermare ✅."
+  }
+}

--- a/src/app/i18n/translations/pt.json
+++ b/src/app/i18n/translations/pt.json
@@ -1,0 +1,194 @@
+{
+  "app": {
+    "title": "PDF Annotator",
+    "languageLabel": "Idioma",
+    "languageAriaLabel": "Selecione o idioma da aplicação",
+    "languages": {
+      "es-ES": "Espanhol",
+      "en": "Inglês",
+      "ca": "Catalão",
+      "fr": "Francês",
+      "it": "Italiano",
+      "pt": "Português",
+      "de": "Alemão"
+    },
+    "landing": {
+      "badge": "Anote mais rápido",
+      "title": "Marque coordenadas em qualquer PDF em segundos",
+      "description": "Envie o seu documento para adicionar anotações ligadas a JSON, reutilizar modelos e exportar ficheiros prontos a usar.",
+      "cta": "Selecionar PDF"
+    },
+    "upload": {
+      "title": "Carregue o seu PDF",
+      "subtitle": "Arraste e largue o ficheiro aqui ou clique para procurar",
+      "hint": "Apenas PDF",
+      "invalidFormat": "Apenas ficheiros PDF são suportados."
+    },
+    "workspaceUpload": {
+      "title": "Precisa de recomeçar?",
+      "subtitle": "Largue outro PDF ou clique para substituir o documento atual.",
+      "ariaLabel": "Carregar um novo PDF para reiniciar o espaço de trabalho"
+    }
+  },
+  "controls": {
+    "prev": "Anterior",
+    "next": "Seguinte",
+    "pageIndicator": "Página {{current}} / {{total}}",
+    "zoomLabel": "Zoom",
+    "zoomIn": "Aumentar",
+    "zoomOut": "Reduzir",
+    "undo": "Anular",
+    "redo": "Refazer",
+    "clear": "Limpar",
+    "copyJson": "Copiar JSON",
+    "importJson": "Importar JSON",
+    "downloadJson": "Transferir JSON",
+    "viewJsonTree": "Ver em árvore",
+    "viewJsonText": "Ver editor JSON",
+    "jsonViewModeToggle": "Modo de visualização JSON",
+    "downloadPdf": "Transferir PDF",
+    "toolbarAriaLabel": "Ações do PDF",
+    "navigationGroup": "Navegação de páginas",
+    "zoomGroup": "Controlos de zoom",
+    "historyGroup": "Ações de histórico",
+    "exportGroup": "Opções de exportação"
+  },
+  "sidebar": {
+    "title": "Anotações (JSON)",
+    "importJsonFile": "Importar de ficheiro",
+    "applyJson": "Aplicar JSON",
+    "jsonPlaceholder": "Cole ou edite aqui as coordenadas das anotações...",
+    "jsonTree": {
+      "empty": "O editor JSON está vazio.",
+      "invalid": "O conteúdo não é um JSON válido. Corrija os erros para ver a árvore."
+    },
+    "templates": {
+      "title": "Modelos reutilizáveis",
+      "placeholder": "Nome do modelo",
+      "saveButton": "Guardar modelo",
+      "selectLabel": "Modelos guardados",
+      "loadButton": "Carregar",
+      "deleteButton": "Eliminar",
+      "empty": "Ainda não guardou nenhum modelo."
+    },
+    "thumbnails": {
+      "title": "Miniaturas",
+      "pageLabel": "Página {{index}}"
+    },
+    "jsonHint": "Cole as coordenadas ou importe-as de um JSON com o mesmo formato dos dados exportados.",
+    "advancedTitle": "Opções avançadas",
+    "advancedHint": "Ative as guias e os auxiliares de alinhamento apenas quando precisar de mais precisão."
+  },
+  "guides": {
+    "enableFeature": "Ativar guias e encaixes",
+    "title": "Guias e encaixes",
+    "showGrid": "Mostrar grelha",
+    "showRulers": "Mostrar réguas",
+    "showAlignment": "Destacar alinhamentos ativos",
+    "snapGrid": "Encaixar na grelha",
+    "snapMargins": "Encaixar nas margens",
+    "snapCenters": "Encaixar nos eixos centrais",
+    "snapCustom": "Encaixar em coordenadas personalizadas",
+    "gridSize": "Espaçamento da grelha (pt)",
+    "marginSize": "Margem (pt)",
+    "tolerance": "Tolerância (px)",
+    "customX": "Coordenadas X (pt)",
+    "customY": {
+      "canvas": "Coordenadas Y (pt desde a margem superior)",
+      "pdf": "Coordenadas Y (pt desde a margem inferior)"
+    },
+    "customPlaceholder": "ex.: 24, 48, 120",
+    "customHint": {
+      "canvas": "Introduza valores em pontos separados por vírgulas ou espaços. Os valores Y são medidos a partir da margem superior do PDF.",
+      "pdf": "Introduza valores em pontos separados por vírgulas ou espaços. Os valores Y são medidos a partir da margem inferior do PDF."
+    },
+    "coordinateMode": {
+      "label": "Origem das coordenadas",
+      "canvas": "Canto superior esquerdo (Canvas)",
+      "pdf": "Canto inferior esquerdo (PDF)"
+    }
+  },
+  "annotation": {
+    "fields": {
+      "text": {
+        "label": "Texto",
+        "placeholder": "Texto..."
+      },
+      "size": {
+        "label": "Tamanho"
+      },
+      "font": {
+        "label": "Tipo de letra",
+        "customTag": "Personalizado",
+        "searchPlaceholder": "Procurar tipos de letra...",
+        "noResults": "Nenhum tipo de letra corresponde à pesquisa."
+      },
+      "opacity": {
+        "label": "Opacidade"
+      },
+      "color": {
+        "label": "Cor"
+      },
+      "background": {
+        "label": "Fundo",
+        "clear": "Remover fundo"
+      },
+      "type": {
+        "label": "Tipo",
+        "options": {
+          "text": "Texto",
+          "check": "Caixa de seleção",
+          "radio": "Botão de opção",
+          "number": "Número"
+        }
+      },
+      "value": {
+        "label": "Valor fixo",
+        "placeholder": "Valor opcional..."
+      },
+      "number": {
+        "decimals": {
+          "label": "Decimais"
+        },
+        "appender": {
+          "label": "Sufixo",
+          "placeholder": "Ex.: %"
+        }
+      },
+      "locked": {
+        "label": "Bloquear anotação",
+        "toggle": "Impedir edições e arrasto"
+      },
+      "hidden": {
+        "label": "Ocultar anotação",
+        "toggle": "Ocultar ao exportar"
+      }
+    },
+    "color": {
+      "hintPreview": "Escolha uma cor, introduza um HEX ou um RGB. O JSON exportará sempre a cor em HEX.",
+      "hintEdit": "Cole um HEX ou um RGB existente para reutilizar cores exatas.",
+      "hexPlaceholder": "#5eead4",
+      "rgbPlaceholder": "rgb(94, 234, 212)"
+    },
+    "actions": {
+      "duplicate": "Duplicar anotação"
+    },
+    "editingBadge": "A editar"
+  },
+  "fonts": {
+    "custom": {
+      "enableFeature": "Ativar tipos de letra personalizados",
+      "hint": "Ative esta opção para carregar os seus ficheiros de fontes a partir do menu avançado.",
+      "title": "Tipos de letra personalizados",
+      "description": "Carregue ficheiros .ttf, .otf, .woff ou .woff2 para os reutilizar nas suas anotações.",
+      "add": "Adicionar tipo de letra",
+      "remove": "Remover",
+      "empty": "Ainda não adicionou tipos de letra personalizados.",
+      "unsupported": "O seu navegador não suporta o carregamento de tipos de letra personalizados.",
+      "error": "Não foi possível carregar esse ficheiro de fonte. Tente outro."
+    }
+  },
+  "viewer": {
+    "emptyMessage": "Carregue um PDF e clique em qualquer ponto para adicionar anotações. Edite-as na pré-visualização antes de confirmar ✅."
+  }
+}


### PR DESCRIPTION
## Summary
- add full French, Italian, Portuguese, and German dictionaries to the i18n layer
- register the new locales in the translation service and expose their flags in the selector
- expand existing language lists so every locale names the complete set

## Testing
- npm run lint *(fails: script not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916e20686908325a48336a5eb0b4b06)