### PR TITLE
Add live test modal on landing page

### DIFF
--- a/src/app/pages/landing/landing.page.html
+++ b/src/app/pages/landing/landing.page.html
@@ -1,4 +1,20 @@
 <div class="app app--landing">
+  <div
+    *ngIf="showLiveTestModal"
+    class="landing-modal-backdrop"
+    role="dialog"
+    aria-modal="true"
+    aria-label="Aviso de prueba en directo"
+  >
+    <div class="landing-modal">
+      <button class="landing-modal__close" type="button" (click)="closeLiveTestModal()" aria-label="Cerrar aviso">
+        ×
+      </button>
+      <h2 class="landing-modal__title">¡Estoy probando esto en directo!!</h2>
+      <p class="landing-modal__subtitle">Disculpa las molestias mientras realizo esta prueba en vivo.</p>
+    </div>
+  </div>
+
   <section class="landing">
     <app-landing-language-bar [languages]="languages" [selectedLanguage]="languageModel"
       (languageChange)="onLanguageChange($event)"></app-landing-language-bar>

--- a/src/app/pages/landing/landing.page.scss
+++ b/src/app/pages/landing/landing.page.scss
@@ -1,0 +1,68 @@
+.landing-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  background: rgba(12, 14, 26, 0.75);
+  backdrop-filter: blur(6px);
+  z-index: 1000;
+}
+
+.landing-modal {
+  position: relative;
+  width: min(640px, 100%);
+  padding: 2.5rem 2.75rem;
+  border-radius: 18px;
+  background: #ffffff;
+  color: #0c0e1a;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.25);
+  text-align: center;
+}
+
+.landing-modal__title {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.5rem, 2vw + 1rem, 2.25rem);
+  font-weight: 800;
+  letter-spacing: 0.01em;
+}
+
+.landing-modal__subtitle {
+  margin: 0;
+  font-size: 1rem;
+  color: rgba(12, 14, 26, 0.75);
+}
+
+.landing-modal__close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  width: 2.25rem;
+  height: 2.25rem;
+  border: none;
+  border-radius: 50%;
+  background: rgba(12, 14, 26, 0.06);
+  color: #0c0e1a;
+  font-size: 1.25rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.landing-modal__close:hover,
+.landing-modal__close:focus-visible {
+  background: rgba(12, 14, 26, 0.12);
+  transform: translateY(-1px);
+}
+
+@media (max-width: 600px) {
+  .landing-modal {
+    padding: 2rem;
+  }
+
+  .landing-modal__close {
+    top: 0.75rem;
+    right: 0.75rem;
+  }
+}

--- a/src/app/pages/landing/landing.page.ts
+++ b/src/app/pages/landing/landing.page.ts
@@ -37,6 +37,7 @@ export class LandingPageComponent {
   readonly languages: readonly Language[] = this.translationService.supportedLanguages;
   languageModel: Language = this.translationService.getCurrentLanguage();
   readonly fileDropActive = signal(false);
+  showLiveTestModal = true;
 
   @ViewChild(LandingDropzoneComponent)
   private landingDropzoneComponent?: LandingDropzoneComponent;
@@ -104,6 +105,10 @@ export class LandingPageComponent {
     }
 
     await this.handleFileSelection(file);
+  }
+
+  closeLiveTestModal() {
+    this.showLiveTestModal = false;
   }
 
   private async handleFileSelection(file: File) {


### PR DESCRIPTION
## Summary
- add a prominent modal on the landing page announcing the live test message
- include dismiss control and accessibility attributes for the modal dialog
- add styling for the modal backdrop, layout, and responsive spacing

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929a5ef3ea88325a0ed2f5419976239)