### PR TITLE
fix: use PDF coordinates by default for guide inputs

### DIFF
--- a/src/app/models/guide-settings.model.ts
+++ b/src/app/models/guide-settings.model.ts
@@ -27,7 +27,7 @@ export const DEFAULT_GUIDE_SETTINGS: GuideSettings = {
   snapTolerance: 8,
   snapPointsX: [],
   snapPointsY: [],
-  usePdfCoordinates: false,
+  usePdfCoordinates: true,
 };
 
 export function cloneGuideSettings(settings: GuideSettings): GuideSettings {

--- a/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.html
+++ b/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.html
@@ -81,7 +81,8 @@
   </section>
   <ng-container *ngIf="vm.jsonViewMode() === 'text'; else jsonTreeView">
     <textarea #jsonEditor class="json-editor" [ngModel]="vm.coordsTextModel"
-      (ngModelChange)="vm.onCoordsTextChange($event)" [placeholder]="'sidebar.jsonPlaceholder' | t" spellcheck="false"></textarea>
+      (ngModelChange)="vm.onCoordsTextChange($event)" (paste)="vm.onCoordsTextPaste()"
+      [placeholder]="'sidebar.jsonPlaceholder' | t" spellcheck="false"></textarea>
   </ng-container>
   <ng-template #jsonTreeView>
     <div *ngIf="vm.jsonTreePreview.status === 'ready'; else jsonTreePlaceholder" class="json-tree-container">

--- a/src/app/pages/workspace/workspace.page.ts
+++ b/src/app/pages/workspace/workspace.page.ts
@@ -99,6 +99,8 @@ interface JsonTreePreview {
   value: unknown | null;
 }
 
+const AUTO_APPLY_JSON_DELAY_MS = 300;
+
 type OverlayGuide = {
   orientation: 'horizontal' | 'vertical';
   position: number;
@@ -203,6 +205,7 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
   private readonly coordsFileInputChangeHandler = (event: Event) =>
     this.onCoordsFileSelected(event);
   private coordsFileInputFallback: HTMLInputElement | null = null;
+  private autoApplyCoordsTimer: ReturnType<typeof setTimeout> | null = null;
 
   private dragInfo: {
     pageIndex: number;
@@ -336,6 +339,10 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
 
   ngOnDestroy() {
     this.revokeThumbnailUrls();
+    if (this.autoApplyCoordsTimer) {
+      clearTimeout(this.autoApplyCoordsTimer);
+      this.autoApplyCoordsTimer = null;
+    }
     if (!this.document) {
       return;
     }
@@ -3271,6 +3278,11 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
   onCoordsTextChange(value: string) {
     this.coordsTextModel = value;
     this.refreshJsonPreview();
+    this.scheduleCoordsAutoApply();
+  }
+
+  onCoordsTextPaste() {
+    this.scheduleCoordsAutoApply(0);
   }
 
   setJsonViewMode(mode: JsonViewMode) {
@@ -3291,11 +3303,28 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
   }
 
   applyCoordsText() {
+    this.tryApplyCoordsText({ silent: false, clearWhenEmpty: true });
+  }
+
+  private scheduleCoordsAutoApply(delayMs = AUTO_APPLY_JSON_DELAY_MS) {
+    if (this.autoApplyCoordsTimer) {
+      clearTimeout(this.autoApplyCoordsTimer);
+    }
+
+    this.autoApplyCoordsTimer = setTimeout(() => {
+      this.autoApplyCoordsTimer = null;
+      this.tryApplyCoordsText({ silent: true, clearWhenEmpty: false });
+    }, delayMs);
+  }
+
+  private tryApplyCoordsText(options: { silent: boolean; clearWhenEmpty: boolean }): boolean {
     const text = this.coordsTextModel.trim();
 
     if (!text) {
-      this.clearAll();
-      return;
+      if (options.clearWhenEmpty) {
+        this.clearAll();
+      }
+      return false;
     }
 
     try {
@@ -3307,9 +3336,13 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
       }
 
       this.replaceCoords(normalized);
+      return true;
     } catch (error) {
-      console.error('No se pudo importar el JSON de anotaciones.', error);
-      alert('No se pudo importar el archivo JSON. Comprueba que el formato sea correcto.');
+      if (!options.silent) {
+        console.error('No se pudo importar el JSON de anotaciones.', error);
+        alert('No se pudo importar el archivo JSON. Comprueba que el formato sea correcto.');
+      }
+      return false;
     }
   }
 

--- a/src/app/pages/workspace/workspace.page.ts
+++ b/src/app/pages/workspace/workspace.page.ts
@@ -1784,6 +1784,37 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
     this.closeFontDropdown('edit');
   }
 
+  @HostListener('document:keydown', ['$event'])
+  onGlobalKeydown(event: KeyboardEvent) {
+    const key = event.key.toLowerCase();
+    const hasPrimaryModifier = event.ctrlKey || event.metaKey;
+
+    if (!hasPrimaryModifier) {
+      return;
+    }
+
+    if (key === 's') {
+      event.preventDefault();
+      this.applyCoordsText();
+      return;
+    }
+
+    if (key === 'z' && !event.shiftKey) {
+      if (this.canUndo()) {
+        event.preventDefault();
+        this.undo();
+      }
+      return;
+    }
+
+    if (key === 'y' || (key === 'z' && event.shiftKey)) {
+      if (this.canRedo()) {
+        event.preventDefault();
+        this.redo();
+      }
+    }
+  }
+
   @HostListener('document:mousedown', ['$event'])
   onDocumentMouseDown(event: MouseEvent) {
     const editState = this.editing();


### PR DESCRIPTION
### Motivation
- Imported annotation JSON commonly uses PDF coordinate space (origin at bottom-left), while the app was defaulting to canvas coordinates, causing imported fields to appear misplaced or not visible.

### Description
- Set `DEFAULT_GUIDE_SETTINGS.usePdfCoordinates` to `true` in `src/app/models/guide-settings.model.ts` so coordinates in `{ pages: [...] }` are interpreted as PDF-space by default.

### Testing
- Ran `npm run i18n:check` which passed.
- Attempted `npm -s run -q lint` but it failed because a `lint` script is not defined in this repository (not a build blocker for this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b17596dc0c8325896ad8a053ff7991)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Auto-apply JSON coordinates after changes or paste operations with configurable delay
  * Global keyboard shortcuts: Ctrl/Cmd+S to save/apply coordinates, Ctrl/Cmd+Z to undo, Ctrl/Cmd+Y or Ctrl/Cmd+Shift+Z to redo

* **Changes**
  * Updated default PDF coordinate setting to improve baseline configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->