### PR TITLE
Add AcroForm field linking and export alignment

### DIFF
--- a/src/app/annotation-templates.service.ts
+++ b/src/app/annotation-templates.service.ts
@@ -142,8 +142,23 @@ export class AnnotationTemplatesService {
   private clonePages(pages: readonly PageAnnotations[]): PageAnnotations[] {
     return pages.map((page) => ({
       num: page.num,
-      fields: page.fields.map((field): PageField => ({ ...field })),
+      fields: page.fields.map((field): PageField => this.cloneField(field)),
     }));
+  }
+
+  private cloneField(field: PageField): PageField {
+    if (!field.acroField) {
+      return { ...field };
+    }
+
+    return {
+      ...field,
+      acroField: {
+        name: field.acroField.name,
+        page: field.acroField.page,
+        rect: { ...field.acroField.rect },
+      },
+    };
   }
 
   private getStoredTemplates(): AnnotationTemplate[] {

--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -55,6 +55,12 @@
     "historyGroup": "Accions d'historial",
     "exportGroup": "Opcions d'exportació"
   },
+  "acroForm": {
+    "title": "Camps del formulari",
+    "empty": "Aquest PDF no inclou camps de formulari.",
+    "associate": "Associar anotació",
+    "pageLabel": "Pàgina {{page}}"
+  },
   "sidebar": {
     "title": "Anotacions (JSON)",
     "importJsonFile": "Importa des d'un fitxer",

--- a/src/app/i18n/translations/de.json
+++ b/src/app/i18n/translations/de.json
@@ -55,6 +55,12 @@
     "historyGroup": "Verlauf",
     "exportGroup": "Exportoptionen"
   },
+  "acroForm": {
+    "title": "Formularfelder",
+    "empty": "Dieses PDF enthält keine Formularfelder.",
+    "associate": "Annotation verknüpfen",
+    "pageLabel": "Seite {{page}}"
+  },
   "sidebar": {
     "title": "Anmerkungen (JSON)",
     "importJsonFile": "Aus Datei importieren",

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -55,6 +55,12 @@
     "historyGroup": "History actions",
     "exportGroup": "Export options"
   },
+  "acroForm": {
+    "title": "Form fields",
+    "empty": "This PDF does not define form fields.",
+    "associate": "Link annotation",
+    "pageLabel": "Page {{page}}"
+  },
   "sidebar": {
     "title": "Annotations (JSON)",
     "importJsonFile": "Import from file",

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -55,6 +55,12 @@
     "historyGroup": "Acciones de historial",
     "exportGroup": "Opciones de exportación"
   },
+  "acroForm": {
+    "title": "Campos del formulario",
+    "empty": "Este PDF no incluye campos de formulario.",
+    "associate": "Asociar anotación",
+    "pageLabel": "Página {{page}}"
+  },
   "sidebar": {
     "title": "Anotaciones (JSON)",
     "importJsonFile": "Importar desde archivo",

--- a/src/app/i18n/translations/fr.json
+++ b/src/app/i18n/translations/fr.json
@@ -55,6 +55,12 @@
     "historyGroup": "Actions d'historique",
     "exportGroup": "Options d'export"
   },
+  "acroForm": {
+    "title": "Champs du formulaire",
+    "empty": "Ce PDF ne contient pas de champs de formulaire.",
+    "associate": "Associer une annotation",
+    "pageLabel": "Page {{page}}"
+  },
   "sidebar": {
     "title": "Annotations (JSON)",
     "importJsonFile": "Importer depuis un fichier",

--- a/src/app/i18n/translations/it.json
+++ b/src/app/i18n/translations/it.json
@@ -55,6 +55,12 @@
     "historyGroup": "Azioni cronologia",
     "exportGroup": "Opzioni di esportazione"
   },
+  "acroForm": {
+    "title": "Campi del modulo",
+    "empty": "Questo PDF non contiene campi modulo.",
+    "associate": "Associa annotazione",
+    "pageLabel": "Pagina {{page}}"
+  },
   "sidebar": {
     "title": "Annotazioni (JSON)",
     "importJsonFile": "Importa da file",

--- a/src/app/i18n/translations/pt.json
+++ b/src/app/i18n/translations/pt.json
@@ -55,6 +55,12 @@
     "historyGroup": "Ações de histórico",
     "exportGroup": "Opções de exportação"
   },
+  "acroForm": {
+    "title": "Campos do formulário",
+    "empty": "Este PDF não inclui campos de formulário.",
+    "associate": "Associar anotação",
+    "pageLabel": "Página {{page}}"
+  },
   "sidebar": {
     "title": "Anotações (JSON)",
     "importJsonFile": "Importar de ficheiro",

--- a/src/app/models/acro-form-field.model.ts
+++ b/src/app/models/acro-form-field.model.ts
@@ -1,0 +1,12 @@
+export interface AcroFormFieldRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface AcroFormField {
+  name: string;
+  page: number;
+  rect: AcroFormFieldRect;
+}

--- a/src/app/models/annotation.model.ts
+++ b/src/app/models/annotation.model.ts
@@ -1,3 +1,5 @@
+import { AcroFormField } from './acro-form-field.model';
+
 export type FieldType = 'text' | 'check' | 'radio' | 'number';
 
 export interface PageField {
@@ -15,6 +17,7 @@ export interface PageField {
   backgroundColor?: string | null;
   locked?: boolean;
   hidden?: boolean;
+  acroField?: AcroFormField | null;
 }
 
 export interface PageAnnotations {

--- a/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.html
+++ b/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.html
@@ -45,6 +45,33 @@
       ></app-page-thumbnails>
     </div>
   </section>
+  <section class="acroform-panel">
+    <div class="acroform-panel__header">
+      <h5 class="acroform-panel__title">{{ 'acroForm.title' | t }}</h5>
+      <span class="acroform-panel__badge" *ngIf="vm.acroFormFields().length">{{ vm.acroFormFields().length }}</span>
+    </div>
+    <ng-container *ngIf="vm.acroFormFields().length; else acroFormEmpty">
+      <div class="acroform-panel__pages">
+        <div class="acroform-panel__page" *ngFor="let page of vm.acroFormFieldsByPage()">
+          <div class="acroform-panel__page-header">
+            <span class="acroform-panel__page-title">{{ 'acroForm.pageLabel' | t:{ page: page.page } }}</span>
+            <span class="acroform-panel__badge">{{ page.fields.length }}</span>
+          </div>
+          <ul class="acroform-panel__field-list">
+            <li class="acroform-panel__field" *ngFor="let field of page.fields">
+              <span class="acroform-panel__field-name" [title]="field.name">{{ field.name }}</span>
+              <button type="button" class="btn btn--inline" (click)="vm.associateAnnotationWithField(field)">
+                {{ 'acroForm.associate' | t }}
+              </button>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </ng-container>
+    <ng-template #acroFormEmpty>
+      <p class="acroform-panel__empty">{{ 'acroForm.empty' | t }}</p>
+    </ng-template>
+  </section>
   <section class="templates">
     <h5>{{ 'sidebar.templates.title' | t }}</h5>
     <div class="templates__save">

--- a/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.scss
+++ b/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.scss
@@ -60,6 +60,106 @@
   color: rgba(255, 255, 255, 0.75);
 }
 
+.acroform-panel {
+  margin: 18px 0;
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(94, 234, 212, 0.14);
+  background: rgba(18, 20, 30, 0.7);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.acroform-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.acroform-panel__title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.acroform-panel__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3px 8px;
+  border-radius: 999px;
+  border: 1px solid rgba(94, 234, 212, 0.35);
+  background: rgba(94, 234, 212, 0.12);
+  color: var(--accent);
+  font-weight: 700;
+  font-size: 0.8rem;
+}
+
+.acroform-panel__pages {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.acroform-panel__page {
+  padding: 10px;
+  border-radius: 10px;
+  border: 1px solid rgba(94, 234, 212, 0.14);
+  background: rgba(8, 12, 22, 0.65);
+}
+
+.acroform-panel__page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.acroform-panel__page-title {
+  margin: 0;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.acroform-panel__field-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.acroform-panel__field {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.acroform-panel__field-name {
+  flex: 1;
+  min-width: 0;
+  font-weight: 500;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.acroform-panel__empty {
+  margin: 6px 0 0;
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.btn--inline {
+  padding: 6px 10px;
+  font-size: 0.85rem;
+}
+
 @media (max-width: 1024px) {
   .sidebar-thumbnails__list {
     max-height: clamp(140px, 28vh, 300px);

--- a/src/app/services/pdf-loader.service.ts
+++ b/src/app/services/pdf-loader.service.ts
@@ -1,0 +1,120 @@
+import { Injectable } from '@angular/core';
+import type { PDFDocumentProxy } from 'pdfjs-dist';
+import * as pdfjsLib from 'pdfjs-dist/legacy/build/pdf';
+import { AcroFormField, AcroFormFieldRect } from '../models/acro-form-field.model';
+
+const PDF_WORKER_MODULE_SRC = '/assets/pdfjs/pdf.worker.entry.mjs';
+const PDF_WORKER_TYPE_MODULE = 'module';
+
+function supportsModuleWorkers(): boolean {
+  if (
+    typeof Worker === 'undefined' ||
+    typeof Blob === 'undefined' ||
+    typeof URL === 'undefined' ||
+    typeof URL.createObjectURL !== 'function'
+  ) {
+    return false;
+  }
+
+  let url: string | null = null;
+
+  try {
+    const blob = new Blob([''], { type: 'application/javascript' });
+    url = URL.createObjectURL(blob);
+    const tester = new Worker(url, { type: 'module' });
+    tester.terminate();
+    return true;
+  } catch {
+    return false;
+  } finally {
+    if (url) {
+      URL.revokeObjectURL(url);
+    }
+  }
+}
+
+const workerOptions = (pdfjsLib as any).GlobalWorkerOptions as {
+  workerSrc?: string;
+  workerType?: string;
+};
+
+if (supportsModuleWorkers()) {
+  workerOptions.workerSrc = PDF_WORKER_MODULE_SRC;
+  workerOptions.workerType = PDF_WORKER_TYPE_MODULE;
+} else {
+  workerOptions.workerSrc = undefined;
+  workerOptions.workerType = undefined;
+}
+
+@Injectable({ providedIn: 'root' })
+export class PdfLoaderService {
+  async loadDocument(data: Uint8Array): Promise<{
+    pdf: PDFDocumentProxy;
+    acroFormFields: AcroFormField[];
+  }> {
+    const loadingTask = pdfjsLib.getDocument({ data });
+    const pdf = await loadingTask.promise;
+    const acroFormFields = await this.extractAcroFormFields(pdf);
+    return { pdf, acroFormFields };
+  }
+
+  private async extractAcroFormFields(pdf: PDFDocumentProxy): Promise<AcroFormField[]> {
+    const fields: AcroFormField[] = [];
+
+    for (let pageNumber = 1; pageNumber <= pdf.numPages; pageNumber += 1) {
+      const page = await pdf.getPage(pageNumber);
+      const annotations = await page.getAnnotations({ intent: 'display' });
+
+      for (const annotation of annotations) {
+        const fieldName = (annotation as { fieldName?: unknown }).fieldName;
+        const rect = (annotation as { rect?: unknown }).rect;
+        if (typeof fieldName !== 'string' || !fieldName.trim() || !Array.isArray(rect)) {
+          continue;
+        }
+
+        const normalizedRect = this.normalizeRect(rect);
+        if (!normalizedRect) {
+          continue;
+        }
+
+        fields.push({
+          name: fieldName.trim(),
+          page: pageNumber,
+          rect: normalizedRect,
+        });
+      }
+    }
+
+    return fields.sort((a, b) => a.page - b.page || a.name.localeCompare(b.name));
+  }
+
+  private normalizeRect(rect: unknown[]): AcroFormFieldRect | null {
+    if (!Array.isArray(rect) || rect.length < 4) {
+      return null;
+    }
+
+    const [x1, y1, x2, y2] = rect.map((value) => Number(value));
+
+    if ([x1, y1, x2, y2].some((num) => Number.isNaN(num) || !Number.isFinite(num))) {
+      return null;
+    }
+
+    const normalized = typeof pdfjsLib.Util?.normalizeRect === 'function'
+      ? pdfjsLib.Util.normalizeRect([x1, y1, x2, y2])
+      : [Math.min(x1, x2), Math.min(y1, y2), Math.max(x1, x2), Math.max(y1, y2)];
+
+    const width = normalized[2] - normalized[0];
+    const height = normalized[3] - normalized[1];
+
+    if (width <= 0 || height <= 0) {
+      return null;
+    }
+
+    return {
+      x: Math.round(normalized[0] * 100) / 100,
+      y: Math.round(normalized[1] * 100) / 100,
+      width: Math.round(width * 100) / 100,
+      height: Math.round(height * 100) / 100,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- load PDFs through a pdf.js-backed loader service to capture AcroForm field metadata
- display detected form fields in the workspace sidebar with an action to create linked annotations
- persist AcroForm links in saved data and align pdf-lib exports relative to their mapped fields

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ed1c3c0dc8325930a0c371ddf4024)