### PR TITLE
Add QA contact page

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -12,5 +12,10 @@ export const routes: Routes = [
     loadComponent: () =>
       import('./pages/workspace/workspace.page').then((m) => m.WorkspacePageComponent),
   },
+  {
+    path: 'contact-qa',
+    loadComponent: () =>
+      import('./pages/contact-qa/contact-qa.page').then((m) => m.ContactQaPageComponent),
+  },
   { path: '**', redirectTo: 'landing' },
 ];

--- a/src/app/pages/contact-qa/contact-qa.page.html
+++ b/src/app/pages/contact-qa/contact-qa.page.html
@@ -1,0 +1,65 @@
+<div class="app app--contact">
+  <section class="contact">
+    <header class="contact__header">
+      <a class="contact__pill" routerLink="/landing">← Volver al inicio</a>
+      <div class="contact__titles">
+        <p class="contact__eyebrow">QA & Customer Care</p>
+        <h1 class="contact__title">Contacto rápido y cuidados extra para tu release</h1>
+        <p class="contact__subtitle">
+          Acceso directo al equipo de QA para desbloquear regresiones, validar flujos críticos
+          y recibir acompañamiento en pruebas con PDFs pesados o escenarios edge.
+        </p>
+        <div class="contact__cta-row">
+          <a class="btn contact__btn" routerLink="/workspace">Abrir workspace</a>
+          <span class="contact__hint">Prometemos respuestas accionables, no solo "funciona en mi máquina".</span>
+        </div>
+      </div>
+    </header>
+
+    <div class="contact__grid">
+      <article class="contact__card" *ngFor="let channel of contactChannels">
+        <div class="contact__card-icon">{{ channel.icon }}</div>
+        <div class="contact__card-body">
+          <div class="contact__card-header">
+            <span class="contact__badge">Canal</span>
+            <h2>{{ channel.title }}</h2>
+          </div>
+          <p class="contact__card-text">{{ channel.description }}</p>
+          <a class="contact__link" [href]="channel.link" target="_blank" rel="noopener noreferrer">
+            {{ channel.ctaLabel }}
+          </a>
+          <span class="contact__card-hint" *ngIf="channel.hint">{{ channel.hint }}</span>
+        </div>
+      </article>
+    </div>
+
+    <div class="contact__insights">
+      <div class="contact__column">
+        <h3>Cómo garantizamos calidad</h3>
+        <div class="contact__highlights">
+          <div class="contact__highlight" *ngFor="let highlight of qaHighlights">
+            <span class="contact__tag">{{ highlight.pill }}</span>
+            <div>
+              <h4>{{ highlight.title }}</h4>
+              <p>{{ highlight.description }}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="contact__column contact__column--panel">
+        <h3>Guardrails que ya vienen listos</h3>
+        <ul class="contact__list">
+          <li *ngFor="let guardrail of guardrails">{{ guardrail }}</li>
+        </ul>
+        <div class="contact__panel-footer">
+          <div>
+            <p class="contact__metric">SLA <strong>2h</strong></p>
+            <span class="contact__metric-hint">Respuesta en horario laboral (UTC+1)</span>
+          </div>
+          <a class="contact__link" routerLink="/landing">Ver roadmap</a>
+        </div>
+      </div>
+    </div>
+  </section>
+</div>

--- a/src/app/pages/contact-qa/contact-qa.page.scss
+++ b/src/app/pages/contact-qa/contact-qa.page.scss
@@ -1,0 +1,259 @@
+.app--contact {
+  min-height: 100vh;
+  padding: 72px 20px;
+  background: radial-gradient(circle at 10% 20%, rgba(94, 234, 212, 0.08), transparent 35%),
+    radial-gradient(circle at 90% 10%, rgba(94, 234, 212, 0.08), transparent 30%),
+    var(--bg);
+}
+
+.contact {
+  max-width: 1080px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 36px;
+  color: var(--text);
+}
+
+.contact__header {
+  background: linear-gradient(135deg, rgba(42, 42, 61, 0.95), rgba(32, 38, 45, 0.9));
+  border: 1px solid rgba(94, 234, 212, 0.2);
+  border-radius: 24px;
+  padding: 24px;
+  box-shadow: 0 16px 38px rgba(5, 5, 17, 0.4);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.contact__pill {
+  align-self: flex-start;
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: rgba(94, 234, 212, 0.12);
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 600;
+  border: 1px solid rgba(94, 234, 212, 0.25);
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.contact__pill:hover {
+  transform: translateY(-1px);
+  border-color: rgba(94, 234, 212, 0.6);
+}
+
+.contact__titles {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.contact__eyebrow {
+  margin: 0;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  font-weight: 700;
+  font-size: 0.8rem;
+}
+
+.contact__title {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  line-height: 1.2;
+}
+
+.contact__subtitle {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.contact__cta-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.contact__btn {
+  background: var(--accent);
+  color: #041818;
+  border: none;
+  padding-inline: 18px;
+}
+
+.contact__hint {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.contact__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 18px;
+}
+
+.contact__card {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 16px;
+  padding: 20px;
+  border-radius: 20px;
+  background: rgba(26, 26, 40, 0.8);
+  border: 1px solid rgba(94, 234, 212, 0.1);
+  box-shadow: 0 14px 28px rgba(5, 5, 17, 0.35);
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.contact__card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(94, 234, 212, 0.25);
+}
+
+.contact__card-icon {
+  width: 48px;
+  height: 48px;
+  display: grid;
+  place-items: center;
+  background: rgba(94, 234, 212, 0.14);
+  border-radius: 14px;
+  font-size: 1.6rem;
+}
+
+.contact__card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.contact__card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.contact__badge {
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(94, 234, 212, 0.12);
+  color: var(--accent);
+  font-weight: 700;
+  font-size: 0.75rem;
+}
+
+.contact__card-text {
+  margin: 0;
+  color: var(--muted);
+}
+
+.contact__link {
+  color: var(--accent);
+  font-weight: 700;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.contact__link:hover {
+  text-decoration: underline;
+}
+
+.contact__card-hint {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.contact__insights {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 16px;
+}
+
+.contact__column {
+  padding: 20px;
+  border-radius: 20px;
+  background: rgba(26, 26, 40, 0.85);
+  border: 1px solid rgba(94, 234, 212, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.contact__highlights {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.contact__highlight {
+  padding: 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(94, 234, 212, 0.12);
+  background: rgba(38, 38, 56, 0.7);
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 12px;
+}
+
+.contact__tag {
+  padding: 6px 10px;
+  border-radius: 12px;
+  background: rgba(94, 234, 212, 0.18);
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.contact__column--panel {
+  background: linear-gradient(160deg, rgba(42, 42, 60, 0.95), rgba(24, 30, 36, 0.9));
+}
+
+.contact__list {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--muted);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.contact__panel-footer {
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding-top: 12px;
+  border-top: 1px solid rgba(94, 234, 212, 0.12);
+}
+
+.contact__metric {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.contact__metric strong {
+  color: var(--accent);
+}
+
+.contact__metric-hint {
+  color: var(--muted);
+}
+
+@media (max-width: 640px) {
+  .app--contact {
+    padding: 48px 16px;
+  }
+
+  .contact__card {
+    grid-template-columns: 1fr;
+  }
+
+  .contact__panel-footer {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/src/app/pages/contact-qa/contact-qa.page.ts
+++ b/src/app/pages/contact-qa/contact-qa.page.ts
@@ -1,0 +1,82 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { RouterModule } from '@angular/router';
+
+interface ContactChannel {
+  title: string;
+  description: string;
+  ctaLabel: string;
+  link: string;
+  hint?: string;
+  icon: string;
+}
+
+interface QaHighlight {
+  title: string;
+  description: string;
+  pill: string;
+}
+
+@Component({
+  selector: 'app-contact-qa-page',
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  templateUrl: './contact-qa.page.html',
+  styleUrls: ['./contact-qa.page.scss'],
+})
+export class ContactQaPageComponent {
+  readonly contactChannels: ContactChannel[] = [
+    {
+      title: 'Contacto directo',
+      description: 'Respuestas rápidas para bloqueos críticos, dudas de despliegue o repro de bugs.',
+      ctaLabel: 'Abrir email',
+      link: 'mailto:qa@pdf-annotator.test?subject=Soporte%20QA%20-%20Pdf%20Annotator',
+      hint: 'Tiempo de respuesta promedio: < 2h en horario laboral.',
+      icon: '📧',
+    },
+    {
+      title: 'Canal síncrono',
+      description: 'Sesiones de pairing de QA, validación de flujos complejos y diseño de casos edge.',
+      ctaLabel: 'Agendar 25 min',
+      link: 'https://cal.com/qa-office-hours',
+      hint: 'Incluye checklist previa y enlace de videollamada.',
+      icon: '🎥',
+    },
+    {
+      title: 'Feedback continuo',
+      description: 'Suscríbete a las notas de regresión, bitácora de fixes y métricas de estabilidad.',
+      ctaLabel: 'Ver tablero',
+      link: 'https://linear.app/qa/pdf-annotator',
+      hint: 'Actualizado cada mañana con prioridades y owners.',
+      icon: '📊',
+    },
+  ];
+
+  readonly qaHighlights: QaHighlight[] = [
+    {
+      pill: 'Smoke diario',
+      title: 'Checklists accionables',
+      description:
+        'Cobertura diaria de smoke, flujos críticos y verificación de PDFs con anotaciones pesadas.',
+    },
+    {
+      pill: 'DX first',
+      title: 'Definición de listo',
+      description:
+        'Criterios claros por historia: reproducibilidad, trazas, capturas y dataset mínimo de prueba.',
+    },
+    {
+      pill: 'Autonomía',
+      title: 'Escalada inmediata',
+      description:
+        'Canal directo con ingeniería para desbloquear flujos y priorizar regresiones sin fricción.',
+    },
+  ];
+
+  readonly guardrails: string[] = [
+    'Reproducibilidad garantizada: pasos, datos de entrada y resultado esperado en cada ticket.',
+    'Validación de accesibilidad en formularios y atajos clave en el visor.',
+    'Métricas claras: tiempo de respuesta, severidad y tiempo a fix visible en el tablero.',
+    'Ambiente estable: versiones de navegador soportadas y PDFs de prueba versionados.',
+  ];
+}

--- a/src/app/pages/landing/components/footer/landing-footer.component.html
+++ b/src/app/pages/landing/components/footer/landing-footer.component.html
@@ -10,4 +10,8 @@
     <span>© {{ currentYear }} {{ appName }}</span>
     <span>Desarrollado por {{ appAuthor }}</span>
   </div>
+  <div class="footer__actions">
+    <a class="footer__link" routerLink="/contact-qa">Contacto QA</a>
+    <a class="footer__link" href="mailto:qa@pdf-annotator.test">Soporte</a>
+  </div>
 </footer>

--- a/src/app/pages/landing/components/footer/landing-footer.component.scss
+++ b/src/app/pages/landing/components/footer/landing-footer.component.scss
@@ -1,0 +1,73 @@
+.footer {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  padding: 16px;
+  background: rgba(26, 26, 40, 0.85);
+  border: 1px solid rgba(94, 234, 212, 0.1);
+  border-radius: 16px;
+}
+
+.footer__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.footer__logo {
+  width: 36px;
+  height: 36px;
+}
+
+.footer__brand-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.footer__app-name {
+  font-weight: 700;
+}
+
+.footer__version {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.footer__details {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.footer__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+}
+
+.footer__link {
+  color: var(--accent);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.footer__link:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 720px) {
+  .footer {
+    justify-content: center;
+    text-align: center;
+  }
+
+  .footer__details {
+    align-items: center;
+  }
+}

--- a/src/app/pages/landing/components/footer/landing-footer.component.ts
+++ b/src/app/pages/landing/components/footer/landing-footer.component.ts
@@ -1,11 +1,13 @@
 import { CommonModule } from '@angular/common';
 import { Component, Input } from '@angular/core';
+import { RouterModule } from '@angular/router';
 
 @Component({
   selector: 'app-landing-footer',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, RouterModule],
   templateUrl: './landing-footer.component.html',
+  styleUrl: './landing-footer.component.scss',
 })
 export class LandingFooterComponent {
   @Input({ required: true }) appName = '';


### PR DESCRIPTION
## Summary
- add a QA-focused contact page with quick-access channels, highlights, and guardrails
- style the new contact experience to match the app theme
- link the contact page from the landing footer with refreshed footer styling

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925908a68dc83258fb02d295423ffb7)