### PR TITLE
Add fun prompt corner to workspace sidebar

### DIFF
--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -177,6 +177,28 @@
     },
     "editingBadge": "Editant"
   },
+  "funCorner": {
+    "title": "Espurna creativa",
+    "shuffle": "Mostra'm una altra idea",
+    "prompts": {
+      "magic": {
+        "title": "Afegeix una etiqueta màgica",
+        "description": "Posa una anotació amb l'emoji ✨ al costat de la signatura o ressalta la clàusula estrella."
+      },
+      "navigator": {
+        "title": "Mini recorregut guiat",
+        "description": "Col·loca petites notes numerades (1️⃣, 2️⃣, 3️⃣) per crear un camí de revisió divertit per a l'equip."
+      },
+      "bubble": {
+        "title": "Bombolla de diàleg",
+        "description": "Utilitza una nota arrodonida amb 💬 i lletra en negreta per simular un comentari d'estil còmic."
+      },
+      "target": {
+        "title": "Repte de precisió",
+        "description": "Puja el zoom al 200% i alinea dues anotacions amb les guies; després celebra-ho amb 🎯."
+      }
+    }
+  },
   "fonts": {
     "custom": {
       "enableFeature": "Activa les fonts personalitzades",

--- a/src/app/i18n/translations/de.json
+++ b/src/app/i18n/translations/de.json
@@ -177,6 +177,28 @@
     },
     "editingBadge": "Bearbeitung"
   },
+  "funCorner": {
+    "title": "Kreativfunke",
+    "shuffle": "Noch eine Idee",
+    "prompts": {
+      "magic": {
+        "title": "Zauber-Label setzen",
+        "description": "Füge eine Anmerkung mit dem Emoji ✨ neben der Unterschrift hinzu oder markiere die beste Klausel."
+      },
+      "navigator": {
+        "title": "Geführte Mini-Tour",
+        "description": "Platziere kleine nummerierte Notizen (1️⃣, 2️⃣, 3️⃣), um einen spielerischen Prüfpfad fürs Team zu bauen."
+      },
+      "bubble": {
+        "title": "Sprechblasen-Feeling",
+        "description": "Nutze eine runde Notiz mit 💬 und fetter Schrift, um einen Comic-Kommentar nachzuahmen."
+      },
+      "target": {
+        "title": "Präzisions-Challenge",
+        "description": "Zoome auf 200 % und richte zwei Anmerkungen mit den Hilfslinien aus – danach feiern mit 🎯."
+      }
+    }
+  },
   "fonts": {
     "custom": {
       "enableFeature": "Benutzerdefinierte Schriften aktivieren",

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -177,6 +177,28 @@
     },
     "editingBadge": "Editing"
   },
+  "funCorner": {
+    "title": "Creative spark",
+    "shuffle": "Show another idea",
+    "prompts": {
+      "magic": {
+        "title": "Drop a magic label",
+        "description": "Add an annotation with a ✨ emoji next to the signature or highlight the best clause."
+      },
+      "navigator": {
+        "title": "Guided micro-tour",
+        "description": "Place small numbered notes (1️⃣, 2️⃣, 3️⃣) to create a playful review path for teammates."
+      },
+      "bubble": {
+        "title": "Speech bubble vibe",
+        "description": "Use a rounded note with 💬 and a bold font to simulate a comic-style comment on the PDF."
+      },
+      "target": {
+        "title": "Precision challenge",
+        "description": "Scale to 200% and try to align two annotations perfectly using guides—then celebrate with 🎯."
+      }
+    }
+  },
   "fonts": {
     "custom": {
       "enableFeature": "Enable custom fonts",

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -177,6 +177,28 @@
     },
     "editingBadge": "Editando"
   },
+  "funCorner": {
+    "title": "Chispa creativa",
+    "shuffle": "Quiero otra idea",
+    "prompts": {
+      "magic": {
+        "title": "Pon una etiqueta mágica",
+        "description": "Añade una anotación con el emoji ✨ junto a la firma o resalta la cláusula estrella."
+      },
+      "navigator": {
+        "title": "Mini tour guiado",
+        "description": "Coloca notas numeradas (1️⃣, 2️⃣, 3️⃣) para proponer un recorrido divertido a tu equipo."
+      },
+      "bubble": {
+        "title": "Burbuja de diálogo",
+        "description": "Usa una nota redondeada con 💬 y fuente en negrita para imitar un comentario estilo cómic."
+      },
+      "target": {
+        "title": "Reto de precisión",
+        "description": "Sube el zoom a 200% y alinea dos anotaciones con las guías; después celebra con 🎯."
+      }
+    }
+  },
   "fonts": {
     "custom": {
       "enableFeature": "Activar fuentes personalizadas",

--- a/src/app/i18n/translations/fr.json
+++ b/src/app/i18n/translations/fr.json
@@ -177,6 +177,28 @@
     },
     "editingBadge": "Édition"
   },
+  "funCorner": {
+    "title": "Étincelle créative",
+    "shuffle": "Une autre idée",
+    "prompts": {
+      "magic": {
+        "title": "Dépose une étiquette magique",
+        "description": "Ajoute une annotation avec l'emoji ✨ près de la signature ou souligne la meilleure clause."
+      },
+      "navigator": {
+        "title": "Mini-visite guidée",
+        "description": "Place de petites notes numérotées (1️⃣, 2️⃣, 3️⃣) pour créer un parcours ludique pour l'équipe."
+      },
+      "bubble": {
+        "title": "Bulle de dialogue",
+        "description": "Utilise une note arrondie avec 💬 et une police en gras pour simuler un commentaire façon BD."
+      },
+      "target": {
+        "title": "Défi précision",
+        "description": "Passe à 200 % et aligne deux annotations avec les repères, puis fête ça avec 🎯."
+      }
+    }
+  },
   "fonts": {
     "custom": {
       "enableFeature": "Activer les polices personnalisées",

--- a/src/app/i18n/translations/it.json
+++ b/src/app/i18n/translations/it.json
@@ -177,6 +177,28 @@
     },
     "editingBadge": "Modifica in corso"
   },
+  "funCorner": {
+    "title": "Spinta creativa",
+    "shuffle": "Mostra un'altra idea",
+    "prompts": {
+      "magic": {
+        "title": "Aggiungi un'etichetta magica",
+        "description": "Inserisci un'annotazione con l'emoji ✨ vicino alla firma o evidenzia la clausola migliore."
+      },
+      "navigator": {
+        "title": "Micro tour guidato",
+        "description": "Posiziona piccole note numerate (1️⃣, 2️⃣, 3️⃣) per creare un percorso di revisione giocoso per il team."
+      },
+      "bubble": {
+        "title": "Bolla di dialogo",
+        "description": "Usa una nota arrotondata con 💬 e un font grassetto per simulare un commento in stile fumetto."
+      },
+      "target": {
+        "title": "Sfida di precisione",
+        "description": "Porta lo zoom al 200% e allinea due annotazioni con le guide, poi festeggia con 🎯."
+      }
+    }
+  },
   "fonts": {
     "custom": {
       "enableFeature": "Attiva font personalizzati",

--- a/src/app/i18n/translations/pt.json
+++ b/src/app/i18n/translations/pt.json
@@ -177,6 +177,28 @@
     },
     "editingBadge": "A editar"
   },
+  "funCorner": {
+    "title": "Faísca criativa",
+    "shuffle": "Mostrar outra ideia",
+    "prompts": {
+      "magic": {
+        "title": "Solte um rótulo mágico",
+        "description": "Adicione uma anotação com o emoji ✨ perto da assinatura ou destaque a melhor cláusula."
+      },
+      "navigator": {
+        "title": "Micro tour guiado",
+        "description": "Posicione pequenas notas numeradas (1️⃣, 2️⃣, 3️⃣) para criar um percurso divertido para o time."
+      },
+      "bubble": {
+        "title": "Clima de balão de fala",
+        "description": "Use uma nota arredondada com 💬 e fonte em negrito para simular um comentário em estilo quadrinhos."
+      },
+      "target": {
+        "title": "Desafio de precisão",
+        "description": "Aumente para 200% e alinhe duas anotações com as guias; depois comemore com 🎯."
+      }
+    }
+  },
   "fonts": {
     "custom": {
       "enableFeature": "Ativar tipos de letra personalizados",

--- a/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.html
+++ b/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.html
@@ -79,6 +79,19 @@
       <p class="templates__empty">{{ 'sidebar.templates.empty' | t }}</p>
     </ng-template>
   </section>
+  <section class="fun-box" aria-live="polite">
+    <div class="fun-box__header">
+      <span class="fun-box__emoji" aria-hidden="true">{{ vm.funPrompt().emoji }}</span>
+      <div>
+        <p class="fun-box__eyebrow">{{ 'funCorner.title' | t }}</p>
+        <p class="fun-box__title">{{ vm.funPrompt().title }}</p>
+      </div>
+    </div>
+    <p class="fun-box__description">{{ vm.funPrompt().description }}</p>
+    <button type="button" class="btn fun-box__button" (click)="vm.refreshFunPrompt()">
+      {{ 'funCorner.shuffle' | t }}
+    </button>
+  </section>
   <ng-container *ngIf="vm.jsonViewMode() === 'text'; else jsonTreeView">
     <textarea #jsonEditor class="json-editor" [ngModel]="vm.coordsTextModel"
       (ngModelChange)="vm.onCoordsTextChange($event)" [placeholder]="'sidebar.jsonPlaceholder' | t" spellcheck="false"></textarea>

--- a/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.scss
+++ b/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.scss
@@ -60,6 +60,61 @@
   color: rgba(255, 255, 255, 0.75);
 }
 
+.fun-box {
+  margin: 16px 0 12px;
+  padding: 14px 14px 12px;
+  border-radius: 14px;
+  border: 1px solid rgba(94, 234, 212, 0.12);
+  background: linear-gradient(145deg, rgba(23, 27, 45, 0.95), rgba(27, 31, 53, 0.75));
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.26);
+}
+
+.fun-box__header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.fun-box__emoji {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  background: rgba(94, 234, 212, 0.12);
+  font-size: 1.4rem;
+}
+
+.fun-box__eyebrow {
+  margin: 0;
+  color: var(--accent);
+  font-weight: 700;
+  font-size: 0.85rem;
+}
+
+.fun-box__title {
+  margin: 2px 0 0;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.fun-box__description {
+  margin: 10px 0 12px;
+  color: rgba(255, 255, 255, 0.9);
+  line-height: 1.45;
+}
+
+.fun-box__button {
+  width: 100%;
+  justify-content: center;
+  background: rgba(94, 234, 212, 0.16);
+}
+
+.fun-box__button:hover {
+  background: rgba(94, 234, 212, 0.26);
+}
+
 @media (max-width: 1024px) {
   .sidebar-thumbnails__list {
     max-height: clamp(140px, 28vh, 300px);

--- a/src/app/pages/workspace/workspace.page.ts
+++ b/src/app/pages/workspace/workspace.page.ts
@@ -131,6 +131,12 @@ interface FontDropdownUiState {
   readonly query: string;
 }
 
+interface FunPromptDefinition {
+  readonly emoji: string;
+  readonly titleKey: string;
+  readonly descriptionKey: string;
+}
+
 const DEFAULT_FONT_ID = 'standard:helvetica';
 const DEFAULT_OPACITY = 1;
 
@@ -199,6 +205,38 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
   readonly currentYear = new Date().getFullYear();
   readonly languages: readonly Language[] = this.translationService.supportedLanguages;
   languageModel: Language = this.translationService.getCurrentLanguage();
+  private readonly funPrompts: readonly FunPromptDefinition[] = [
+    {
+      emoji: '🪄',
+      titleKey: 'funCorner.prompts.magic.title',
+      descriptionKey: 'funCorner.prompts.magic.description',
+    },
+    {
+      emoji: '🧭',
+      titleKey: 'funCorner.prompts.navigator.title',
+      descriptionKey: 'funCorner.prompts.navigator.description',
+    },
+    {
+      emoji: '💬',
+      titleKey: 'funCorner.prompts.bubble.title',
+      descriptionKey: 'funCorner.prompts.bubble.description',
+    },
+    {
+      emoji: '🎯',
+      titleKey: 'funCorner.prompts.target.title',
+      descriptionKey: 'funCorner.prompts.target.description',
+    },
+  ];
+  readonly funPromptIndex = signal(this.buildRandomFunPromptIndex());
+  readonly funPrompt = computed(() => {
+    const prompt = this.funPrompts[this.funPromptIndex()];
+
+    return {
+      emoji: prompt.emoji,
+      title: this.translationService.translate(prompt.titleKey),
+      description: this.translationService.translate(prompt.descriptionKey),
+    };
+  });
   readonly defaultFontId = DEFAULT_FONT_ID;
   private readonly coordsFileInputChangeHandler = (event: Event) =>
     this.onCoordsFileSelected(event);
@@ -346,6 +384,25 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
       }
       this.coordsFileInputFallback = null;
     }
+  }
+
+  refreshFunPrompt() {
+    if (!this.funPrompts.length) {
+      return;
+    }
+
+    const currentIndex = this.funPromptIndex();
+    let nextIndex = this.buildRandomFunPromptIndex();
+
+    if (this.funPrompts.length > 1 && nextIndex === currentIndex) {
+      nextIndex = (nextIndex + 1) % this.funPrompts.length;
+    }
+
+    this.funPromptIndex.set(nextIndex);
+  }
+
+  private buildRandomFunPromptIndex(): number {
+    return Math.floor(Math.random() * this.funPrompts.length);
   }
 
   setFieldFont(mode: EditorMode, fontId: string) {


### PR DESCRIPTION
## Summary
- add a playful "Creative spark" corner in the workspace sidebar with rotating annotation ideas
- style the new fun box to match the app's accent theme
- localize the feature text across all supported languages

## Testing
- npm run i18n:check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692897e0d25c8325b82ea5059cb29fde)