### PR TITLE
Add guided tour overlay with localized steps

### DIFF
--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -192,5 +192,37 @@
   },
   "viewer": {
     "emptyMessage": "Puja un PDF i fes clic on vulguis afegir anotacions. Edita-les a la previsualització abans de confirmar ✅."
+  },
+  "tour": {
+    "badge": "Guia ràpida",
+    "startCta": "Veure guia",
+    "close": "Tancar",
+    "progress": "Pas {{current}} de {{total}}",
+    "restart": "Reiniciar",
+    "previous": "Anterior",
+    "next": "Següent",
+    "finish": "Acabar",
+    "steps": {
+      "upload": {
+        "title": "Carrega un PDF",
+        "description": "Arrossega el fitxer o usa la targeta de pujada per habilitar el visor i les anotacions."
+      },
+      "zoom": {
+        "title": "Ajusta el zoom",
+        "description": "Utilitza els controls superiors per canviar de pàgina i fixar el factor de zoom."
+      },
+      "annotate": {
+        "title": "Afegeix anotacions",
+        "description": "Fes clic sobre el llenç, escriu el text, ajusta mida i color i confirma per desar."
+      },
+      "json": {
+        "title": "Gestiona el JSON",
+        "description": "Edita o enganxa coordenades, alterna vista de text/arbres i copia o descarrega l'esquema."
+      },
+      "export": {
+        "title": "Exporta el PDF anotat",
+        "description": "Quan tinguis marques, usa el botó de descàrrega per obtenir el PDF amb anotacions."
+      }
+    }
   }
 }

--- a/src/app/i18n/translations/de.json
+++ b/src/app/i18n/translations/de.json
@@ -192,5 +192,37 @@
   },
   "viewer": {
     "emptyMessage": "Laden Sie ein PDF hoch und klicken Sie irgendwo, um Anmerkungen hinzuzufügen. Bearbeiten Sie sie in der Vorschau, bevor Sie bestätigen ✅."
+  },
+  "tour": {
+    "badge": "Schnellstart",
+    "startCta": "Anleitung ansehen",
+    "close": "Schließen",
+    "progress": "Schritt {{current}} von {{total}}",
+    "restart": "Neu starten",
+    "previous": "Zurück",
+    "next": "Weiter",
+    "finish": "Fertig",
+    "steps": {
+      "upload": {
+        "title": "PDF laden",
+        "description": "Ziehe die Datei hinein oder nutze die Upload-Kachel, um Viewer und Anmerkungen zu aktivieren."
+      },
+      "zoom": {
+        "title": "Zoom anpassen",
+        "description": "Nutze die oberen Steuerelemente, um Seiten zu wechseln und den Zoomfaktor zu setzen."
+      },
+      "annotate": {
+        "title": "Anmerkungen hinzufügen",
+        "description": "Klicke auf die Arbeitsfläche, schreibe deinen Text, passe Größe und Farbe an und bestätige zum Speichern."
+      },
+      "json": {
+        "title": "JSON verwalten",
+        "description": "Bearbeite oder füge Koordinaten ein, wechsle zwischen Text-/Baumansicht und kopiere oder lade das Schema herunter."
+      },
+      "export": {
+        "title": "Kommentiertes PDF exportieren",
+        "description": "Sobald Markierungen existieren, nutze den Download-Button, um das PDF mit Anmerkungen zu erhalten."
+      }
+    }
   }
 }

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -192,5 +192,37 @@
   },
   "viewer": {
     "emptyMessage": "Upload a PDF and click anywhere to add annotations. Edit them in the preview before confirming ✅."
+  },
+  "tour": {
+    "badge": "Quick guide",
+    "startCta": "View guide",
+    "close": "Close",
+    "progress": "Step {{current}} of {{total}}",
+    "restart": "Restart",
+    "previous": "Previous",
+    "next": "Next",
+    "finish": "Finish",
+    "steps": {
+      "upload": {
+        "title": "Load a PDF",
+        "description": "Drag the file or use the upload card to enable the viewer and annotations."
+      },
+      "zoom": {
+        "title": "Adjust zoom",
+        "description": "Use the top controls to change pages and lock in the zoom factor."
+      },
+      "annotate": {
+        "title": "Add annotations",
+        "description": "Click on the canvas, write your text, tune size and color, then confirm to save."
+      },
+      "json": {
+        "title": "Manage JSON",
+        "description": "Edit or paste coordinates, switch text/tree views, and copy or download the schema."
+      },
+      "export": {
+        "title": "Export annotated PDF",
+        "description": "When you have marks, use the download button to get the PDF with annotations applied."
+      }
+    }
   }
 }

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -192,5 +192,37 @@
   },
   "viewer": {
     "emptyMessage": "Sube un PDF y haz click donde quieras añadir anotaciones. Edítalas en la vista previa antes de confirmar ✅."
+  },
+  "tour": {
+    "badge": "Guía rápida",
+    "startCta": "Ver guía",
+    "close": "Cerrar",
+    "progress": "Paso {{current}} de {{total}}",
+    "restart": "Reiniciar",
+    "previous": "Anterior",
+    "next": "Siguiente",
+    "finish": "Finalizar",
+    "steps": {
+      "upload": {
+        "title": "Carga un PDF",
+        "description": "Arrastra el archivo o usa el panel de carga para habilitar el visor y las anotaciones."
+      },
+      "zoom": {
+        "title": "Ajusta el zoom",
+        "description": "Usa los controles superiores para navegar entre páginas y fijar el factor de zoom."
+      },
+      "annotate": {
+        "title": "Añade anotaciones",
+        "description": "Haz clic sobre el lienzo, escribe tu texto, ajusta tamaño y color y confirma para guardarlo."
+      },
+      "json": {
+        "title": "Gestiona el JSON",
+        "description": "Edita o pega coordenadas, alterna vista de texto/árbol y copia o descarga el esquema."
+      },
+      "export": {
+        "title": "Exporta el PDF anotado",
+        "description": "Cuando tengas marcas creadas, usa el botón de descarga para obtener el PDF con anotaciones."
+      }
+    }
   }
 }

--- a/src/app/i18n/translations/fr.json
+++ b/src/app/i18n/translations/fr.json
@@ -192,5 +192,37 @@
   },
   "viewer": {
     "emptyMessage": "Téléversez un PDF et cliquez n'importe où pour ajouter des annotations. Modifiez-les dans l'aperçu avant de valider ✅."
+  },
+  "tour": {
+    "badge": "Guide rapide",
+    "startCta": "Voir le guide",
+    "close": "Fermer",
+    "progress": "Étape {{current}} sur {{total}}",
+    "restart": "Redémarrer",
+    "previous": "Précédent",
+    "next": "Suivant",
+    "finish": "Terminer",
+    "steps": {
+      "upload": {
+        "title": "Chargez un PDF",
+        "description": "Glissez le fichier ou utilisez la carte d'import pour activer le lecteur et les annotations."
+      },
+      "zoom": {
+        "title": "Ajustez le zoom",
+        "description": "Utilisez les contrôles supérieurs pour changer de page et verrouiller le niveau de zoom."
+      },
+      "annotate": {
+        "title": "Ajoutez des annotations",
+        "description": "Cliquez sur la zone de travail, saisissez le texte, ajustez taille et couleur puis validez pour enregistrer."
+      },
+      "json": {
+        "title": "Gérez le JSON",
+        "description": "Modifiez ou collez des coordonnées, alternez vue texte/arbre et copiez ou téléchargez le schéma."
+      },
+      "export": {
+        "title": "Exportez le PDF annoté",
+        "description": "Quand des marques existent, utilisez le bouton de téléchargement pour obtenir le PDF annoté."
+      }
+    }
   }
 }

--- a/src/app/i18n/translations/it.json
+++ b/src/app/i18n/translations/it.json
@@ -192,5 +192,37 @@
   },
   "viewer": {
     "emptyMessage": "Carica un PDF e fai clic in qualsiasi punto per aggiungere annotazioni. Modificale nell'anteprima prima di confermare ✅."
+  },
+  "tour": {
+    "badge": "Guida rapida",
+    "startCta": "Vedi guida",
+    "close": "Chiudi",
+    "progress": "Passo {{current}} di {{total}}",
+    "restart": "Riavvia",
+    "previous": "Indietro",
+    "next": "Avanti",
+    "finish": "Fine",
+    "steps": {
+      "upload": {
+        "title": "Carica un PDF",
+        "description": "Trascina il file o usa il pannello di upload per abilitare il visualizzatore e le annotazioni."
+      },
+      "zoom": {
+        "title": "Regola lo zoom",
+        "description": "Usa i controlli superiori per cambiare pagina e fissare il fattore di zoom."
+      },
+      "annotate": {
+        "title": "Aggiungi annotazioni",
+        "description": "Fai clic sul canvas, scrivi il testo, regola dimensione e colore e conferma per salvare."
+      },
+      "json": {
+        "title": "Gestisci il JSON",
+        "description": "Modifica o incolla coordinate, alterna vista testo/albero e copia o scarica lo schema."
+      },
+      "export": {
+        "title": "Esporta il PDF annotato",
+        "description": "Quando hai annotazioni, usa il pulsante di download per ottenere il PDF con le note applicate."
+      }
+    }
   }
 }

--- a/src/app/i18n/translations/pt.json
+++ b/src/app/i18n/translations/pt.json
@@ -192,5 +192,37 @@
   },
   "viewer": {
     "emptyMessage": "Carregue um PDF e clique em qualquer ponto para adicionar anotações. Edite-as na pré-visualização antes de confirmar ✅."
+  },
+  "tour": {
+    "badge": "Guia rápida",
+    "startCta": "Ver guia",
+    "close": "Fechar",
+    "progress": "Passo {{current}} de {{total}}",
+    "restart": "Reiniciar",
+    "previous": "Anterior",
+    "next": "Avançar",
+    "finish": "Concluir",
+    "steps": {
+      "upload": {
+        "title": "Carregue um PDF",
+        "description": "Arraste o arquivo ou use o cartão de upload para habilitar o visualizador e as anotações."
+      },
+      "zoom": {
+        "title": "Ajuste o zoom",
+        "description": "Use os controles superiores para trocar de página e definir o fator de zoom."
+      },
+      "annotate": {
+        "title": "Adicione anotações",
+        "description": "Clique na área de trabalho, escreva o texto, ajuste tamanho e cor e confirme para salvar."
+      },
+      "json": {
+        "title": "Gerencie o JSON",
+        "description": "Edite ou cole coordenadas, alterne a visualização texto/árvore e copie ou baixe o esquema."
+      },
+      "export": {
+        "title": "Exporte o PDF anotado",
+        "description": "Quando houver marcações, use o botão de download para obter o PDF com as anotações aplicadas."
+      }
+    }
   }
 }

--- a/src/app/pages/workspace/components/header/workspace-header.component.html
+++ b/src/app/pages/workspace/components/header/workspace-header.component.html
@@ -24,7 +24,7 @@
       </button>
     </div>
 
-    <div class="toolbar__group" role="group" [attr.aria-label]="'controls.zoomGroup' | t">
+    <div class="toolbar__group" role="group" [attr.aria-label]="'controls.zoomGroup' | t" appGuideAnchor="zoom">
       <button class="btn btn--icon" (click)="vm.zoomOut()" [disabled]="!vm.pdfDoc">
         <span class="btn__icon" aria-hidden="true">−</span>
         <span class="btn__label">{{ 'controls.zoomOut' | t }}</span>
@@ -52,9 +52,16 @@
     </div>
 
     <div class="toolbar__group" role="group" [attr.aria-label]="'controls.exportGroup' | t">
-      <button class="btn btn--icon" (click)="vm.downloadAnnotatedPDF()" [disabled]="!vm.coords().length || !vm.pdfDoc">
+      <button class="btn btn--icon" (click)="vm.downloadAnnotatedPDF()" [disabled]="!vm.coords().length || !vm.pdfDoc"
+        appGuideAnchor="export">
         <span class="btn__icon" aria-hidden="true">⬇</span>
         <span class="btn__label">{{ 'controls.downloadPdf' | t }}</span>
+      </button>
+    </div>
+
+    <div class="toolbar__group">
+      <button class="btn" type="button" (click)="vm.openGuidedTour()">
+        {{ 'tour.startCta' | t }}
       </button>
     </div>
 

--- a/src/app/pages/workspace/components/header/workspace-header.component.ts
+++ b/src/app/pages/workspace/components/header/workspace-header.component.ts
@@ -4,13 +4,14 @@ import { FormsModule } from '@angular/forms';
 import type { WorkspacePageComponent } from '../../workspace.page';
 import { TranslationPipe } from '../../../../i18n/translation.pipe';
 import { LanguageSelectorComponent } from '../../../../components/language-selector/language-selector.component';
+import { GuidedTourAnchorDirective } from '../../../../shared/guided-tour/guided-tour-anchor.directive';
 
 @Component({
   selector: 'app-workspace-header',
   standalone: true,
   templateUrl: './workspace-header.component.html',
   styleUrls: ['./workspace-header.component.scss'],
-  imports: [CommonModule, FormsModule, TranslationPipe, LanguageSelectorComponent],
+  imports: [CommonModule, FormsModule, TranslationPipe, LanguageSelectorComponent, GuidedTourAnchorDirective],
 })
 export class WorkspaceHeaderComponent {
   @Input({ required: true }) vm!: WorkspacePageComponent;

--- a/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.html
+++ b/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.html
@@ -14,7 +14,8 @@
   <section class="sidebar-upload" role="button" tabindex="0" (click)="vm.openPdfFilePicker()"
     (keydown)="vm.onFileUploadKeydown($event)" (dragover)="vm.onFileDragOver($event)"
     (dragleave)="vm.onFileDragLeave($event)" (drop)="vm.onFileDrop($event)"
-    [class.sidebar-upload--active]="vm.fileDropActive()" [attr.aria-label]="'app.workspaceUpload.ariaLabel' | t">
+    [class.sidebar-upload--active]="vm.fileDropActive()" [attr.aria-label]="'app.workspaceUpload.ariaLabel' | t"
+    appGuideAnchor="upload">
     <input #pdfFileInput type="file" accept="application/pdf" (change)="vm.onFileSelected($event)" hidden />
 
     <div class="sidebar-upload__body">
@@ -94,7 +95,7 @@
       </div>
     </ng-template>
   </ng-template>
-  <div class="json-toolbar">
+  <div class="json-toolbar" appGuideAnchor="json">
     <div class="json-toolbar__view-toggle-group" role="group"
       [attr.aria-label]="'controls.jsonViewModeToggle' | t">
       <button type="button" class="json-toolbar__view-toggle-option"

--- a/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.ts
+++ b/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.ts
@@ -5,13 +5,14 @@ import type { WorkspacePageComponent } from '../../workspace.page';
 import { TranslationPipe } from '../../../../i18n/translation.pipe';
 import { JsonTreeComponent } from '../json-tree/json-tree.component';
 import { PageThumbnailsComponent } from '../page-thumbnails/page-thumbnails.component';
+import { GuidedTourAnchorDirective } from '../../../../shared/guided-tour/guided-tour-anchor.directive';
 
 @Component({
   selector: 'app-workspace-sidebar',
   standalone: true,
   templateUrl: './workspace-sidebar.component.html',
   styleUrls: ['./workspace-sidebar.component.scss'],
-  imports: [CommonModule, FormsModule, TranslationPipe, JsonTreeComponent, PageThumbnailsComponent],
+  imports: [CommonModule, FormsModule, TranslationPipe, JsonTreeComponent, PageThumbnailsComponent, GuidedTourAnchorDirective],
 })
 export class WorkspaceSidebarComponent {
   @Input({ required: true }) vm!: WorkspacePageComponent;

--- a/src/app/pages/workspace/components/viewer/workspace-viewer.component.html
+++ b/src/app/pages/workspace/components/viewer/workspace-viewer.component.html
@@ -1,5 +1,6 @@
 <main class="viewer" *ngIf="vm.pdfDoc as _">
-  <div class="canvas-container" #pdfViewer (mousemove)="vm.onViewerMouseMove($event)" (mouseleave)="vm.onViewerMouseLeave()">
+  <div class="canvas-container" #pdfViewer (mousemove)="vm.onViewerMouseMove($event)" (mouseleave)="vm.onViewerMouseLeave()"
+    appGuideAnchor="annotate">
     <canvas #pdfCanvas class="canvas canvas--pdf"></canvas>
     <canvas #overlayCanvas class="canvas canvas--overlay"></canvas>
     <div #annotationsLayer class="annotations-layer"></div>

--- a/src/app/pages/workspace/components/viewer/workspace-viewer.component.ts
+++ b/src/app/pages/workspace/components/viewer/workspace-viewer.component.ts
@@ -3,13 +3,14 @@ import { Component, ElementRef, Input, ViewChild } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import type { WorkspacePageComponent } from '../../workspace.page';
 import { TranslationPipe } from '../../../../i18n/translation.pipe';
+import { GuidedTourAnchorDirective } from '../../../../shared/guided-tour/guided-tour-anchor.directive';
 
 @Component({
   selector: 'app-workspace-viewer',
   standalone: true,
   templateUrl: './workspace-viewer.component.html',
   styleUrls: ['./workspace-viewer.component.scss'],
-  imports: [CommonModule, FormsModule, TranslationPipe],
+  imports: [CommonModule, FormsModule, TranslationPipe, GuidedTourAnchorDirective],
 })
 export class WorkspaceViewerComponent {
   @Input({ required: true }) vm!: WorkspacePageComponent;

--- a/src/app/pages/workspace/workspace.page.html
+++ b/src/app/pages/workspace/workspace.page.html
@@ -3,4 +3,5 @@
   <app-workspace-sidebar [vm]="vm"></app-workspace-sidebar>
   <app-workspace-viewer [vm]="vm"></app-workspace-viewer>
   <app-workspace-footer [vm]="vm"></app-workspace-footer>
+  <app-guided-tour-overlay></app-guided-tour-overlay>
 </div>

--- a/src/app/shared/guided-tour/guided-tour-anchor.directive.ts
+++ b/src/app/shared/guided-tour/guided-tour-anchor.directive.ts
@@ -1,0 +1,24 @@
+import { Directive, ElementRef, Input, OnDestroy, OnInit } from '@angular/core';
+import { GuidedTourService } from './guided-tour.service';
+
+@Directive({
+  selector: '[appGuideAnchor]',
+  standalone: true,
+})
+export class GuidedTourAnchorDirective implements OnInit, OnDestroy {
+  @Input({ required: true }) appGuideAnchor!: string;
+
+  constructor(private readonly elementRef: ElementRef<HTMLElement>, private readonly tour: GuidedTourService) {}
+
+  ngOnInit() {
+    if (this.appGuideAnchor) {
+      this.tour.registerAnchor(this.appGuideAnchor, this.elementRef.nativeElement);
+    }
+  }
+
+  ngOnDestroy() {
+    if (this.appGuideAnchor) {
+      this.tour.unregisterAnchor(this.appGuideAnchor, this.elementRef.nativeElement);
+    }
+  }
+}

--- a/src/app/shared/guided-tour/guided-tour-overlay.component.html
+++ b/src/app/shared/guided-tour/guided-tour-overlay.component.html
@@ -1,0 +1,33 @@
+@if (isActive()) {
+  <div class="tour-overlay" role="dialog" aria-modal="true" aria-live="assertive">
+    <div class="tour-overlay__backdrop"></div>
+    @if (highlightStyle() as style) {
+      <div class="tour-overlay__highlight" [ngStyle]="style"></div>
+    }
+
+    <div class="tour-overlay__card" [class.tour-overlay__card--floating]="!!highlightStyle()" [class.tour-overlay__card--centered]="!highlightStyle()">
+      <header class="tour-overlay__header">
+        <span class="tour-overlay__badge">{{ 'tour.badge' | t }}</span>
+        <button type="button" class="tour-overlay__close" (click)="close()" [attr.aria-label]="'tour.close' | t">✕</button>
+      </header>
+
+      <div class="tour-overlay__body">
+        <p class="tour-overlay__kicker">{{ 'tour.progress' | t : { current: currentIndex() + 1, total: steps().length } }}</p>
+        <h3 class="tour-overlay__title">{{ currentStep()?.title }}</h3>
+        <p class="tour-overlay__description">{{ currentStep()?.description }}</p>
+      </div>
+
+      <footer class="tour-overlay__footer">
+        <button type="button" class="tour-overlay__link" (click)="restart()">{{ 'tour.restart' | t }}</button>
+        <div class="tour-overlay__actions">
+          <button type="button" class="tour-overlay__button" (click)="previous()" [disabled]="currentIndex() === 0">
+            {{ 'tour.previous' | t }}
+          </button>
+          <button type="button" class="tour-overlay__button tour-overlay__button--primary" (click)="next()">
+            {{ currentIndex() + 1 === steps().length ? ('tour.finish' | t) : ('tour.next' | t) }}
+          </button>
+        </div>
+      </footer>
+    </div>
+  </div>
+}

--- a/src/app/shared/guided-tour/guided-tour-overlay.component.scss
+++ b/src/app/shared/guided-tour/guided-tour-overlay.component.scss
@@ -1,0 +1,164 @@
+.tour-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
+}
+
+.tour-overlay__backdrop {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at center, rgba(0, 0, 0, 0.35), rgba(0, 0, 0, 0.65));
+}
+
+.tour-overlay__highlight {
+  position: fixed;
+  border: 2px solid #7dd3fc;
+  border-radius: 12px;
+  box-shadow: 0 0 0 10px rgba(125, 211, 252, 0.25);
+  pointer-events: none;
+  transition: all 0.25s ease;
+  background: rgba(125, 211, 252, 0.08);
+}
+
+.tour-overlay__card {
+  position: relative;
+  max-width: 420px;
+  width: calc(100% - 32px);
+  background: #0f172a;
+  color: #e2e8f0;
+  border-radius: 14px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4);
+  padding: 18px 18px 16px;
+  pointer-events: auto;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.tour-overlay__card--floating {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.tour-overlay__card--centered {
+  max-width: 520px;
+}
+
+.tour-overlay__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.tour-overlay__badge {
+  padding: 4px 10px;
+  background: rgba(125, 211, 252, 0.16);
+  color: #7dd3fc;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.tour-overlay__close {
+  background: transparent;
+  border: none;
+  color: #cbd5e1;
+  font-size: 18px;
+  cursor: pointer;
+  padding: 6px;
+  border-radius: 6px;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.tour-overlay__close:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: #ffffff;
+}
+
+.tour-overlay__body {
+  margin-bottom: 12px;
+}
+
+.tour-overlay__kicker {
+  margin: 0 0 6px;
+  font-size: 13px;
+  color: #94a3b8;
+}
+
+.tour-overlay__title {
+  margin: 0 0 6px;
+  font-size: 20px;
+  font-weight: 700;
+  color: #f8fafc;
+}
+
+.tour-overlay__description {
+  margin: 0;
+  line-height: 1.5;
+  color: #cbd5e1;
+}
+
+.tour-overlay__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.tour-overlay__actions {
+  display: flex;
+  gap: 8px;
+}
+
+.tour-overlay__link {
+  background: none;
+  border: none;
+  color: #7dd3fc;
+  cursor: pointer;
+  font-weight: 600;
+  padding: 6px 0;
+  text-decoration: underline;
+}
+
+.tour-overlay__button {
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(255, 255, 255, 0.04);
+  color: #e2e8f0;
+  padding: 10px 14px;
+  border-radius: 10px;
+  cursor: pointer;
+  font-weight: 600;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.tour-overlay__button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.tour-overlay__button:not(:disabled):hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(125, 211, 252, 0.5);
+}
+
+.tour-overlay__button--primary {
+  background: linear-gradient(135deg, #38bdf8, #0ea5e9);
+  color: #0b1021;
+  border: none;
+}
+
+.tour-overlay__button--primary:not(:disabled):hover {
+  background: linear-gradient(135deg, #7dd3fc, #38bdf8);
+}
+
+@media (max-width: 720px) {
+  .tour-overlay__card {
+    align-self: flex-end;
+    margin-bottom: 18px;
+  }
+}

--- a/src/app/shared/guided-tour/guided-tour-overlay.component.ts
+++ b/src/app/shared/guided-tour/guided-tour-overlay.component.ts
@@ -1,0 +1,56 @@
+import { CommonModule } from '@angular/common';
+import { Component, HostListener, computed, inject } from '@angular/core';
+import { TranslationPipe } from '../../i18n/translation.pipe';
+import { GuidedTourService } from './guided-tour.service';
+
+@Component({
+  selector: 'app-guided-tour-overlay',
+  standalone: true,
+  imports: [CommonModule, TranslationPipe],
+  templateUrl: './guided-tour-overlay.component.html',
+  styleUrls: ['./guided-tour-overlay.component.scss'],
+})
+export class GuidedTourOverlayComponent {
+  private readonly tour = inject(GuidedTourService);
+
+  readonly isActive = this.tour.isActive;
+  readonly currentStep = this.tour.currentStep;
+  readonly currentIndex = this.tour.currentIndex;
+  readonly steps = this.tour.steps;
+
+  readonly highlightStyle = computed(() => {
+    const rect = this.tour.activeAnchorRect();
+    if (!rect) {
+      return null;
+    }
+
+    return {
+      top: `${rect.top}px`,
+      left: `${rect.left}px`,
+      width: `${rect.width}px`,
+      height: `${rect.height}px`,
+    } satisfies Record<string, string>;
+  });
+
+  @HostListener('window:resize')
+  @HostListener('window:scroll')
+  onViewportChange() {
+    this.tour.refreshAnchorRect();
+  }
+
+  close() {
+    this.tour.endTour();
+  }
+
+  restart() {
+    this.tour.restartTour();
+  }
+
+  next() {
+    this.tour.nextStep();
+  }
+
+  previous() {
+    this.tour.previousStep();
+  }
+}

--- a/src/app/shared/guided-tour/guided-tour.service.ts
+++ b/src/app/shared/guided-tour/guided-tour.service.ts
@@ -1,0 +1,130 @@
+import { Injectable, computed, signal } from '@angular/core';
+
+export type GuidedTourPlacement = 'top' | 'bottom' | 'left' | 'right' | 'center';
+
+export interface GuidedTourStep {
+  readonly id: string;
+  readonly title: string;
+  readonly description: string;
+  readonly anchorId?: string;
+  readonly placement?: GuidedTourPlacement;
+}
+
+@Injectable({ providedIn: 'root' })
+export class GuidedTourService {
+  private readonly stepsSignal = signal<readonly GuidedTourStep[]>([]);
+  private readonly activeSignal = signal(false);
+  private readonly currentIndexSignal = signal(0);
+  private readonly anchorRectSignal = signal<DOMRect | null>(null);
+  private readonly anchors = new Map<string, HTMLElement>();
+
+  readonly isActive = computed(() => this.activeSignal());
+  readonly steps = computed(() => this.stepsSignal());
+  readonly currentStep = computed<GuidedTourStep | null>(() => {
+    const steps = this.stepsSignal();
+    const index = this.currentIndexSignal();
+    return steps[index] ?? null;
+  });
+  readonly currentIndex = computed(() => this.currentIndexSignal());
+  readonly activeAnchorRect = computed(() => this.anchorRectSignal());
+
+  setSteps(steps: readonly GuidedTourStep[]) {
+    this.stepsSignal.set([...steps]);
+    if (!steps.length) {
+      this.endTour();
+      return;
+    }
+
+    if (this.isActive()) {
+      this.restartTour();
+    }
+  }
+
+  startTour() {
+    if (!this.stepsSignal().length) {
+      return;
+    }
+    this.activeSignal.set(true);
+    this.currentIndexSignal.set(0);
+    this.updateAnchorRect();
+  }
+
+  restartTour() {
+    this.currentIndexSignal.set(0);
+    this.activeSignal.set(true);
+    this.updateAnchorRect();
+  }
+
+  endTour() {
+    this.activeSignal.set(false);
+    this.currentIndexSignal.set(0);
+    this.anchorRectSignal.set(null);
+  }
+
+  nextStep() {
+    const steps = this.stepsSignal();
+    const nextIndex = this.currentIndexSignal() + 1;
+    if (nextIndex >= steps.length) {
+      this.endTour();
+      return;
+    }
+
+    this.currentIndexSignal.set(nextIndex);
+    this.updateAnchorRect();
+  }
+
+  previousStep() {
+    const prevIndex = this.currentIndexSignal() - 1;
+    if (prevIndex < 0) {
+      return;
+    }
+
+    this.currentIndexSignal.set(prevIndex);
+    this.updateAnchorRect();
+  }
+
+  registerAnchor(id: string, element: HTMLElement) {
+    this.anchors.set(id, element);
+    this.refreshIfCurrent(id);
+  }
+
+  unregisterAnchor(id: string, element: HTMLElement) {
+    const stored = this.anchors.get(id);
+    if (stored === element) {
+      this.anchors.delete(id);
+    }
+    this.refreshIfCurrent(id);
+  }
+
+  refreshAnchorRect() {
+    this.updateAnchorRect();
+  }
+
+  private refreshIfCurrent(anchorId: string) {
+    if (this.currentStep()?.anchorId === anchorId) {
+      this.updateAnchorRect();
+    }
+  }
+
+  private updateAnchorRect() {
+    if (!this.isActive()) {
+      this.anchorRectSignal.set(null);
+      return;
+    }
+
+    const anchorId = this.currentStep()?.anchorId;
+    if (!anchorId) {
+      this.anchorRectSignal.set(null);
+      return;
+    }
+
+    const element = this.anchors.get(anchorId);
+    if (!element) {
+      this.anchorRectSignal.set(null);
+      return;
+    }
+
+    const rect = element.getBoundingClientRect();
+    this.anchorRectSignal.set(new DOMRect(rect.x, rect.y, rect.width, rect.height));
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared guided tour overlay and anchor directive to highlight key workspace areas
- wire a restartable "Ver guía" entry point and anchors for upload, zoom, annotate, JSON, and export steps
- localize tour messaging across all supported languages

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ed1c81458832598a135bb44e32a0d)