### PR TITLE
Add annotation JSON diff review overlays

### DIFF
--- a/src/app/models/annotation-diff.model.ts
+++ b/src/app/models/annotation-diff.model.ts
@@ -1,0 +1,22 @@
+import { PageField } from './annotation.model';
+
+export type DiffKind = 'added' | 'removed' | 'modified';
+
+export type DiffResolution = 'pending' | 'accepted' | 'rejected';
+
+export interface AnnotationDiffChange {
+  readonly property: string;
+  readonly before: unknown;
+  readonly after: unknown;
+}
+
+export interface AnnotationDiff {
+  readonly id: string;
+  readonly page: number;
+  readonly fieldKey: string;
+  readonly kind: DiffKind;
+  readonly baseField?: PageField;
+  readonly targetField?: PageField;
+  readonly changes?: AnnotationDiffChange[];
+  readonly resolution: DiffResolution;
+}

--- a/src/app/pages/workspace/components/annotation-diff/annotation-diff.component.html
+++ b/src/app/pages/workspace/components/annotation-diff/annotation-diff.component.html
@@ -1,0 +1,77 @@
+<section class="diff-panel">
+  <header class="diff-panel__header">
+    <div>
+      <p class="diff-panel__kicker">Revisión de cambios</p>
+      <h5>Compara dos JSON de anotaciones</h5>
+      <p class="diff-panel__hint">Carga un archivo base y otro con cambios para revisar las diferencias por página y campo.</p>
+    </div>
+    <div class="diff-panel__toggles">
+      <label class="toggle">
+        <input type="checkbox" [checked]="vm.diffOverlayVisible()" (change)="vm.toggleDiffOverlay($event.target.checked)" />
+        <span>Ver overlays</span>
+      </label>
+      <button type="button" class="btn btn--ghost" (click)="vm.resetDiffReview()" [disabled]="!summary().total">Limpiar</button>
+    </div>
+  </header>
+
+  <div class="diff-panel__inputs">
+    <label class="btn diff-panel__file">
+      <span>JSON base</span>
+      <input type="file" accept="application/json" (change)="vm.onDiffFileSelected($event, 'base')" hidden />
+      <small *ngIf="vm.diffBaseName()">{{ vm.diffBaseName() }}</small>
+    </label>
+    <label class="btn diff-panel__file">
+      <span>JSON con cambios</span>
+      <input type="file" accept="application/json" (change)="vm.onDiffFileSelected($event, 'target')" hidden />
+      <small *ngIf="vm.diffTargetName()">{{ vm.diffTargetName() }}</small>
+    </label>
+    <button type="button" class="btn" (click)="vm.exportConsolidatedDiff()" [disabled]="!summary().accepted">
+      Descargar JSON consolidado
+    </button>
+  </div>
+
+  <div class="diff-panel__summary" *ngIf="summary().total">
+    <div class="diff-panel__chips">
+      <span class="chip chip--added">Añadidos: {{ summary().added }}</span>
+      <span class="chip chip--removed">Eliminados: {{ summary().removed }}</span>
+      <span class="chip chip--modified">Modificados: {{ summary().modified }}</span>
+      <span class="chip">Aceptados: {{ summary().accepted }}</span>
+    </div>
+    <p class="diff-panel__helper">Selecciona un cambio para verlo sobre el lienzo y usa Aceptar/Rechazar para generar el JSON final.</p>
+  </div>
+
+  <p class="diff-panel__empty" *ngIf="!summary().total && (vm.diffBaseName() || vm.diffTargetName())">No se detectaron diferencias entre los archivos cargados.</p>
+
+  <div class="diff-panel__list" *ngIf="summary().total">
+    <article class="diff-card" *ngFor="let diff of vm.diffEntries(); trackBy: trackById" [class.diff-card--active]="vm.selectedDiffId() === diff.id">
+      <div class="diff-card__info">
+        <span class="chip" [class.chip--added]="diff.kind === 'added'" [class.chip--removed]="diff.kind === 'removed'" [class.chip--modified]="diff.kind === 'modified'">
+          {{ formatKind(diff.kind) }}
+        </span>
+        <strong>Página {{ diff.page }}</strong>
+        <span class="diff-card__field">{{ diff.fieldKey }}</span>
+        <span class="diff-card__status" [attr.data-status]="diff.resolution">
+          {{ diff.resolution === 'pending' ? 'Pendiente' : diff.resolution === 'accepted' ? 'Aceptado' : 'Rechazado' }}
+        </span>
+      </div>
+      <div class="diff-card__changes" *ngIf="diff.changes?.length">
+        <span class="diff-card__change" *ngFor="let change of diff.changes">
+          {{ change.property }}
+        </span>
+      </div>
+      <div class="diff-card__actions">
+        <button type="button" class="btn" (click)="vm.selectDiff(diff.id)" [attr.aria-pressed]="vm.selectedDiffId() === diff.id">
+          Ver overlay
+        </button>
+        <div class="diff-card__cta">
+          <button type="button" class="btn" [class.btn--ghost]="diff.resolution !== 'accepted'" (click)="vm.resolveDiff(diff.id, 'accepted')">
+            Aceptar
+          </button>
+          <button type="button" class="btn btn--ghost" [class.btn--danger]="diff.resolution === 'rejected'" (click)="vm.resolveDiff(diff.id, 'rejected')">
+            Rechazar
+          </button>
+        </div>
+      </div>
+    </article>
+  </div>
+</section>

--- a/src/app/pages/workspace/components/annotation-diff/annotation-diff.component.scss
+++ b/src/app/pages/workspace/components/annotation-diff/annotation-diff.component.scss
@@ -1,0 +1,227 @@
+:host {
+  display: block;
+}
+
+.diff-panel {
+  margin-top: 18px;
+  padding: 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(94, 234, 212, 0.15);
+  background: rgba(12, 17, 27, 0.75);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.diff-panel__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.diff-panel__kicker {
+  margin: 0;
+  color: var(--accent);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  font-size: .75rem;
+}
+
+.diff-panel__hint {
+  margin: 4px 0 0;
+  color: var(--muted);
+  font-size: .9rem;
+}
+
+.diff-panel__toggles {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.diff-panel__inputs {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 10px;
+}
+
+.diff-panel__file {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: flex-start;
+}
+
+.diff-panel__file small {
+  color: var(--muted);
+}
+
+.diff-panel__summary {
+  border-radius: 12px;
+  border: 1px dashed rgba(94, 234, 212, 0.25);
+  padding: 10px;
+  background: rgba(18, 24, 38, 0.7);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.diff-panel__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.diff-panel__helper {
+  margin: 0;
+  color: var(--muted);
+  font-size: .9rem;
+}
+
+.diff-panel__empty {
+  margin: 0;
+  padding: 10px;
+  border-radius: 12px;
+  background: rgba(33, 41, 55, 0.75);
+  color: var(--muted);
+}
+
+.diff-panel__list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 420px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.diff-card {
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  padding: 10px;
+  background: rgba(20, 26, 40, 0.7);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  transition: border-color .2s, box-shadow .2s;
+}
+
+.diff-card--active {
+  border-color: rgba(94, 234, 212, 0.45);
+  box-shadow: 0 10px 18px rgba(0, 0, 0, 0.25);
+}
+
+.diff-card__info {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.diff-card__field {
+  color: var(--muted);
+}
+
+.diff-card__status {
+  margin-left: auto;
+  padding: 4px 8px;
+  border-radius: 999px;
+  font-size: .85rem;
+  background: rgba(148, 163, 184, 0.18);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.diff-card__status[data-status="accepted"] {
+  background: rgba(52, 211, 153, 0.18);
+  border-color: rgba(52, 211, 153, 0.4);
+  color: #7fffd4;
+}
+
+.diff-card__status[data-status="rejected"] {
+  background: rgba(248, 113, 113, 0.18);
+  border-color: rgba(248, 113, 113, 0.4);
+  color: #fecdd3;
+}
+
+.diff-card__changes {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.diff-card__change {
+  padding: 4px 8px;
+  border-radius: 8px;
+  background: rgba(148, 163, 184, 0.16);
+  color: var(--text);
+  font-size: .85rem;
+}
+
+.diff-card__actions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+
+.diff-card__cta {
+  display: flex;
+  gap: 6px;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--text);
+  font-size: .85rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  white-space: nowrap;
+}
+
+.chip--added {
+  background: rgba(52, 211, 153, 0.15);
+  border-color: rgba(52, 211, 153, 0.35);
+  color: #7fffd4;
+}
+
+.chip--removed {
+  background: rgba(248, 113, 113, 0.15);
+  border-color: rgba(248, 113, 113, 0.35);
+  color: #fecdd3;
+}
+
+.chip--modified {
+  background: rgba(251, 191, 36, 0.15);
+  border-color: rgba(251, 191, 36, 0.35);
+  color: #facc15;
+}
+
+.toggle {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.btn--danger {
+  border-color: rgba(248, 113, 113, 0.5);
+  color: #fecdd3;
+}
+
+@media (max-width: 640px) {
+  .diff-panel__header {
+    flex-direction: column;
+  }
+
+  .diff-panel__status {
+    margin-left: 0;
+  }
+}

--- a/src/app/pages/workspace/components/annotation-diff/annotation-diff.component.ts
+++ b/src/app/pages/workspace/components/annotation-diff/annotation-diff.component.ts
@@ -1,0 +1,41 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input, computed } from '@angular/core';
+import type { WorkspacePageComponent } from '../../workspace.page';
+import { DiffKind } from '../../../../models/annotation-diff.model';
+
+@Component({
+  selector: 'app-annotation-diff',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './annotation-diff.component.html',
+  styleUrls: ['./annotation-diff.component.scss'],
+})
+export class AnnotationDiffComponent {
+  @Input({ required: true }) vm!: WorkspacePageComponent;
+
+  readonly summary = computed(() => {
+    const diffs = this.vm.diffEntries();
+    return {
+      total: diffs.length,
+      added: diffs.filter((item) => item.kind === 'added').length,
+      removed: diffs.filter((item) => item.kind === 'removed').length,
+      modified: diffs.filter((item) => item.kind === 'modified').length,
+      accepted: diffs.filter((item) => item.resolution === 'accepted').length,
+    };
+  });
+
+  trackById(_index: number, item: { id: string }) {
+    return item.id;
+  }
+
+  formatKind(kind: DiffKind): string {
+    switch (kind) {
+      case 'added':
+        return 'Añadido';
+      case 'removed':
+        return 'Eliminado';
+      case 'modified':
+        return 'Modificado';
+    }
+  }
+}

--- a/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.html
+++ b/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.html
@@ -117,6 +117,8 @@
   </div>
   <small class="sidebar-hint">{{ 'sidebar.jsonHint' | t }}</small>
 
+  <app-annotation-diff [vm]="vm"></app-annotation-diff>
+
   <section class="advanced-panel" [class.open]="vm.advancedOptionsOpen()"
     [class.active]="vm.guidesFeatureEnabled() || vm.customFontsFeatureEnabled()">
     <button type="button" class="advanced-toggle" (click)="vm.toggleAdvancedOptions(!vm.advancedOptionsOpen())"

--- a/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.ts
+++ b/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.ts
@@ -5,13 +5,21 @@ import type { WorkspacePageComponent } from '../../workspace.page';
 import { TranslationPipe } from '../../../../i18n/translation.pipe';
 import { JsonTreeComponent } from '../json-tree/json-tree.component';
 import { PageThumbnailsComponent } from '../page-thumbnails/page-thumbnails.component';
+import { AnnotationDiffComponent } from '../annotation-diff/annotation-diff.component';
 
 @Component({
   selector: 'app-workspace-sidebar',
   standalone: true,
   templateUrl: './workspace-sidebar.component.html',
   styleUrls: ['./workspace-sidebar.component.scss'],
-  imports: [CommonModule, FormsModule, TranslationPipe, JsonTreeComponent, PageThumbnailsComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    TranslationPipe,
+    JsonTreeComponent,
+    PageThumbnailsComponent,
+    AnnotationDiffComponent,
+  ],
 })
 export class WorkspaceSidebarComponent {
   @Input({ required: true }) vm!: WorkspacePageComponent;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1111,6 +1111,44 @@ header .logo {
   pointer-events: none;
 }
 
+.diff-overlay {
+  position: absolute;
+  border-radius: 6px;
+  border: 2px solid rgba(148, 163, 184, 0.6);
+  background: rgba(148, 163, 184, 0.2);
+  pointer-events: none;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.2);
+  transition: box-shadow .2s, opacity .2s;
+}
+
+.diff-overlay--added {
+  border-color: rgba(52, 211, 153, 0.8);
+  background: rgba(52, 211, 153, 0.18);
+}
+
+.diff-overlay--removed {
+  border-color: rgba(248, 113, 113, 0.9);
+  background: rgba(248, 113, 113, 0.2);
+}
+
+.diff-overlay--modified {
+  border-color: rgba(251, 191, 36, 0.9);
+  background: rgba(251, 191, 36, 0.18);
+}
+
+.diff-overlay--active {
+  box-shadow: 0 0 0 3px rgba(94, 234, 212, 0.45);
+}
+
+.diff-overlay--accepted {
+  opacity: 0.75;
+}
+
+.diff-overlay--rejected {
+  opacity: 0.35;
+  border-style: dashed;
+}
+
 .hitbox {
   position: absolute;
   inset: 0;


### PR DESCRIPTION
## Summary
- add a diff review panel to load base and changed annotation JSON files and review them inside the workspace sidebar
- compute annotation-level differences with overlays for added, removed, and modified fields plus accept/reject resolution and consolidated export
- style the diff UI and overlay highlights to distinguish change types and selections

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ed1d7735883259f24a36461d8e4fc)