### PR TITLE
Add PDF cursor coordinate indicator

### DIFF
--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -47,6 +47,8 @@
     "viewJsonText": "Veure editor JSON",
     "jsonViewModeToggle": "Mode de visualització del JSON",
     "downloadPdf": "Descarregar PDF",
+    "cursorLabel": "Cursor (PDF)",
+    "cursorInactive": "Passa el cursor pel PDF per veure les coordenades",
     "toolbarAriaLabel": "Accions del PDF",
     "navigationGroup": "Navegació de pàgines",
     "zoomGroup": "Controls de zoom",

--- a/src/app/i18n/translations/de.json
+++ b/src/app/i18n/translations/de.json
@@ -47,6 +47,8 @@
     "viewJsonText": "JSON-Editor",
     "jsonViewModeToggle": "JSON-Ansicht",
     "downloadPdf": "PDF herunterladen",
+    "cursorLabel": "Cursor (PDF)",
+    "cursorInactive": "Fahre über das PDF, um Koordinaten zu sehen",
     "toolbarAriaLabel": "PDF-Aktionen",
     "navigationGroup": "Seitennavigation",
     "zoomGroup": "Zoom-Steuerung",

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -47,6 +47,8 @@
     "viewJsonText": "View JSON editor",
     "jsonViewModeToggle": "JSON view mode",
     "downloadPdf": "Download PDF",
+    "cursorLabel": "Cursor (PDF)",
+    "cursorInactive": "Hover over the PDF to see coordinates",
     "toolbarAriaLabel": "PDF actions",
     "navigationGroup": "Page navigation",
     "zoomGroup": "Zoom controls",

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -47,6 +47,8 @@
     "viewJsonText": "Volver al editor",
     "jsonViewModeToggle": "Modo de visualización del JSON",
     "downloadPdf": "Descargar PDF",
+    "cursorLabel": "Cursor (PDF)",
+    "cursorInactive": "Mueve el cursor sobre el PDF",
     "toolbarAriaLabel": "Acciones del PDF",
     "navigationGroup": "Navegación de páginas",
     "zoomGroup": "Controles de zoom",

--- a/src/app/i18n/translations/fr.json
+++ b/src/app/i18n/translations/fr.json
@@ -47,6 +47,8 @@
     "viewJsonText": "Voir l'éditeur JSON",
     "jsonViewModeToggle": "Mode d'affichage du JSON",
     "downloadPdf": "Télécharger le PDF",
+    "cursorLabel": "Curseur (PDF)",
+    "cursorInactive": "Survolez le PDF pour voir les coordonnées",
     "toolbarAriaLabel": "Actions PDF",
     "navigationGroup": "Navigation des pages",
     "zoomGroup": "Contrôles du zoom",

--- a/src/app/i18n/translations/it.json
+++ b/src/app/i18n/translations/it.json
@@ -47,6 +47,8 @@
     "viewJsonText": "Visualizza editor JSON",
     "jsonViewModeToggle": "Modalità di visualizzazione JSON",
     "downloadPdf": "Scarica PDF",
+    "cursorLabel": "Cursore (PDF)",
+    "cursorInactive": "Passa il cursore sul PDF per vedere le coordinate",
     "toolbarAriaLabel": "Azioni PDF",
     "navigationGroup": "Navigazione pagine",
     "zoomGroup": "Controlli zoom",

--- a/src/app/i18n/translations/pt.json
+++ b/src/app/i18n/translations/pt.json
@@ -47,6 +47,8 @@
     "viewJsonText": "Ver editor JSON",
     "jsonViewModeToggle": "Modo de visualização JSON",
     "downloadPdf": "Transferir PDF",
+    "cursorLabel": "Cursor (PDF)",
+    "cursorInactive": "Passe o cursor sobre o PDF para ver as coordenadas",
     "toolbarAriaLabel": "Ações do PDF",
     "navigationGroup": "Navegação de páginas",
     "zoomGroup": "Controlos de zoom",

--- a/src/app/pages/workspace/components/header/workspace-header.component.html
+++ b/src/app/pages/workspace/components/header/workspace-header.component.html
@@ -36,21 +36,6 @@
       </button>
     </div>
 
-    <div class="toolbar__group toolbar__group--coords" role="status"
-      [attr.aria-label]="'controls.cursorLabel' | t">
-      <ng-container *ngIf="vm.cursorPdfCoords() as cursor; else coordsIdle">
-        <span class="toolbar__badge toolbar__badge--coords">
-          <span class="toolbar__coords-label">{{ 'controls.cursorLabel' | t }}</span>
-          <span class="toolbar__coords-value">X: {{ cursor.x | number:'1.0-2' }}</span>
-          <span class="toolbar__coords-divider" aria-hidden="true">·</span>
-          <span class="toolbar__coords-value">Y: {{ cursor.y | number:'1.0-2' }}</span>
-        </span>
-      </ng-container>
-      <ng-template #coordsIdle>
-        <span class="toolbar__badge toolbar__badge--coords">{{ 'controls.cursorInactive' | t }}</span>
-      </ng-template>
-    </div>
-
     <div class="toolbar__group" role="group" [attr.aria-label]="'controls.historyGroup' | t">
       <button class="btn btn--icon" (click)="vm.undo()" [disabled]="!vm.canUndo()">
         <span class="btn__icon" aria-hidden="true">↺</span>

--- a/src/app/pages/workspace/components/header/workspace-header.component.html
+++ b/src/app/pages/workspace/components/header/workspace-header.component.html
@@ -36,6 +36,21 @@
       </button>
     </div>
 
+    <div class="toolbar__group toolbar__group--coords" role="status"
+      [attr.aria-label]="'controls.cursorLabel' | t">
+      <ng-container *ngIf="vm.cursorPdfCoords() as cursor; else coordsIdle">
+        <span class="toolbar__badge toolbar__badge--coords">
+          <span class="toolbar__coords-label">{{ 'controls.cursorLabel' | t }}</span>
+          <span class="toolbar__coords-value">X: {{ cursor.x | number:'1.0-2' }}</span>
+          <span class="toolbar__coords-divider" aria-hidden="true">·</span>
+          <span class="toolbar__coords-value">Y: {{ cursor.y | number:'1.0-2' }}</span>
+        </span>
+      </ng-container>
+      <ng-template #coordsIdle>
+        <span class="toolbar__badge toolbar__badge--coords">{{ 'controls.cursorInactive' | t }}</span>
+      </ng-template>
+    </div>
+
     <div class="toolbar__group" role="group" [attr.aria-label]="'controls.historyGroup' | t">
       <button class="btn btn--icon" (click)="vm.undo()" [disabled]="!vm.canUndo()">
         <span class="btn__icon" aria-hidden="true">↺</span>

--- a/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.html
+++ b/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.html
@@ -1,4 +1,16 @@
 <aside class="sidebar">
+  <div class="json-coords" role="status" [attr.aria-label]="'controls.cursorLabel' | t">
+    <ng-container *ngIf="vm.cursorPdfCoords() as cursor; else coordsIdle">
+      <span class="json-coords__label">{{ 'controls.cursorLabel' | t }}</span>
+      <span class="json-coords__value">X: {{ cursor.x | number:'1.0-2' }}</span>
+      <span class="json-coords__divider" aria-hidden="true">·</span>
+      <span class="json-coords__value">Y: {{ cursor.y | number:'1.0-2' }}</span>
+    </ng-container>
+    <ng-template #coordsIdle>
+      <span class="json-coords__idle">{{ 'controls.cursorInactive' | t }}</span>
+    </ng-template>
+  </div>
+
   <section class="sidebar-upload" role="button" tabindex="0" (click)="vm.openPdfFilePicker()"
     (keydown)="vm.onFileUploadKeydown($event)" (dragover)="vm.onFileDragOver($event)"
     (dragleave)="vm.onFileDragLeave($event)" (drop)="vm.onFileDrop($event)"
@@ -67,18 +79,6 @@
       <p class="templates__empty">{{ 'sidebar.templates.empty' | t }}</p>
     </ng-template>
   </section>
-  <div class="json-coords" role="status" [attr.aria-label]="'controls.cursorLabel' | t">
-    <ng-container *ngIf="vm.cursorPdfCoords() as cursor; else coordsIdle">
-      <span class="json-coords__label">{{ 'controls.cursorLabel' | t }}</span>
-      <span class="json-coords__value">X: {{ cursor.x | number:'1.0-2' }}</span>
-      <span class="json-coords__divider" aria-hidden="true">·</span>
-      <span class="json-coords__value">Y: {{ cursor.y | number:'1.0-2' }}</span>
-    </ng-container>
-    <ng-template #coordsIdle>
-      <span class="json-coords__idle">{{ 'controls.cursorInactive' | t }}</span>
-    </ng-template>
-  </div>
-
   <ng-container *ngIf="vm.jsonViewMode() === 'text'; else jsonTreeView">
     <textarea #jsonEditor class="json-editor" [ngModel]="vm.coordsTextModel"
       (ngModelChange)="vm.onCoordsTextChange($event)" [placeholder]="'sidebar.jsonPlaceholder' | t" spellcheck="false"></textarea>

--- a/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.html
+++ b/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.html
@@ -67,6 +67,18 @@
       <p class="templates__empty">{{ 'sidebar.templates.empty' | t }}</p>
     </ng-template>
   </section>
+  <div class="json-coords" role="status" [attr.aria-label]="'controls.cursorLabel' | t">
+    <ng-container *ngIf="vm.cursorPdfCoords() as cursor; else coordsIdle">
+      <span class="json-coords__label">{{ 'controls.cursorLabel' | t }}</span>
+      <span class="json-coords__value">X: {{ cursor.x | number:'1.0-2' }}</span>
+      <span class="json-coords__divider" aria-hidden="true">·</span>
+      <span class="json-coords__value">Y: {{ cursor.y | number:'1.0-2' }}</span>
+    </ng-container>
+    <ng-template #coordsIdle>
+      <span class="json-coords__idle">{{ 'controls.cursorInactive' | t }}</span>
+    </ng-template>
+  </div>
+
   <ng-container *ngIf="vm.jsonViewMode() === 'text'; else jsonTreeView">
     <textarea #jsonEditor class="json-editor" [ngModel]="vm.coordsTextModel"
       (ngModelChange)="vm.onCoordsTextChange($event)" [placeholder]="'sidebar.jsonPlaceholder' | t" spellcheck="false"></textarea>

--- a/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.scss
+++ b/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.scss
@@ -30,6 +30,36 @@
   display: block;
 }
 
+.json-coords {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 14px 0;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(94, 234, 212, 0.14);
+  background: rgba(18, 20, 30, 0.7);
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+
+.json-coords__label {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.json-coords__value {
+  font-weight: 600;
+}
+
+.json-coords__divider {
+  opacity: 0.6;
+}
+
+.json-coords__idle {
+  color: rgba(255, 255, 255, 0.75);
+}
+
 @media (max-width: 1024px) {
   .sidebar-thumbnails__list {
     max-height: clamp(140px, 28vh, 300px);

--- a/src/app/pages/workspace/components/viewer/workspace-viewer.component.html
+++ b/src/app/pages/workspace/components/viewer/workspace-viewer.component.html
@@ -1,5 +1,5 @@
 <main class="viewer" *ngIf="vm.pdfDoc as _">
-  <div class="canvas-container" #pdfViewer>
+  <div class="canvas-container" #pdfViewer (mousemove)="vm.onViewerMouseMove($event)" (mouseleave)="vm.onViewerMouseLeave()">
     <canvas #pdfCanvas class="canvas canvas--pdf"></canvas>
     <canvas #overlayCanvas class="canvas canvas--overlay"></canvas>
     <div #annotationsLayer class="annotations-layer"></div>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -265,6 +265,25 @@ header .logo {
   font-weight: 600;
 }
 
+.toolbar__group--coords {
+  flex-wrap: wrap;
+}
+
+.toolbar__badge--coords {
+  gap: 8px;
+  background: rgba(94, 234, 212, 0.15);
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+
+.toolbar__coords-label {
+  color: var(--accent);
+}
+
+.toolbar__coords-divider {
+  opacity: 0.6;
+}
+
 .btn {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- show a cursor coordinate badge in the workspace header using PDF-based values when hovering the viewer
- convert viewer mouse movement into PDF coordinates, clearing the indicator when leaving the canvas or loading a new file
- style the new toolbar badge and add translations for the new cursor strings

## Testing
- npm run lint *(fails: script not defined in package.json)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691adfcd5eac8325a4ba1be9717a23c4)