### PR TITLE
Add red disclaimer banner to landing page

### DIFF
--- a/src/app/pages/landing/landing.page.html
+++ b/src/app/pages/landing/landing.page.html
@@ -5,6 +5,10 @@
 
     <app-landing-hero></app-landing-hero>
 
+    <div class="landing__disclaimer" role="alert">
+      ¡DISCLAIMER! Esta es una herramienta de demostración. Usa tus PDFs bajo tu responsabilidad.
+    </div>
+
     <app-landing-dropzone [fileDropActive]="fileDropActive()" (fileSelected)="onFileSelected($event)"
       (fileUploadKeydown)="onFileUploadKeydown($event)" (fileDragOver)="onFileDragOver($event)"
       (fileDragLeave)="onFileDragLeave($event)" (fileDrop)="onFileDrop($event)"

--- a/src/app/pages/landing/landing.page.scss
+++ b/src/app/pages/landing/landing.page.scss
@@ -1,0 +1,14 @@
+.landing__disclaimer {
+  margin: 2rem auto;
+  max-width: 960px;
+  padding: 1.5rem;
+  border: 2px solid #c1121f;
+  border-radius: 1rem;
+  color: #b00020;
+  background: rgba(192, 18, 31, 0.08);
+  font-size: clamp(1.75rem, 3vw + 1rem, 3.5rem);
+  font-weight: 800;
+  line-height: 1.2;
+  text-align: center;
+  text-transform: uppercase;
+}


### PR DESCRIPTION
## Summary
- add a prominent disclaimer alert to the landing page content
- style the disclaimer with large red typography and supporting layout spacing

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928924793c883259a8214e35e8480e0)