### PR TITLE
Add light/dark theme toggle

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,5 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { ThemeService } from './services/theme.service';
 
 @Component({
   selector: 'app-root',
@@ -7,4 +8,6 @@ import { RouterOutlet } from '@angular/router';
   imports: [RouterOutlet],
   template: '<router-outlet />',
 })
-export class App {}
+export class App {
+  private readonly themeService = inject(ThemeService);
+}

--- a/src/app/components/theme-toggle/theme-toggle.component.html
+++ b/src/app/components/theme-toggle/theme-toggle.component.html
@@ -1,0 +1,12 @@
+<button
+  type="button"
+  class="btn btn--icon btn--ghost theme-toggle"
+  (click)="toggleTheme()"
+  [attr.aria-label]="
+    'theme.switchTo' | t : { mode: isLight() ? ('theme.dark' | t) : ('theme.light' | t) }
+  "
+  [attr.title]="'theme.toggleLabel' | t"
+>
+  <span class="btn__icon" aria-hidden="true">{{ isLight() ? '🌙' : '🌞' }}</span>
+  <span class="btn__label">{{ isLight() ? ('theme.dark' | t) : ('theme.light' | t) }}</span>
+</button>

--- a/src/app/components/theme-toggle/theme-toggle.component.scss
+++ b/src/app/components/theme-toggle/theme-toggle.component.scss
@@ -1,0 +1,3 @@
+.theme-toggle {
+  white-space: nowrap;
+}

--- a/src/app/components/theme-toggle/theme-toggle.component.ts
+++ b/src/app/components/theme-toggle/theme-toggle.component.ts
@@ -1,0 +1,21 @@
+import { CommonModule } from '@angular/common';
+import { Component, computed, inject } from '@angular/core';
+import { TranslationPipe } from '../../i18n/translation.pipe';
+import { ThemeService } from '../../services/theme.service';
+
+@Component({
+  selector: 'app-theme-toggle',
+  standalone: true,
+  imports: [CommonModule, TranslationPipe],
+  templateUrl: './theme-toggle.component.html',
+  styleUrls: ['./theme-toggle.component.scss'],
+})
+export class ThemeToggleComponent {
+  private readonly themeService = inject(ThemeService);
+  readonly theme = this.themeService.theme;
+  readonly isLight = computed(() => this.theme() === 'light');
+
+  toggleTheme() {
+    this.themeService.toggleTheme();
+  }
+}

--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -30,6 +30,12 @@
       "ariaLabel": "Puja un nou PDF per reiniciar l'espai de treball"
     }
   },
+  "theme": {
+    "toggleLabel": "Canviar tema",
+    "light": "Mode clar",
+    "dark": "Mode fosc",
+    "switchTo": "Canvia a {{mode}}"
+  },
   "controls": {
     "prev": "Anterior",
     "next": "Següent",
@@ -53,7 +59,8 @@
     "navigationGroup": "Navegació de pàgines",
     "zoomGroup": "Controls de zoom",
     "historyGroup": "Accions d'historial",
-    "exportGroup": "Opcions d'exportació"
+    "exportGroup": "Opcions d'exportació",
+    "preferencesGroup": "Preferències"
   },
   "sidebar": {
     "title": "Anotacions (JSON)",

--- a/src/app/i18n/translations/de.json
+++ b/src/app/i18n/translations/de.json
@@ -30,6 +30,12 @@
       "ariaLabel": "Neues PDF hochladen, um den Arbeitsbereich zurückzusetzen"
     }
   },
+  "theme": {
+    "toggleLabel": "Design wechseln",
+    "light": "Heller Modus",
+    "dark": "Dunkler Modus",
+    "switchTo": "Zu {{mode}} wechseln"
+  },
   "controls": {
     "prev": "Zurück",
     "next": "Weiter",
@@ -53,7 +59,8 @@
     "navigationGroup": "Seitennavigation",
     "zoomGroup": "Zoom-Steuerung",
     "historyGroup": "Verlauf",
-    "exportGroup": "Exportoptionen"
+    "exportGroup": "Exportoptionen",
+    "preferencesGroup": "Einstellungen"
   },
   "sidebar": {
     "title": "Anmerkungen (JSON)",

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -30,6 +30,12 @@
       "ariaLabel": "Upload a new PDF to restart the annotation workspace"
     }
   },
+  "theme": {
+    "toggleLabel": "Toggle theme",
+    "light": "Light mode",
+    "dark": "Dark mode",
+    "switchTo": "Switch to {{mode}}"
+  },
   "controls": {
     "prev": "Prev",
     "next": "Next",
@@ -53,7 +59,8 @@
     "navigationGroup": "Page navigation",
     "zoomGroup": "Zoom controls",
     "historyGroup": "History actions",
-    "exportGroup": "Export options"
+    "exportGroup": "Export options",
+    "preferencesGroup": "Preferences"
   },
   "sidebar": {
     "title": "Annotations (JSON)",

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -30,6 +30,12 @@
       "ariaLabel": "Subir un nuevo PDF para reiniciar el espacio de trabajo"
     }
   },
+  "theme": {
+    "toggleLabel": "Cambiar tema",
+    "light": "Modo claro",
+    "dark": "Modo oscuro",
+    "switchTo": "Cambiar a {{mode}}"
+  },
   "controls": {
     "prev": "Anterior",
     "next": "Siguiente",
@@ -53,7 +59,8 @@
     "navigationGroup": "Navegación de páginas",
     "zoomGroup": "Controles de zoom",
     "historyGroup": "Acciones de historial",
-    "exportGroup": "Opciones de exportación"
+    "exportGroup": "Opciones de exportación",
+    "preferencesGroup": "Preferencias"
   },
   "sidebar": {
     "title": "Anotaciones (JSON)",

--- a/src/app/i18n/translations/fr.json
+++ b/src/app/i18n/translations/fr.json
@@ -30,6 +30,12 @@
       "ariaLabel": "Téléverser un nouveau PDF pour réinitialiser l'espace de travail"
     }
   },
+  "theme": {
+    "toggleLabel": "Changer de thème",
+    "light": "Mode clair",
+    "dark": "Mode sombre",
+    "switchTo": "Passer en {{mode}}"
+  },
   "controls": {
     "prev": "Précédent",
     "next": "Suivant",
@@ -53,7 +59,8 @@
     "navigationGroup": "Navigation des pages",
     "zoomGroup": "Contrôles du zoom",
     "historyGroup": "Actions d'historique",
-    "exportGroup": "Options d'export"
+    "exportGroup": "Options d'export",
+    "preferencesGroup": "Préférences"
   },
   "sidebar": {
     "title": "Annotations (JSON)",

--- a/src/app/i18n/translations/it.json
+++ b/src/app/i18n/translations/it.json
@@ -30,6 +30,12 @@
       "ariaLabel": "Carica un nuovo PDF per reimpostare l'area di lavoro"
     }
   },
+  "theme": {
+    "toggleLabel": "Cambia tema",
+    "light": "Modalità chiara",
+    "dark": "Modalità scura",
+    "switchTo": "Passa a {{mode}}"
+  },
   "controls": {
     "prev": "Precedente",
     "next": "Successivo",
@@ -53,7 +59,8 @@
     "navigationGroup": "Navigazione pagine",
     "zoomGroup": "Controlli zoom",
     "historyGroup": "Azioni cronologia",
-    "exportGroup": "Opzioni di esportazione"
+    "exportGroup": "Opzioni di esportazione",
+    "preferencesGroup": "Preferenze"
   },
   "sidebar": {
     "title": "Annotazioni (JSON)",

--- a/src/app/i18n/translations/pt.json
+++ b/src/app/i18n/translations/pt.json
@@ -30,6 +30,12 @@
       "ariaLabel": "Carregar um novo PDF para reiniciar o espaço de trabalho"
     }
   },
+  "theme": {
+    "toggleLabel": "Alterar tema",
+    "light": "Modo claro",
+    "dark": "Modo escuro",
+    "switchTo": "Mudar para {{mode}}"
+  },
   "controls": {
     "prev": "Anterior",
     "next": "Seguinte",
@@ -53,7 +59,8 @@
     "navigationGroup": "Navegação de páginas",
     "zoomGroup": "Controlos de zoom",
     "historyGroup": "Ações de histórico",
-    "exportGroup": "Opções de exportação"
+    "exportGroup": "Opções de exportação",
+    "preferencesGroup": "Preferências"
   },
   "sidebar": {
     "title": "Anotações (JSON)",

--- a/src/app/pages/landing/components/language-bar/landing-language-bar.component.html
+++ b/src/app/pages/landing/components/language-bar/landing-language-bar.component.html
@@ -1,4 +1,5 @@
 <div class="landing__language">
+  <app-theme-toggle></app-theme-toggle>
   <app-language-selector
     [languages]="languages"
     [selectedLanguage]="selectedLanguage"

--- a/src/app/pages/landing/components/language-bar/landing-language-bar.component.ts
+++ b/src/app/pages/landing/components/language-bar/landing-language-bar.component.ts
@@ -1,12 +1,13 @@
 import { CommonModule } from '@angular/common';
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { LanguageSelectorComponent } from '../../../../components/language-selector/language-selector.component';
+import { ThemeToggleComponent } from '../../../../components/theme-toggle/theme-toggle.component';
 import { Language } from '../../../../i18n/translation.service';
 
 @Component({
   selector: 'app-landing-language-bar',
   standalone: true,
-  imports: [CommonModule, LanguageSelectorComponent],
+  imports: [CommonModule, LanguageSelectorComponent, ThemeToggleComponent],
   templateUrl: './landing-language-bar.component.html',
 })
 export class LandingLanguageBarComponent {

--- a/src/app/pages/workspace/components/header/workspace-header.component.html
+++ b/src/app/pages/workspace/components/header/workspace-header.component.html
@@ -58,8 +58,11 @@
       </button>
     </div>
 
-    <app-language-selector class="header__language-selector" [languages]="vm.languages"
-      [selectedLanguage]="vm.languageModel" (languageChange)="vm.onLanguageChange($event)" variant="compact">
-    </app-language-selector>
+    <div class="toolbar__group toolbar__group--preferences" role="group" [attr.aria-label]="'controls.preferencesGroup' | t">
+      <app-theme-toggle></app-theme-toggle>
+      <app-language-selector class="header__language-selector" [languages]="vm.languages"
+        [selectedLanguage]="vm.languageModel" (languageChange)="vm.onLanguageChange($event)" variant="compact">
+      </app-language-selector>
+    </div>
   </div>
 </header>

--- a/src/app/pages/workspace/components/header/workspace-header.component.ts
+++ b/src/app/pages/workspace/components/header/workspace-header.component.ts
@@ -4,13 +4,20 @@ import { FormsModule } from '@angular/forms';
 import type { WorkspacePageComponent } from '../../workspace.page';
 import { TranslationPipe } from '../../../../i18n/translation.pipe';
 import { LanguageSelectorComponent } from '../../../../components/language-selector/language-selector.component';
+import { ThemeToggleComponent } from '../../../../components/theme-toggle/theme-toggle.component';
 
 @Component({
   selector: 'app-workspace-header',
   standalone: true,
   templateUrl: './workspace-header.component.html',
   styleUrls: ['./workspace-header.component.scss'],
-  imports: [CommonModule, FormsModule, TranslationPipe, LanguageSelectorComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    TranslationPipe,
+    LanguageSelectorComponent,
+    ThemeToggleComponent,
+  ],
 })
 export class WorkspaceHeaderComponent {
   @Input({ required: true }) vm!: WorkspacePageComponent;

--- a/src/app/services/theme.service.ts
+++ b/src/app/services/theme.service.ts
@@ -1,0 +1,59 @@
+import { DOCUMENT } from '@angular/common';
+import { Injectable, inject, signal } from '@angular/core';
+
+type Theme = 'light' | 'dark';
+
+const STORAGE_KEY = 'pdf-annotator-theme';
+
+@Injectable({ providedIn: 'root' })
+export class ThemeService {
+  private readonly document = inject(DOCUMENT);
+  readonly theme = signal<Theme>('dark');
+
+  constructor() {
+    const stored = this.loadStoredTheme();
+    this.applyTheme(stored ?? 'dark');
+  }
+
+  toggleTheme() {
+    const next: Theme = this.theme() === 'dark' ? 'light' : 'dark';
+    this.applyTheme(next);
+  }
+
+  private applyTheme(theme: Theme) {
+    this.theme.set(theme);
+    const root = this.document.documentElement;
+    root.classList.remove('theme-dark', 'theme-light');
+    root.classList.add(`theme-${theme}`);
+    root.setAttribute('data-theme', theme);
+    this.persistTheme(theme);
+  }
+
+  private loadStoredTheme(): Theme | null {
+    if (typeof localStorage === 'undefined') {
+      return null;
+    }
+
+    try {
+      const value = localStorage.getItem(STORAGE_KEY);
+      if (value === 'light' || value === 'dark') {
+        return value;
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  private persistTheme(theme: Theme) {
+    if (typeof localStorage === 'undefined') {
+      return;
+    }
+
+    try {
+      localStorage.setItem(STORAGE_KEY, theme);
+    } catch {
+      /* noop */
+    }
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -5,6 +5,21 @@
   --danger: #ff4d4d;
   --text: #f5f5f5;
   --muted: #b0b0b0;
+  color-scheme: dark;
+}
+
+:root.theme-dark {
+  color-scheme: dark;
+}
+
+:root.theme-light {
+  --bg: #f6f7fb;
+  --panel: #ffffff;
+  --accent: #0f9b8e;
+  --danger: #dc2626;
+  --text: #0f172a;
+  --muted: #475569;
+  color-scheme: light;
 }
 
 * {
@@ -18,6 +33,12 @@ body {
   font-family: 'Segoe UI', sans-serif;
   color: var(--text);
   background: var(--bg);
+}
+
+:root.theme-light html,
+:root.theme-light body {
+  background: var(--bg);
+  color: var(--text);
 }
 
 .app {
@@ -58,6 +79,7 @@ body {
   right: 32px;
   display: flex;
   justify-content: flex-end;
+  gap: 8px;
 }
 
 .landing__language app-language-selector {
@@ -126,6 +148,22 @@ body {
 .landing__dropzone--active {
   border-color: var(--accent);
   background: rgba(26, 41, 45, 0.85);
+}
+
+:root.theme-light .landing__dropzone {
+  background: rgba(255, 255, 255, 0.95);
+  border-color: rgba(15, 155, 142, 0.25);
+  box-shadow: 0 18px 38px rgba(15, 23, 42, 0.14);
+}
+
+:root.theme-light .landing__dropzone:hover {
+  border-color: rgba(15, 155, 142, 0.45);
+  background: rgba(255, 255, 255, 0.98);
+}
+
+:root.theme-light .landing__dropzone--active {
+  background: rgba(238, 249, 247, 0.95);
+  border-color: rgba(15, 155, 142, 0.6);
 }
 
 .landing__icon {
@@ -209,6 +247,12 @@ header.header {
   grid-template-columns: minmax(0, 1fr);
 }
 
+:root.theme-light header.header {
+  background: linear-gradient(135deg, #ffffff, #e5edf5);
+  border: 1px solid #d7dde9;
+  box-shadow: 0 18px 34px rgba(15, 23, 42, 0.12);
+}
+
 .header__top {
   display: flex;
   flex-wrap: wrap;
@@ -253,6 +297,12 @@ header .logo {
   backdrop-filter: blur(10px);
 }
 
+:root.theme-light .toolbar__group {
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid #d9e2ec;
+  box-shadow: 0 10px 18px rgba(15, 23, 42, 0.1);
+}
+
 .toolbar__badge {
   display: inline-flex;
   align-items: center;
@@ -263,6 +313,11 @@ header .logo {
   color: var(--accent);
   font-size: 0.85rem;
   font-weight: 600;
+}
+
+:root.theme-light .toolbar__badge {
+  background: rgba(15, 155, 142, 0.12);
+  color: var(--accent);
 }
 
 .toolbar__group--coords {
@@ -299,10 +354,21 @@ header .logo {
   transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
 }
 
+:root.theme-light .btn {
+  background: #e2e8f0;
+  border-color: #cbd5e1;
+  color: var(--text);
+}
+
 .btn:hover:not(:disabled) {
   transform: translateY(-1px);
   border-color: var(--accent);
   background: rgba(52, 52, 80, 0.95);
+}
+
+:root.theme-light .btn:hover:not(:disabled) {
+  background: #d6e0eb;
+  border-color: rgba(15, 155, 142, 0.7);
 }
 
 .btn:disabled {
@@ -329,9 +395,20 @@ header .logo {
   color: #ffe5e5;
 }
 
+:root.theme-light .btn--danger {
+  border-color: rgba(220, 38, 38, 0.5);
+  background: rgba(220, 38, 38, 0.12);
+  color: #7f1d1d;
+}
+
 .btn--danger:hover:not(:disabled) {
   border-color: rgba(255, 77, 77, 0.6);
   background: rgba(255, 77, 77, 0.25);
+}
+
+:root.theme-light .btn--danger:hover:not(:disabled) {
+  border-color: rgba(220, 38, 38, 0.7);
+  background: rgba(220, 38, 38, 0.2);
 }
 
 .btn--ghost {
@@ -344,6 +421,14 @@ header .logo {
   border-color: transparent;
   background: rgba(94, 234, 212, 0.12);
   color: var(--accent);
+}
+
+:root.theme-light .btn--ghost {
+  color: var(--muted);
+}
+
+:root.theme-light .btn--ghost:hover:not(:disabled) {
+  background: rgba(15, 155, 142, 0.12);
 }
 
 @media (min-width: 960px) {
@@ -370,6 +455,12 @@ header .logo {
   cursor: pointer;
   transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
   outline: none;
+}
+
+:root.theme-light .sidebar-upload {
+  background: #ffffff;
+  border-color: #d7dde9;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
 }
 
 .sidebar-upload:hover {
@@ -511,6 +602,14 @@ header .logo {
     padding: 10px;
     font-family: 'Fira Code', monospace;
     font-size: 0.85rem;
+  }
+
+  :root.theme-light & .json-editor,
+  :root.theme-light & .json-tree-container,
+  :root.theme-light & .json-tree-placeholder {
+    background: #f8fafc;
+    border-color: #d7dde9;
+    color: var(--text);
   }
 
   .json-tree-container {
@@ -713,6 +812,12 @@ header .logo {
   overflow: hidden;
 }
 
+:root.theme-light .advanced-panel {
+  background: linear-gradient(140deg, #ffffff, #e9edf5);
+  border: 1px solid #d9e2ec;
+  box-shadow: 0 18px 36px -16px rgba(15, 23, 42, 0.14);
+}
+
 .advanced-panel::before {
   content: "";
   position: absolute;
@@ -755,6 +860,12 @@ header .logo {
   transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
   position: relative;
   z-index: 1;
+}
+
+:root.theme-light .advanced-panel .advanced-toggle {
+  background: #f1f5f9;
+  border-color: #d9e2ec;
+  color: var(--text);
 }
 
 .advanced-panel .advanced-toggle:hover,


### PR DESCRIPTION
## Summary
- add a reusable theme service and toggle component to switch between light and dark modes with persistence
- surface the toggle on landing and workspace headers alongside existing language controls
- style a new light theme variant and localize the new controls across available languages

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692896f995c483258aaccfbee441828f)