### PR TITLE
Add Valencian language support

### DIFF
--- a/src/app/components/language-selector/language-selector.component.ts
+++ b/src/app/components/language-selector/language-selector.component.ts
@@ -10,6 +10,7 @@ const LANGUAGE_FLAGS: Record<Language, string> = {
   'es-ES': '🇪🇸',
   en: '🇬🇧',
   ca: '🏴',
+  'ca-ES-valencia': '🏴',
   fr: '🇫🇷',
   it: '🇮🇹',
   pt: '🇵🇹',

--- a/src/app/i18n/translation.service.ts
+++ b/src/app/i18n/translation.service.ts
@@ -3,6 +3,7 @@ import { isPlatformBrowser } from '@angular/common';
 import { PLATFORM_ID } from '@angular/core';
 
 import ca from './translations/ca.json';
+import caValencia from './translations/ca-ES-valencia.json';
 import de from './translations/de.json';
 import en from './translations/en.json';
 import es from './translations/es-ES.json';
@@ -10,7 +11,7 @@ import fr from './translations/fr.json';
 import it from './translations/it.json';
 import pt from './translations/pt.json';
 
-export const LANGUAGES = ['es-ES', 'en', 'ca', 'fr', 'it', 'pt', 'de'] as const;
+export const LANGUAGES = ['es-ES', 'en', 'ca', 'ca-ES-valencia', 'fr', 'it', 'pt', 'de'] as const;
 export type Language = (typeof LANGUAGES)[number];
 
 type TranslationRecord = typeof es;
@@ -19,6 +20,7 @@ const TRANSLATIONS: Record<Language, TranslationRecord> = {
   'es-ES': es,
   en,
   ca,
+  'ca-ES-valencia': caValencia,
   fr,
   it,
   pt,

--- a/src/app/i18n/translations/ca-ES-valencia.json
+++ b/src/app/i18n/translations/ca-ES-valencia.json
@@ -5,7 +5,7 @@
     "languageAriaLabel": "Selecciona l'idioma de l'aplicació",
     "languages": {
       "es-ES": "Espanyol",
-      "en": "Anglès",
+      "en": "Anglés",
       "ca": "Català",
       "ca-ES-valencia": "Valencià",
       "fr": "Francès",
@@ -21,7 +21,7 @@
     },
     "upload": {
       "title": "Carrega el teu PDF",
-      "subtitle": "Arrossega i deixa anar el fitxer aquí o fes clic per cercar",
+      "subtitle": "Arrossega i deixa anar el fitxer ací o fes clic per cercar",
       "hint": "Només PDF",
       "invalidFormat": "Només s'admeten fitxers PDF."
     },
@@ -60,7 +60,7 @@
     "title": "Anotacions (JSON)",
     "importJsonFile": "Importa des d'un fitxer",
     "applyJson": "Aplica el JSON",
-    "jsonPlaceholder": "Enganxa o edita aquí les coordenades de les anotacions...",
+    "jsonPlaceholder": "Enganxa o edita ací les coordenades de les anotacions...",
     "jsonTree": {
       "empty": "L'editor JSON és buit.",
       "invalid": "El contingut no és un JSON vàlid. Corregeix els errors per veure l'arbre."

--- a/src/app/i18n/translations/de.json
+++ b/src/app/i18n/translations/de.json
@@ -7,6 +7,7 @@
       "es-ES": "Spanisch",
       "en": "Englisch",
       "ca": "Katalanisch",
+      "ca-ES-valencia": "Valencianisch",
       "fr": "Französisch",
       "it": "Italienisch",
       "pt": "Portugiesisch",

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -7,6 +7,7 @@
       "es-ES": "Spanish",
       "en": "English",
       "ca": "Catalan",
+      "ca-ES-valencia": "Valencian",
       "fr": "French",
       "it": "Italian",
       "pt": "Portuguese",

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -7,6 +7,7 @@
       "es-ES": "Español",
       "en": "Inglés",
       "ca": "Catalán",
+      "ca-ES-valencia": "Valenciano",
       "fr": "Francés",
       "it": "Italiano",
       "pt": "Portugués",

--- a/src/app/i18n/translations/fr.json
+++ b/src/app/i18n/translations/fr.json
@@ -7,6 +7,7 @@
       "es-ES": "Espagnol",
       "en": "Anglais",
       "ca": "Catalan",
+      "ca-ES-valencia": "Valencien",
       "fr": "Français",
       "it": "Italien",
       "pt": "Portugais",

--- a/src/app/i18n/translations/it.json
+++ b/src/app/i18n/translations/it.json
@@ -7,6 +7,7 @@
       "es-ES": "Spagnolo",
       "en": "Inglese",
       "ca": "Catalano",
+      "ca-ES-valencia": "Valenziano",
       "fr": "Francese",
       "it": "Italiano",
       "pt": "Portoghese",

--- a/src/app/i18n/translations/pt.json
+++ b/src/app/i18n/translations/pt.json
@@ -7,6 +7,7 @@
       "es-ES": "Espanhol",
       "en": "Inglês",
       "ca": "Catalão",
+      "ca-ES-valencia": "Valenciano",
       "fr": "Francês",
       "it": "Italiano",
       "pt": "Português",


### PR DESCRIPTION
## Summary
- add Valencian translation bundle and register it in the translation service
- expose Valencian as a selectable language label across existing locales

## Testing
- npm run i18n:check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692896e602848325861b9292336e6fd4)