### PR TITLE
Add configurable keyboard shortcuts dialog

### DIFF
--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -53,7 +53,8 @@
     "navigationGroup": "Navegació de pàgines",
     "zoomGroup": "Controls de zoom",
     "historyGroup": "Accions d'historial",
-    "exportGroup": "Opcions d'exportació"
+    "exportGroup": "Opcions d'exportació",
+    "shortcuts": "Dreceres"
   },
   "sidebar": {
     "title": "Anotacions (JSON)",
@@ -188,6 +189,25 @@
       "empty": "Encara no has afegit fonts personalitzades.",
       "unsupported": "El teu navegador no permet carregar fonts personalitzades.",
       "error": "No s'ha pogut carregar la font seleccionada. Prova amb un altre fitxer."
+    }
+  },
+  "shortcuts": {
+    "title": "Dreceres de teclat",
+    "description": "Personalitza les tecles per a les accions habituals de l'espai de treball.",
+    "addBinding": "Afegir drecera",
+    "removeBinding": "Eliminar",
+    "restoreDefaults": "Restaurar valors per defecte",
+    "close": "Tancar",
+    "listening": "Prem la combinació desitjada…",
+    "actions": {
+      "openShortcuts": "Obrir el diàleg de dreceres",
+      "prevPage": "Pàgina anterior",
+      "nextPage": "Pàgina següent",
+      "zoomIn": "Ampliar",
+      "zoomOut": "Reduir",
+      "undo": "Desfer",
+      "redo": "Refer",
+      "downloadPdf": "Descarregar PDF anotat"
     }
   },
   "viewer": {

--- a/src/app/i18n/translations/de.json
+++ b/src/app/i18n/translations/de.json
@@ -53,7 +53,8 @@
     "navigationGroup": "Seitennavigation",
     "zoomGroup": "Zoom-Steuerung",
     "historyGroup": "Verlauf",
-    "exportGroup": "Exportoptionen"
+    "exportGroup": "Exportoptionen",
+    "shortcuts": "Shortcuts"
   },
   "sidebar": {
     "title": "Anmerkungen (JSON)",
@@ -188,6 +189,25 @@
       "empty": "Sie haben noch keine benutzerdefinierten Schriften hinzugefügt.",
       "unsupported": "Ihr Browser unterstützt das Laden benutzerdefinierter Schriften nicht.",
       "error": "Die Schriftdatei konnte nicht geladen werden. Versuchen Sie es mit einer anderen."
+    }
+  },
+  "shortcuts": {
+    "title": "Tastenkombinationen",
+    "description": "Passen Sie die Tasten für häufige Aktionen im Arbeitsbereich an.",
+    "addBinding": "Shortcut hinzufügen",
+    "removeBinding": "Entfernen",
+    "restoreDefaults": "Standard wiederherstellen",
+    "close": "Schließen",
+    "listening": "Drücken Sie die gewünschte Kombination…",
+    "actions": {
+      "openShortcuts": "Shortcut-Dialog öffnen",
+      "prevPage": "Vorherige Seite",
+      "nextPage": "Nächste Seite",
+      "zoomIn": "Heranzoomen",
+      "zoomOut": "Herauszoomen",
+      "undo": "Rückgängig",
+      "redo": "Wiederholen",
+      "downloadPdf": "Annotiertes PDF herunterladen"
     }
   },
   "viewer": {

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -53,7 +53,8 @@
     "navigationGroup": "Page navigation",
     "zoomGroup": "Zoom controls",
     "historyGroup": "History actions",
-    "exportGroup": "Export options"
+    "exportGroup": "Export options",
+    "shortcuts": "Shortcuts"
   },
   "sidebar": {
     "title": "Annotations (JSON)",
@@ -192,5 +193,24 @@
   },
   "viewer": {
     "emptyMessage": "Upload a PDF and click anywhere to add annotations. Edit them in the preview before confirming ✅."
+  },
+  "shortcuts": {
+    "title": "Keyboard shortcuts",
+    "description": "Customize the keys for common workspace actions.",
+    "addBinding": "Add shortcut",
+    "removeBinding": "Remove",
+    "restoreDefaults": "Restore defaults",
+    "close": "Close",
+    "listening": "Press the desired keys…",
+    "actions": {
+      "openShortcuts": "Open shortcuts dialog",
+      "prevPage": "Previous page",
+      "nextPage": "Next page",
+      "zoomIn": "Zoom in",
+      "zoomOut": "Zoom out",
+      "undo": "Undo",
+      "redo": "Redo",
+      "downloadPdf": "Download annotated PDF"
+    }
   }
 }

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -53,7 +53,8 @@
     "navigationGroup": "Navegación de páginas",
     "zoomGroup": "Controles de zoom",
     "historyGroup": "Acciones de historial",
-    "exportGroup": "Opciones de exportación"
+    "exportGroup": "Opciones de exportación",
+    "shortcuts": "Atajos"
   },
   "sidebar": {
     "title": "Anotaciones (JSON)",
@@ -188,6 +189,25 @@
       "empty": "Aún no agregaste fuentes personalizadas.",
       "unsupported": "Tu navegador no soporta la carga de fuentes personalizadas.",
       "error": "No se pudo cargar la fuente seleccionada. Intenta con otro archivo."
+    }
+  },
+  "shortcuts": {
+    "title": "Atajos de teclado",
+    "description": "Configura las teclas para las acciones habituales del espacio de trabajo.",
+    "addBinding": "Añadir atajo",
+    "removeBinding": "Quitar",
+    "restoreDefaults": "Restaurar valores por defecto",
+    "close": "Cerrar",
+    "listening": "Pulsa la combinación deseada…",
+    "actions": {
+      "openShortcuts": "Abrir ayuda de atajos",
+      "prevPage": "Página anterior",
+      "nextPage": "Página siguiente",
+      "zoomIn": "Acercar",
+      "zoomOut": "Alejar",
+      "undo": "Deshacer",
+      "redo": "Rehacer",
+      "downloadPdf": "Descargar PDF anotado"
     }
   },
   "viewer": {

--- a/src/app/i18n/translations/fr.json
+++ b/src/app/i18n/translations/fr.json
@@ -53,7 +53,8 @@
     "navigationGroup": "Navigation des pages",
     "zoomGroup": "Contrôles du zoom",
     "historyGroup": "Actions d'historique",
-    "exportGroup": "Options d'export"
+    "exportGroup": "Options d'export",
+    "shortcuts": "Raccourcis"
   },
   "sidebar": {
     "title": "Annotations (JSON)",
@@ -188,6 +189,25 @@
       "empty": "Vous n'avez pas encore ajouté de polices personnalisées.",
       "unsupported": "Votre navigateur ne permet pas de charger des polices personnalisées.",
       "error": "Impossible de charger ce fichier de police. Essayez avec un autre."
+    }
+  },
+  "shortcuts": {
+    "title": "Raccourcis clavier",
+    "description": "Personnalisez les touches pour les actions courantes de l'espace de travail.",
+    "addBinding": "Ajouter un raccourci",
+    "removeBinding": "Supprimer",
+    "restoreDefaults": "Restaurer les valeurs par défaut",
+    "close": "Fermer",
+    "listening": "Appuyez sur la combinaison souhaitée…",
+    "actions": {
+      "openShortcuts": "Ouvrir la fenêtre des raccourcis",
+      "prevPage": "Page précédente",
+      "nextPage": "Page suivante",
+      "zoomIn": "Zoom avant",
+      "zoomOut": "Zoom arrière",
+      "undo": "Annuler",
+      "redo": "Rétablir",
+      "downloadPdf": "Télécharger le PDF annoté"
     }
   },
   "viewer": {

--- a/src/app/i18n/translations/it.json
+++ b/src/app/i18n/translations/it.json
@@ -53,7 +53,8 @@
     "navigationGroup": "Navigazione pagine",
     "zoomGroup": "Controlli zoom",
     "historyGroup": "Azioni cronologia",
-    "exportGroup": "Opzioni di esportazione"
+    "exportGroup": "Opzioni di esportazione",
+    "shortcuts": "Scorciatoie"
   },
   "sidebar": {
     "title": "Annotazioni (JSON)",
@@ -188,6 +189,25 @@
       "empty": "Non hai ancora aggiunto font personalizzati.",
       "unsupported": "Il tuo browser non supporta il caricamento di font personalizzati.",
       "error": "Impossibile caricare il file del font. Prova con un altro."
+    }
+  },
+  "shortcuts": {
+    "title": "Scorciatoie da tastiera",
+    "description": "Personalizza i tasti per le azioni più comuni nell'area di lavoro.",
+    "addBinding": "Aggiungi scorciatoia",
+    "removeBinding": "Rimuovi",
+    "restoreDefaults": "Ripristina predefiniti",
+    "close": "Chiudi",
+    "listening": "Premi la combinazione desiderata…",
+    "actions": {
+      "openShortcuts": "Apri i tasti di scelta rapida",
+      "prevPage": "Pagina precedente",
+      "nextPage": "Pagina successiva",
+      "zoomIn": "Ingrandisci",
+      "zoomOut": "Riduci",
+      "undo": "Annulla",
+      "redo": "Ripristina",
+      "downloadPdf": "Scarica PDF annotato"
     }
   },
   "viewer": {

--- a/src/app/i18n/translations/pt.json
+++ b/src/app/i18n/translations/pt.json
@@ -53,7 +53,8 @@
     "navigationGroup": "Navegação de páginas",
     "zoomGroup": "Controlos de zoom",
     "historyGroup": "Ações de histórico",
-    "exportGroup": "Opções de exportação"
+    "exportGroup": "Opções de exportação",
+    "shortcuts": "Atalhos"
   },
   "sidebar": {
     "title": "Anotações (JSON)",
@@ -188,6 +189,25 @@
       "empty": "Ainda não adicionou tipos de letra personalizados.",
       "unsupported": "O seu navegador não suporta o carregamento de tipos de letra personalizados.",
       "error": "Não foi possível carregar esse ficheiro de fonte. Tente outro."
+    }
+  },
+  "shortcuts": {
+    "title": "Atalhos de teclado",
+    "description": "Personalize as teclas para as ações comuns do espaço de trabalho.",
+    "addBinding": "Adicionar atalho",
+    "removeBinding": "Remover",
+    "restoreDefaults": "Restaurar predefinições",
+    "close": "Fechar",
+    "listening": "Prima a combinação pretendida…",
+    "actions": {
+      "openShortcuts": "Abrir atalhos",
+      "prevPage": "Página anterior",
+      "nextPage": "Página seguinte",
+      "zoomIn": "Aumentar zoom",
+      "zoomOut": "Reduzir zoom",
+      "undo": "Anular",
+      "redo": "Refazer",
+      "downloadPdf": "Transferir PDF anotado"
     }
   },
   "viewer": {

--- a/src/app/pages/workspace/components/header/workspace-header.component.html
+++ b/src/app/pages/workspace/components/header/workspace-header.component.html
@@ -58,6 +58,13 @@
       </button>
     </div>
 
+    <div class="toolbar__group" role="group">
+      <button class="btn btn--icon" type="button" (click)="vm.openShortcutsDialog()">
+        <span class="btn__icon" aria-hidden="true">⌨️</span>
+        <span class="btn__label">{{ 'controls.shortcuts' | t }}</span>
+      </button>
+    </div>
+
     <app-language-selector class="header__language-selector" [languages]="vm.languages"
       [selectedLanguage]="vm.languageModel" (languageChange)="vm.onLanguageChange($event)" variant="compact">
     </app-language-selector>

--- a/src/app/pages/workspace/components/shortcuts-dialog/shortcuts-dialog.component.html
+++ b/src/app/pages/workspace/components/shortcuts-dialog/shortcuts-dialog.component.html
@@ -1,0 +1,52 @@
+<div class="shortcuts-overlay" (click)="onBackdropClick($event)">
+  <div #dialogRoot class="shortcuts-dialog" role="dialog" tabindex="-1"
+    aria-modal="true" [attr.aria-label]="'shortcuts.title' | t" (keydown)="onKeydown($event)">
+    <header class="shortcuts-dialog__header">
+      <div>
+        <p class="shortcuts-dialog__eyebrow">⌨️</p>
+        <h2 class="shortcuts-dialog__title">{{ 'shortcuts.title' | t }}</h2>
+        <p class="shortcuts-dialog__description">{{ 'shortcuts.description' | t }}</p>
+      </div>
+      <button type="button" class="btn btn--icon" (click)="close.emit()">
+        <span class="btn__icon" aria-hidden="true">✕</span>
+        <span class="btn__label">{{ 'shortcuts.close' | t }}</span>
+      </button>
+    </header>
+
+    <div class="shortcuts-list" role="list">
+      <div class="shortcuts-list__item" *ngFor="let shortcut of definitions" role="listitem">
+        <div class="shortcuts-list__info">
+          <p class="shortcuts-list__label">{{ shortcut.labelKey | t }}</p>
+          <p class="shortcuts-list__hint" *ngIf="listeningFor === shortcut.action">
+            {{ 'shortcuts.listening' | t }}
+          </p>
+        </div>
+        <div class="shortcuts-list__bindings">
+          <ng-container *ngFor="let binding of getBindingsFor(shortcut.action)">
+            <span class="shortcut-chip">
+              <span>{{ formatBinding(binding) }}</span>
+              <button type="button" class="chip-remove" (click)="removeBinding(shortcut.action, binding)"
+                [attr.aria-label]="'shortcuts.removeBinding' | t">
+                ✕
+              </button>
+            </span>
+          </ng-container>
+          <button type="button" class="btn btn--icon" (click)="startListening(shortcut.action)"
+            [disabled]="listeningFor === shortcut.action">
+            <span class="btn__icon" aria-hidden="true">＋</span>
+            <span class="btn__label">{{ 'shortcuts.addBinding' | t }}</span>
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div class="shortcuts-dialog__footer">
+      <button type="button" class="btn" (click)="restoreDefaults.emit()">
+        {{ 'shortcuts.restoreDefaults' | t }}
+      </button>
+      <button type="button" class="btn" (click)="close.emit()">
+        {{ 'shortcuts.close' | t }}
+      </button>
+    </div>
+  </div>
+</div>

--- a/src/app/pages/workspace/components/shortcuts-dialog/shortcuts-dialog.component.scss
+++ b/src/app/pages/workspace/components/shortcuts-dialog/shortcuts-dialog.component.scss
@@ -1,0 +1,159 @@
+:host {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.shortcuts-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+}
+
+.shortcuts-dialog {
+  background: #ffffff;
+  color: #0f172a;
+  border-radius: 12px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
+  max-width: 840px;
+  width: min(960px, 100%);
+  max-height: 85vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.5rem;
+  outline: none;
+}
+
+.shortcuts-dialog__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.shortcuts-dialog__eyebrow {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.shortcuts-dialog__title {
+  margin: 0.1rem 0 0.35rem;
+  font-size: 1.5rem;
+  line-height: 1.2;
+}
+
+.shortcuts-dialog__description {
+  margin: 0;
+  color: #475569;
+  max-width: 48ch;
+}
+
+.shortcuts-list {
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 0.5rem;
+  background: #f8fafc;
+  overflow: auto;
+  max-height: 55vh;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.shortcuts-list__item {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.shortcuts-list__info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.shortcuts-list__label {
+  margin: 0;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.shortcuts-list__hint {
+  margin: 0;
+  color: #0284c7;
+  font-size: 0.9rem;
+}
+
+.shortcuts-list__bindings {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.shortcut-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.5rem;
+  border-radius: 999px;
+  background: #0ea5e9;
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.chip-remove {
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+
+.chip-remove:hover,
+.chip-remove:focus {
+  opacity: 0.8;
+}
+
+.shortcuts-dialog__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+@media (max-width: 720px) {
+  .shortcuts-dialog__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .shortcuts-list__item {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .shortcuts-list__bindings {
+    justify-content: flex-start;
+  }
+}

--- a/src/app/pages/workspace/components/shortcuts-dialog/shortcuts-dialog.component.ts
+++ b/src/app/pages/workspace/components/shortcuts-dialog/shortcuts-dialog.component.ts
@@ -1,0 +1,82 @@
+import { CommonModule } from '@angular/common';
+import { Component, ElementRef, EventEmitter, Input, Output, ViewChild, inject } from '@angular/core';
+import { TranslationPipe } from '../../../../i18n/translation.pipe';
+import { ShortcutAction, ShortcutDefinition, ShortcutsService } from '../../../../services/shortcuts.service';
+
+interface ShortcutChangeEvent {
+  readonly action: ShortcutAction;
+  readonly combo: string;
+}
+
+@Component({
+  selector: 'app-shortcuts-dialog',
+  standalone: true,
+  templateUrl: './shortcuts-dialog.component.html',
+  styleUrls: ['./shortcuts-dialog.component.scss'],
+  imports: [CommonModule, TranslationPipe],
+})
+export class ShortcutsDialogComponent {
+  @Input({ required: true }) definitions: readonly ShortcutDefinition[] = [];
+  @Input({ required: true }) bindings: Record<ShortcutAction, string[]> = {};
+  @Output() close = new EventEmitter<void>();
+  @Output() restoreDefaults = new EventEmitter<void>();
+  @Output() bindingAdded = new EventEmitter<ShortcutChangeEvent>();
+  @Output() bindingRemoved = new EventEmitter<ShortcutChangeEvent>();
+
+  @ViewChild('dialogRoot', { static: true }) dialogRoot?: ElementRef<HTMLDivElement>;
+
+  listeningFor: ShortcutAction | null = null;
+
+  private readonly shortcutsService = inject(ShortcutsService);
+
+  getBindingsFor(action: ShortcutAction): string[] {
+    return this.bindings[action] ?? [];
+  }
+
+  formatBinding(binding: string): string {
+    return this.shortcutsService.formatBindingLabel(binding);
+  }
+
+  startListening(action: ShortcutAction) {
+    this.listeningFor = action;
+    queueMicrotask(() => this.dialogRoot?.nativeElement.focus());
+  }
+
+  stopListening() {
+    this.listeningFor = null;
+  }
+
+  onBackdropClick(event: MouseEvent) {
+    if (event.target !== event.currentTarget) {
+      return;
+    }
+    this.close.emit();
+  }
+
+  onKeydown(event: KeyboardEvent) {
+    if (this.listeningFor) {
+      event.preventDefault();
+
+      if (event.key === 'Escape') {
+        this.stopListening();
+        return;
+      }
+
+      const combo = this.shortcutsService.getEventCombo(event);
+
+      if (combo) {
+        this.bindingAdded.emit({ action: this.listeningFor, combo });
+        this.stopListening();
+      }
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      this.close.emit();
+    }
+  }
+
+  removeBinding(action: ShortcutAction, combo: string) {
+    this.bindingRemoved.emit({ action, combo });
+  }
+}

--- a/src/app/pages/workspace/workspace.page.html
+++ b/src/app/pages/workspace/workspace.page.html
@@ -3,4 +3,10 @@
   <app-workspace-sidebar [vm]="vm"></app-workspace-sidebar>
   <app-workspace-viewer [vm]="vm"></app-workspace-viewer>
   <app-workspace-footer [vm]="vm"></app-workspace-footer>
+  <app-shortcuts-dialog *ngIf="vm.shortcutsDialogOpen()" [definitions]="vm.shortcutDefinitions"
+    [bindings]="vm.shortcutBindings()" (close)="vm.closeShortcutsDialog()"
+    (restoreDefaults)="vm.restoreShortcutDefaults()"
+    (bindingAdded)="vm.addShortcutBinding($event.action, $event.combo)"
+    (bindingRemoved)="vm.removeShortcutBinding($event.action, $event.combo)">
+  </app-shortcuts-dialog>
 </div>

--- a/src/app/services/shortcuts.service.ts
+++ b/src/app/services/shortcuts.service.ts
@@ -1,0 +1,307 @@
+import { Injectable, computed, signal } from '@angular/core';
+
+type ShortcutCombination = string;
+
+export type ShortcutAction =
+  | 'openShortcuts'
+  | 'prevPage'
+  | 'nextPage'
+  | 'zoomIn'
+  | 'zoomOut'
+  | 'undo'
+  | 'redo'
+  | 'downloadPdf';
+
+export interface ShortcutDefinition {
+  readonly action: ShortcutAction;
+  readonly labelKey: string;
+  readonly defaultBindings: readonly ShortcutCombination[];
+}
+
+interface ShortcutStorageState {
+  readonly [key: string]: ShortcutCombination[] | undefined;
+}
+
+const SHORTCUT_STORAGE_KEY = 'pdf-annotator.shortcuts';
+
+const SHORTCUT_DEFINITIONS: ShortcutDefinition[] = [
+  {
+    action: 'openShortcuts',
+    labelKey: 'shortcuts.actions.openShortcuts',
+    defaultBindings: ['shift+/', 'ctrl+/', 'meta+/'],
+  },
+  {
+    action: 'prevPage',
+    labelKey: 'shortcuts.actions.prevPage',
+    defaultBindings: ['arrowleft', 'pageup'],
+  },
+  {
+    action: 'nextPage',
+    labelKey: 'shortcuts.actions.nextPage',
+    defaultBindings: ['arrowright', 'pagedown'],
+  },
+  {
+    action: 'zoomIn',
+    labelKey: 'shortcuts.actions.zoomIn',
+    defaultBindings: ['ctrl+=', 'ctrl++', 'meta+=', 'meta++'],
+  },
+  {
+    action: 'zoomOut',
+    labelKey: 'shortcuts.actions.zoomOut',
+    defaultBindings: ['ctrl+-', 'meta+-'],
+  },
+  {
+    action: 'undo',
+    labelKey: 'shortcuts.actions.undo',
+    defaultBindings: ['ctrl+z', 'meta+z'],
+  },
+  {
+    action: 'redo',
+    labelKey: 'shortcuts.actions.redo',
+    defaultBindings: ['ctrl+shift+z', 'meta+shift+z', 'ctrl+y', 'meta+y'],
+  },
+  {
+    action: 'downloadPdf',
+    labelKey: 'shortcuts.actions.downloadPdf',
+    defaultBindings: ['ctrl+s', 'meta+s'],
+  },
+];
+
+@Injectable({ providedIn: 'root' })
+export class ShortcutsService {
+  readonly definitions = SHORTCUT_DEFINITIONS;
+
+  private readonly bindingMap = signal<Record<ShortcutAction, ShortcutCombination[]>>(
+    this.loadBindings()
+  );
+
+  readonly bindings = computed(() => this.bindingMap());
+
+  addBinding(action: ShortcutAction, binding: ShortcutCombination) {
+    const normalized = this.normalizeCombo(binding);
+    if (!normalized) {
+      return;
+    }
+
+    this.bindingMap.update((current) => {
+      const nextBindings = Array.from(new Set([...(current[action] ?? []), normalized]));
+      const nextMap = { ...current, [action]: nextBindings };
+      this.persist(nextMap);
+      return nextMap;
+    });
+  }
+
+  removeBinding(action: ShortcutAction, binding: ShortcutCombination) {
+    const normalized = this.normalizeCombo(binding);
+    if (!normalized) {
+      return;
+    }
+
+    this.bindingMap.update((current) => {
+      const remaining = (current[action] ?? []).filter((combo) => combo !== normalized);
+      const nextMap = { ...current, [action]: remaining };
+      this.persist(nextMap);
+      return nextMap;
+    });
+  }
+
+  resetBindings() {
+    const defaults = this.buildDefaultBindings();
+    this.bindingMap.set(defaults);
+    this.persist(defaults);
+  }
+
+  getBindings(): Record<ShortcutAction, ShortcutCombination[]> {
+    return this.bindingMap();
+  }
+
+  getBindingsFor(action: ShortcutAction): ShortcutCombination[] {
+    return this.bindingMap()[action] ?? [];
+  }
+
+  formatBindingLabel(binding: ShortcutCombination): string {
+    const parts = binding
+      .split('+')
+      .map((part) => part.trim())
+      .filter(Boolean)
+      .map((part) => this.formatKeyPart(part));
+
+    return parts.join(' + ');
+  }
+
+  match(event: KeyboardEvent, action: ShortcutAction): boolean {
+    const combo = this.getEventCombo(event);
+    if (!combo) {
+      return false;
+    }
+
+    return (this.bindingMap()[action] ?? []).includes(combo);
+  }
+
+  matchAny(event: KeyboardEvent): ShortcutAction | null {
+    const combo = this.getEventCombo(event);
+    if (!combo) {
+      return null;
+    }
+
+    for (const definition of this.definitions) {
+      if ((this.bindingMap()[definition.action] ?? []).includes(combo)) {
+        return definition.action;
+      }
+    }
+
+    return null;
+  }
+
+  getEventCombo(event: KeyboardEvent): ShortcutCombination | null {
+    return this.toEventCombo(event);
+  }
+
+  private formatKeyPart(part: string): string {
+    const normalized = part.toLowerCase();
+    switch (normalized) {
+      case 'ctrl':
+        return 'Ctrl';
+      case 'meta':
+        return 'Cmd';
+      case 'alt':
+        return 'Alt';
+      case 'shift':
+        return 'Shift';
+      case 'arrowleft':
+        return 'Arrow Left';
+      case 'arrowright':
+        return 'Arrow Right';
+      case 'arrowup':
+        return 'Arrow Up';
+      case 'arrowdown':
+        return 'Arrow Down';
+      case 'pageup':
+        return 'Page Up';
+      case 'pagedown':
+        return 'Page Down';
+      case ' ': {
+        return 'Space';
+      }
+      default: {
+        return normalized.length === 1
+          ? normalized.toUpperCase()
+          : normalized.charAt(0).toUpperCase() + normalized.slice(1);
+      }
+    }
+  }
+
+  private loadBindings(): Record<ShortcutAction, ShortcutCombination[]> {
+    const defaults = this.buildDefaultBindings();
+    const storage = this.getLocalStorage();
+
+    if (!storage) {
+      return defaults;
+    }
+
+    try {
+      const storedValue = storage.getItem(SHORTCUT_STORAGE_KEY);
+      if (!storedValue) {
+        return defaults;
+      }
+
+      const parsed = JSON.parse(storedValue) as ShortcutStorageState | null;
+      if (!parsed || typeof parsed !== 'object') {
+        return defaults;
+      }
+
+      const merged: Record<ShortcutAction, ShortcutCombination[]> = { ...defaults };
+
+      for (const definition of this.definitions) {
+        const rawBindings = parsed[definition.action];
+        if (!Array.isArray(rawBindings)) {
+          continue;
+        }
+
+        const normalized = rawBindings
+          .map((binding) => this.normalizeCombo(binding))
+          .filter((binding): binding is ShortcutCombination => !!binding);
+
+        if (normalized.length || rawBindings.length === 0) {
+          merged[definition.action] = Array.from(new Set(normalized));
+        }
+      }
+
+      return merged;
+    } catch {
+      return defaults;
+    }
+  }
+
+  private normalizeCombo(combo: string): ShortcutCombination | null {
+    if (!combo) {
+      return null;
+    }
+
+    const normalized = combo
+      .split('+')
+      .map((part) => part.trim().toLowerCase())
+      .filter(Boolean)
+      .join('+');
+
+    return normalized || null;
+  }
+
+  private toEventCombo(event: KeyboardEvent): ShortcutCombination | null {
+    if (!event.key) {
+      return null;
+    }
+
+    const key = event.key.toLowerCase();
+
+    if (['shift', 'control', 'ctrl', 'meta', 'alt'].includes(key)) {
+      return null;
+    }
+
+    const parts: string[] = [];
+    if (event.ctrlKey || key === 'control' || key === 'ctrl') {
+      parts.push('ctrl');
+    }
+    if (event.metaKey) {
+      parts.push('meta');
+    }
+    if (event.altKey) {
+      parts.push('alt');
+    }
+    if (event.shiftKey) {
+      parts.push('shift');
+    }
+
+    parts.push(key);
+
+    return this.normalizeCombo(parts.join('+'));
+  }
+
+  private buildDefaultBindings(): Record<ShortcutAction, ShortcutCombination[]> {
+    const entries = this.definitions.map((definition) => [
+      definition.action,
+      definition.defaultBindings
+        .map((binding) => this.normalizeCombo(binding))
+        .filter((binding): binding is ShortcutCombination => !!binding),
+    ] as const);
+
+    return Object.fromEntries(entries) as Record<ShortcutAction, ShortcutCombination[]>;
+  }
+
+  private persist(bindings: Record<ShortcutAction, ShortcutCombination[]>) {
+    const storage = this.getLocalStorage();
+    if (!storage) {
+      return;
+    }
+
+    storage.setItem(SHORTCUT_STORAGE_KEY, JSON.stringify(bindings));
+  }
+
+  private getLocalStorage(): Storage | null {
+    if (typeof window === 'undefined' || !window.localStorage) {
+      return null;
+    }
+
+    return window.localStorage;
+  }
+}


### PR DESCRIPTION
## Summary
- add a shortcuts service that normalizes, persists, and matches configurable bindings
- introduce a shortcuts dialog to review, edit, and reset keyboard shortcuts with translated labels
- wire global shortcut handling to the saved bindings and surface a toolbar entry point

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ed1e1bdbc83258bdb2cc74cd93ed5)