### PR TITLE
Improve accessibility and keyboard navigation

### DIFF
--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -53,7 +53,10 @@
     "navigationGroup": "Navegació de pàgines",
     "zoomGroup": "Controls de zoom",
     "historyGroup": "Accions d'historial",
-    "exportGroup": "Opcions d'exportació"
+    "exportGroup": "Opcions d'exportació",
+    "accessibilityGroup": "Opcions d'accessibilitat",
+    "highContrast": "Alt contrast",
+    "highContrastToggle": "Activar tema d'alt contrast"
   },
   "sidebar": {
     "title": "Anotacions (JSON)",
@@ -172,10 +175,17 @@
       "hexPlaceholder": "#5eead4",
       "rgbPlaceholder": "rgb(94, 234, 212)"
     },
-    "actions": {
-      "duplicate": "Duplicar anotació"
-    },
-    "editingBadge": "Editant"
+      "actions": {
+        "duplicate": "Duplicar anotació",
+        "confirm": "Desar anotació",
+        "cancel": "Cancel·lar edició",
+        "delete": "Eliminar anotació"
+      },
+      "aria": {
+        "summary": "Anotació {{index}} a la pàgina {{page}} ({{type}}: {{name}})",
+        "unnamed": "Camp sense nom"
+      },
+      "editingBadge": "Editant"
   },
   "fonts": {
     "custom": {

--- a/src/app/i18n/translations/de.json
+++ b/src/app/i18n/translations/de.json
@@ -53,7 +53,10 @@
     "navigationGroup": "Seitennavigation",
     "zoomGroup": "Zoom-Steuerung",
     "historyGroup": "Verlauf",
-    "exportGroup": "Exportoptionen"
+    "exportGroup": "Exportoptionen",
+    "accessibilityGroup": "Barrierefreiheit",
+    "highContrast": "Hoher Kontrast",
+    "highContrastToggle": "Hochkontrast-Theme aktivieren"
   },
   "sidebar": {
     "title": "Anmerkungen (JSON)",
@@ -172,10 +175,17 @@
       "hexPlaceholder": "#5eead4",
       "rgbPlaceholder": "rgb(94, 234, 212)"
     },
-    "actions": {
-      "duplicate": "Anmerkung duplizieren"
-    },
-    "editingBadge": "Bearbeitung"
+      "actions": {
+        "duplicate": "Anmerkung duplizieren",
+        "confirm": "Annotation speichern",
+        "cancel": "Bearbeitung abbrechen",
+        "delete": "Annotation löschen"
+      },
+      "aria": {
+        "summary": "Anmerkung {{index}} auf Seite {{page}} ({{type}}: {{name}})",
+        "unnamed": "Unbenanntes Feld"
+      },
+      "editingBadge": "Bearbeitung"
   },
   "fonts": {
     "custom": {

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -53,7 +53,10 @@
     "navigationGroup": "Page navigation",
     "zoomGroup": "Zoom controls",
     "historyGroup": "History actions",
-    "exportGroup": "Export options"
+    "exportGroup": "Export options",
+    "accessibilityGroup": "Accessibility options",
+    "highContrast": "High contrast",
+    "highContrastToggle": "Toggle high contrast theme"
   },
   "sidebar": {
     "title": "Annotations (JSON)",
@@ -172,10 +175,17 @@
       "hexPlaceholder": "#5eead4",
       "rgbPlaceholder": "rgb(94, 234, 212)"
     },
-    "actions": {
-      "duplicate": "Duplicate annotation"
-    },
-    "editingBadge": "Editing"
+      "actions": {
+        "duplicate": "Duplicate annotation",
+        "confirm": "Save annotation",
+        "cancel": "Cancel editing",
+        "delete": "Delete annotation"
+      },
+      "aria": {
+        "summary": "Annotation {{index}} on page {{page}} ({{type}}: {{name}})",
+        "unnamed": "Unnamed field"
+      },
+      "editingBadge": "Editing"
   },
   "fonts": {
     "custom": {

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -53,7 +53,10 @@
     "navigationGroup": "Navegación de páginas",
     "zoomGroup": "Controles de zoom",
     "historyGroup": "Acciones de historial",
-    "exportGroup": "Opciones de exportación"
+    "exportGroup": "Opciones de exportación",
+    "accessibilityGroup": "Opciones de accesibilidad",
+    "highContrast": "Alto contraste",
+    "highContrastToggle": "Activar tema de alto contraste"
   },
   "sidebar": {
     "title": "Anotaciones (JSON)",
@@ -172,10 +175,17 @@
       "hexPlaceholder": "#5eead4",
       "rgbPlaceholder": "rgb(94, 234, 212)"
     },
-    "actions": {
-      "duplicate": "Duplicar anotación"
-    },
-    "editingBadge": "Editando"
+      "actions": {
+        "duplicate": "Duplicar anotación",
+        "confirm": "Guardar anotación",
+        "cancel": "Cancelar edición",
+        "delete": "Eliminar anotación"
+      },
+      "aria": {
+        "summary": "Anotación {{index}} en la página {{page}} ({{type}}: {{name}})",
+        "unnamed": "Campo sin nombre"
+      },
+      "editingBadge": "Editando"
   },
   "fonts": {
     "custom": {

--- a/src/app/i18n/translations/fr.json
+++ b/src/app/i18n/translations/fr.json
@@ -53,7 +53,10 @@
     "navigationGroup": "Navigation des pages",
     "zoomGroup": "Contrôles du zoom",
     "historyGroup": "Actions d'historique",
-    "exportGroup": "Options d'export"
+    "exportGroup": "Options d'export",
+    "accessibilityGroup": "Options d’accessibilité",
+    "highContrast": "Contraste élevé",
+    "highContrastToggle": "Activer le thème à contraste élevé"
   },
   "sidebar": {
     "title": "Annotations (JSON)",
@@ -172,10 +175,17 @@
       "hexPlaceholder": "#5eead4",
       "rgbPlaceholder": "rgb(94, 234, 212)"
     },
-    "actions": {
-      "duplicate": "Dupliquer l'annotation"
-    },
-    "editingBadge": "Édition"
+      "actions": {
+        "duplicate": "Dupliquer l'annotation",
+        "confirm": "Enregistrer l’annotation",
+        "cancel": "Annuler l’édition",
+        "delete": "Supprimer l’annotation"
+      },
+      "aria": {
+        "summary": "Annotation {{index}} page {{page}} ({{type}} : {{name}})",
+        "unnamed": "Champ sans nom"
+      },
+      "editingBadge": "Édition"
   },
   "fonts": {
     "custom": {

--- a/src/app/i18n/translations/it.json
+++ b/src/app/i18n/translations/it.json
@@ -53,7 +53,10 @@
     "navigationGroup": "Navigazione pagine",
     "zoomGroup": "Controlli zoom",
     "historyGroup": "Azioni cronologia",
-    "exportGroup": "Opzioni di esportazione"
+    "exportGroup": "Opzioni di esportazione",
+    "accessibilityGroup": "Opzioni di accessibilità",
+    "highContrast": "Alto contrasto",
+    "highContrastToggle": "Attiva tema ad alto contrasto"
   },
   "sidebar": {
     "title": "Annotazioni (JSON)",
@@ -172,10 +175,17 @@
       "hexPlaceholder": "#5eead4",
       "rgbPlaceholder": "rgb(94, 234, 212)"
     },
-    "actions": {
-      "duplicate": "Duplica annotazione"
-    },
-    "editingBadge": "Modifica in corso"
+      "actions": {
+        "duplicate": "Duplica annotazione",
+        "confirm": "Salva annotazione",
+        "cancel": "Annulla modifica",
+        "delete": "Elimina annotazione"
+      },
+      "aria": {
+        "summary": "Annotazione {{index}} a pagina {{page}} ({{type}}: {{name}})",
+        "unnamed": "Campo senza nome"
+      },
+      "editingBadge": "Modifica in corso"
   },
   "fonts": {
     "custom": {

--- a/src/app/i18n/translations/pt.json
+++ b/src/app/i18n/translations/pt.json
@@ -53,7 +53,10 @@
     "navigationGroup": "Navegação de páginas",
     "zoomGroup": "Controlos de zoom",
     "historyGroup": "Ações de histórico",
-    "exportGroup": "Opções de exportação"
+    "exportGroup": "Opções de exportação",
+    "accessibilityGroup": "Opções de acessibilidade",
+    "highContrast": "Alto contraste",
+    "highContrastToggle": "Ativar tema de alto contraste"
   },
   "sidebar": {
     "title": "Anotações (JSON)",
@@ -172,10 +175,17 @@
       "hexPlaceholder": "#5eead4",
       "rgbPlaceholder": "rgb(94, 234, 212)"
     },
-    "actions": {
-      "duplicate": "Duplicar anotação"
-    },
-    "editingBadge": "A editar"
+      "actions": {
+        "duplicate": "Duplicar anotação",
+        "confirm": "Salvar anotação",
+        "cancel": "Cancelar edição",
+        "delete": "Excluir anotação"
+      },
+      "aria": {
+        "summary": "Anotação {{index}} na página {{page}} ({{type}}: {{name}})",
+        "unnamed": "Campo sem nome"
+      },
+      "editingBadge": "A editar"
   },
   "fonts": {
     "custom": {

--- a/src/app/pages/landing/components/dropzone/landing-dropzone.component.html
+++ b/src/app/pages/landing/components/dropzone/landing-dropzone.component.html
@@ -16,7 +16,8 @@
     <span class="landing__headline">{{ 'app.upload.title' | t }}</span>
     <span class="landing__subheadline">{{ 'app.upload.subtitle' | t }}</span>
   </div>
-  <button type="button" class="landing__cta" (click)="onOpenFilePicker($event)">
+  <button type="button" class="landing__cta" (click)="onOpenFilePicker($event)"
+    [attr.aria-label]="'app.landing.cta' | t">
     {{ 'app.landing.cta' | t }}
   </button>
   <span class="landing__hint">{{ 'app.upload.hint' | t }}</span>

--- a/src/app/pages/workspace/components/header/workspace-header.component.html
+++ b/src/app/pages/workspace/components/header/workspace-header.component.html
@@ -58,6 +58,14 @@
       </button>
     </div>
 
+    <div class="toolbar__group" role="group" [attr.aria-label]="'controls.accessibilityGroup' | t">
+      <button class="btn btn--icon" type="button" (click)="vm.toggleHighContrast()"
+        [attr.aria-pressed]="vm.highContrast()" [attr.aria-label]="'controls.highContrastToggle' | t">
+        <span class="btn__icon" aria-hidden="true">🌗</span>
+        <span class="btn__label">{{ 'controls.highContrast' | t }}</span>
+      </button>
+    </div>
+
     <app-language-selector class="header__language-selector" [languages]="vm.languages"
       [selectedLanguage]="vm.languageModel" (languageChange)="vm.onLanguageChange($event)" variant="compact">
     </app-language-selector>

--- a/src/app/pages/workspace/components/viewer/workspace-viewer.component.html
+++ b/src/app/pages/workspace/components/viewer/workspace-viewer.component.html
@@ -130,8 +130,10 @@
         <small class="color-hint">{{ 'annotation.color.hintPreview' | t }}</small>
       </div>
       <div class="editor-actions">
-        <button class="action-primary" (click)="vm.confirmPreview()">✅</button>
-        <button (click)="vm.cancelPreview()">❌</button>
+        <button type="button" class="action-primary" (click)="vm.confirmPreview()"
+          [attr.aria-label]="'annotation.actions.confirm' | t">✅</button>
+        <button type="button" (click)="vm.cancelPreview()"
+          [attr.aria-label]="'annotation.actions.cancel' | t">❌</button>
       </div>
     </div>
 
@@ -272,9 +274,10 @@
       <div class="editor-actions">
         <button type="button" (click)="vm.duplicateAnnotation()" [title]="'annotation.actions.duplicate' | t"
           [attr.aria-label]="'annotation.actions.duplicate' | t">⧉</button>
-        <button class="btn-delete" (click)="vm.deleteAnnotation()">🗑️</button>
-        <button class="action-primary" (click)="vm.confirmEdit()">✅</button>
-        <button (click)="vm.cancelEdit()">❌</button>
+        <button class="btn-delete" (click)="vm.deleteAnnotation()" [attr.aria-label]="'annotation.actions.delete' | t">🗑️</button>
+        <button type="button" class="action-primary" (click)="vm.confirmEdit()"
+          [attr.aria-label]="'annotation.actions.confirm' | t">✅</button>
+        <button type="button" (click)="vm.cancelEdit()" [attr.aria-label]="'annotation.actions.cancel' | t">❌</button>
       </div>
     </div>
   </div>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -7,6 +7,15 @@
   --muted: #b0b0b0;
 }
 
+:root.theme-high-contrast {
+  --bg: #000000;
+  --panel: #0f0f0f;
+  --accent: #ffdd2d;
+  --danger: #ff7b7b;
+  --text: #ffffff;
+  --muted: #e0e0e0;
+}
+
 * {
   box-sizing: border-box;
 }
@@ -1133,6 +1142,12 @@ header .logo {
   user-select: none;
   padding: 0;
   outline: 1px solid transparent;
+}
+
+.annotation:focus-visible,
+.annotation--focused {
+  outline: 2px solid var(--accent);
+  box-shadow: 0 0 0 3px rgba(94, 234, 212, 0.35);
 }
 
 .annotation:hover {


### PR DESCRIPTION
## Summary
- add keyboard shortcuts, focus cycling, and ARIA-aware annotation elements to support keyboard-only workflows
- introduce a high-contrast theme toggle in the workspace toolbar and associated styling tokens
- expand ARIA labelling for CTA and editor buttons alongside updated translations

## Testing
- npm run i18n:check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ed1c6172483259f4616ca11c0aa3a)