### PR TITLE
feat: add collapsible JSON panel in workspace sidebar

### DIFF
--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -88,7 +88,9 @@
     "advancedTitle": "Opcions avançades",
     "advancedHint": "Activa les guies i el snapping només quan necessitis més precisió.",
     "jsonPanelHide": "Hide JSON",
-    "jsonPanelShow": "Show JSON"
+    "jsonPanelShow": "Show JSON",
+    "minimizeSidebar": "Minimize sidebar",
+    "expandSidebar": "Expand sidebar"
   },
   "guides": {
     "enableFeature": "Activa les guies i el snapping",

--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -86,7 +86,9 @@
     },
     "jsonHint": "Enganxa les coordenades o importa-les des d'un fitxer JSON amb el mateix format que l'exportat.",
     "advancedTitle": "Opcions avançades",
-    "advancedHint": "Activa les guies i el snapping només quan necessitis més precisió."
+    "advancedHint": "Activa les guies i el snapping només quan necessitis més precisió.",
+    "jsonPanelHide": "Hide JSON",
+    "jsonPanelShow": "Show JSON"
   },
   "guides": {
     "enableFeature": "Activa les guies i el snapping",

--- a/src/app/i18n/translations/de.json
+++ b/src/app/i18n/translations/de.json
@@ -86,7 +86,9 @@
     },
     "jsonHint": "Fügen Sie Koordinaten ein oder importieren Sie sie aus einer JSON-Datei mit demselben Format wie die exportierten Daten.",
     "advancedTitle": "Erweiterte Optionen",
-    "advancedHint": "Aktivieren Sie Hilfslinien und Einrast-Hilfen nur bei Bedarf für mehr Präzision."
+    "advancedHint": "Aktivieren Sie Hilfslinien und Einrast-Hilfen nur bei Bedarf für mehr Präzision.",
+    "jsonPanelHide": "Hide JSON",
+    "jsonPanelShow": "Show JSON"
   },
   "guides": {
     "enableFeature": "Hilfslinien & Einrasten aktivieren",

--- a/src/app/i18n/translations/de.json
+++ b/src/app/i18n/translations/de.json
@@ -88,7 +88,9 @@
     "advancedTitle": "Erweiterte Optionen",
     "advancedHint": "Aktivieren Sie Hilfslinien und Einrast-Hilfen nur bei Bedarf für mehr Präzision.",
     "jsonPanelHide": "Hide JSON",
-    "jsonPanelShow": "Show JSON"
+    "jsonPanelShow": "Show JSON",
+    "minimizeSidebar": "Minimize sidebar",
+    "expandSidebar": "Expand sidebar"
   },
   "guides": {
     "enableFeature": "Hilfslinien & Einrasten aktivieren",

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -86,7 +86,9 @@
     },
     "jsonHint": "Paste coordinates or import them from a JSON file following the same format as the exported data.",
     "advancedTitle": "Advanced options",
-    "advancedHint": "Toggle guides and snapping helpers when you need extra precision."
+    "advancedHint": "Toggle guides and snapping helpers when you need extra precision.",
+    "jsonPanelHide": "Hide JSON",
+    "jsonPanelShow": "Show JSON"
   },
   "guides": {
     "enableFeature": "Enable guides & snapping",

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -88,7 +88,9 @@
     "advancedTitle": "Advanced options",
     "advancedHint": "Toggle guides and snapping helpers when you need extra precision.",
     "jsonPanelHide": "Hide JSON",
-    "jsonPanelShow": "Show JSON"
+    "jsonPanelShow": "Show JSON",
+    "minimizeSidebar": "Minimize sidebar",
+    "expandSidebar": "Expand sidebar"
   },
   "guides": {
     "enableFeature": "Enable guides & snapping",

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -88,7 +88,9 @@
     "advancedTitle": "Opciones avanzadas",
     "advancedHint": "Activa las guías y el snapping solo cuando necesites más precisión.",
     "jsonPanelHide": "Ocultar JSON",
-    "jsonPanelShow": "Mostrar JSON"
+    "jsonPanelShow": "Mostrar JSON",
+    "minimizeSidebar": "Minimizar barra lateral",
+    "expandSidebar": "Expandir barra lateral"
   },
   "guides": {
     "enableFeature": "Activar guías y snapping",

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -86,7 +86,9 @@
     },
     "jsonHint": "Pega las coordenadas o impórtalas desde un JSON con el mismo formato que el archivo exportado.",
     "advancedTitle": "Opciones avanzadas",
-    "advancedHint": "Activa las guías y el snapping solo cuando necesites más precisión."
+    "advancedHint": "Activa las guías y el snapping solo cuando necesites más precisión.",
+    "jsonPanelHide": "Ocultar JSON",
+    "jsonPanelShow": "Mostrar JSON"
   },
   "guides": {
     "enableFeature": "Activar guías y snapping",

--- a/src/app/i18n/translations/fr.json
+++ b/src/app/i18n/translations/fr.json
@@ -88,7 +88,9 @@
     "advancedTitle": "Options avancées",
     "advancedHint": "Activez les guides et les aides d'alignement uniquement lorsque vous avez besoin de plus de précision.",
     "jsonPanelHide": "Hide JSON",
-    "jsonPanelShow": "Show JSON"
+    "jsonPanelShow": "Show JSON",
+    "minimizeSidebar": "Minimize sidebar",
+    "expandSidebar": "Expand sidebar"
   },
   "guides": {
     "enableFeature": "Activer guides et aimantation",

--- a/src/app/i18n/translations/fr.json
+++ b/src/app/i18n/translations/fr.json
@@ -86,7 +86,9 @@
     },
     "jsonHint": "Collez les coordonnées ou importez-les depuis un JSON en suivant le même format que les données exportées.",
     "advancedTitle": "Options avancées",
-    "advancedHint": "Activez les guides et les aides d'alignement uniquement lorsque vous avez besoin de plus de précision."
+    "advancedHint": "Activez les guides et les aides d'alignement uniquement lorsque vous avez besoin de plus de précision.",
+    "jsonPanelHide": "Hide JSON",
+    "jsonPanelShow": "Show JSON"
   },
   "guides": {
     "enableFeature": "Activer guides et aimantation",

--- a/src/app/i18n/translations/it.json
+++ b/src/app/i18n/translations/it.json
@@ -86,7 +86,9 @@
     },
     "jsonHint": "Incolla le coordinate o importale da un JSON seguendo lo stesso formato dei dati esportati.",
     "advancedTitle": "Opzioni avanzate",
-    "advancedHint": "Attiva guide e agganci solo quando ti serve maggiore precisione."
+    "advancedHint": "Attiva guide e agganci solo quando ti serve maggiore precisione.",
+    "jsonPanelHide": "Hide JSON",
+    "jsonPanelShow": "Show JSON"
   },
   "guides": {
     "enableFeature": "Attiva guide e agganci",

--- a/src/app/i18n/translations/it.json
+++ b/src/app/i18n/translations/it.json
@@ -88,7 +88,9 @@
     "advancedTitle": "Opzioni avanzate",
     "advancedHint": "Attiva guide e agganci solo quando ti serve maggiore precisione.",
     "jsonPanelHide": "Hide JSON",
-    "jsonPanelShow": "Show JSON"
+    "jsonPanelShow": "Show JSON",
+    "minimizeSidebar": "Minimize sidebar",
+    "expandSidebar": "Expand sidebar"
   },
   "guides": {
     "enableFeature": "Attiva guide e agganci",

--- a/src/app/i18n/translations/pt.json
+++ b/src/app/i18n/translations/pt.json
@@ -86,7 +86,9 @@
     },
     "jsonHint": "Cole as coordenadas ou importe-as de um JSON com o mesmo formato dos dados exportados.",
     "advancedTitle": "Opções avançadas",
-    "advancedHint": "Ative as guias e os auxiliares de alinhamento apenas quando precisar de mais precisão."
+    "advancedHint": "Ative as guias e os auxiliares de alinhamento apenas quando precisar de mais precisão.",
+    "jsonPanelHide": "Hide JSON",
+    "jsonPanelShow": "Show JSON"
   },
   "guides": {
     "enableFeature": "Ativar guias e encaixes",

--- a/src/app/i18n/translations/pt.json
+++ b/src/app/i18n/translations/pt.json
@@ -88,7 +88,9 @@
     "advancedTitle": "Opções avançadas",
     "advancedHint": "Ative as guias e os auxiliares de alinhamento apenas quando precisar de mais precisão.",
     "jsonPanelHide": "Hide JSON",
-    "jsonPanelShow": "Show JSON"
+    "jsonPanelShow": "Show JSON",
+    "minimizeSidebar": "Minimize sidebar",
+    "expandSidebar": "Expand sidebar"
   },
   "guides": {
     "enableFeature": "Ativar guias e encaixes",

--- a/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.html
+++ b/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.html
@@ -1,4 +1,12 @@
-<aside class="sidebar">
+<aside class="sidebar" [class.sidebar--minimized]="vm.sidebarMinimized()">
+  <button type="button" class="sidebar-minimize-toggle"
+    (click)="vm.toggleSidebarMinimized()"
+    [attr.aria-label]="(vm.sidebarMinimized() ? 'sidebar.expandSidebar' : 'sidebar.minimizeSidebar') | t"
+    [attr.title]="(vm.sidebarMinimized() ? 'sidebar.expandSidebar' : 'sidebar.minimizeSidebar') | t">
+    <span aria-hidden="true">{{ vm.sidebarMinimized() ? '⟩' : '⟨' }}</span>
+  </button>
+
+  <div class="sidebar-content" *ngIf="!vm.sidebarMinimized()">
   <div class="json-coords" role="status" [attr.aria-label]="'controls.cursorLabel' | t">
     <ng-container *ngIf="vm.cursorPdfCoords() as cursor; else coordsIdle">
       <span class="json-coords__label">{{ 'controls.cursorLabel' | t }}</span>
@@ -280,4 +288,5 @@
       </div>
     </ng-container>
   </section>
+  </div>
 </aside>

--- a/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.html
+++ b/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.html
@@ -26,7 +26,6 @@
     </div>
     <span class="sidebar-upload__hint">{{ 'app.upload.hint' | t }}</span>
   </section>
-  <h4>{{ 'sidebar.title' | t }}</h4>
   <div class="sidebar-actions">
     <button type="button" class="btn" (click)="vm.triggerImportCoords()">
       {{ 'sidebar.importJsonFile' | t }}
@@ -79,44 +78,62 @@
       <p class="templates__empty">{{ 'sidebar.templates.empty' | t }}</p>
     </ng-template>
   </section>
-  <ng-container *ngIf="vm.jsonViewMode() === 'text'; else jsonTreeView">
-    <textarea #jsonEditor class="json-editor" [ngModel]="vm.coordsTextModel"
-      (ngModelChange)="vm.onCoordsTextChange($event)" (paste)="vm.onCoordsTextPaste()"
-      [placeholder]="'sidebar.jsonPlaceholder' | t" spellcheck="false"></textarea>
-  </ng-container>
-  <ng-template #jsonTreeView>
-    <div *ngIf="vm.jsonTreePreview.status === 'ready'; else jsonTreePlaceholder" class="json-tree-container">
-      <app-json-tree #jsonTree [value]="vm.jsonTreePreview.value"></app-json-tree>
+  <section class="json-panel" [class.json-panel--collapsed]="vm.jsonPanelCollapsed()">
+    <div class="json-panel__header">
+      <h5 class="json-panel__title">{{ 'sidebar.title' | t }}</h5>
+      <button type="button" class="json-panel__toggle" (click)="vm.toggleJsonPanelCollapsed()"
+        [attr.aria-expanded]="!vm.jsonPanelCollapsed()">
+        <span>{{ (vm.jsonPanelCollapsed() ? 'sidebar.jsonPanelShow' : 'sidebar.jsonPanelHide') | t }}</span>
+        <span class="json-panel__toggle-icon" aria-hidden="true">{{ vm.jsonPanelCollapsed() ? '⟩' : '⟨' }}</span>
+      </button>
     </div>
-    <ng-template #jsonTreePlaceholder>
-      <div class="json-tree-placeholder">
-        <p *ngIf="vm.jsonTreePreview.status === 'empty'">{{ 'sidebar.jsonTree.empty' | t }}</p>
-        <p *ngIf="vm.jsonTreePreview.status === 'error'">{{ 'sidebar.jsonTree.invalid' | t }}</p>
+
+    <ng-container *ngIf="!vm.jsonPanelCollapsed()">
+      <ng-container *ngIf="vm.jsonViewMode() === 'text'; else jsonTreeView">
+        <textarea #jsonEditor class="json-editor" [ngModel]="vm.coordsTextModel"
+          (ngModelChange)="vm.onCoordsTextChange($event)" (paste)="vm.onCoordsTextPaste()"
+          [placeholder]="'sidebar.jsonPlaceholder' | t" spellcheck="false"></textarea>
+      </ng-container>
+      <ng-template #jsonTreeView>
+        <div *ngIf="vm.jsonTreePreview.status === 'ready'; else jsonTreePlaceholder" class="json-tree-container">
+          <app-json-tree #jsonTree [value]="vm.jsonTreePreview.value"></app-json-tree>
+        </div>
+        <ng-template #jsonTreePlaceholder>
+          <div class="json-tree-placeholder">
+            <p *ngIf="vm.jsonTreePreview.status === 'empty'">{{ 'sidebar.jsonTree.empty' | t }}</p>
+            <p *ngIf="vm.jsonTreePreview.status === 'error'">{{ 'sidebar.jsonTree.invalid' | t }}</p>
+          </div>
+        </ng-template>
+      </ng-template>
+      <div class="json-toolbar">
+        <div class="json-toolbar__view-toggle-group" role="group"
+          [attr.aria-label]="'controls.jsonViewModeToggle' | t">
+          <button type="button" class="json-toolbar__view-toggle-option"
+            [class.json-toolbar__view-toggle-option--active]="vm.jsonViewMode() === 'text'"
+            (click)="vm.setJsonViewMode('text')" [attr.aria-pressed]="vm.jsonViewMode() === 'text'">
+            <span class="json-toolbar__view-toggle-icon" aria-hidden="true">📝</span>
+            <span>{{ 'controls.viewJsonText' | t }}</span>
+          </button>
+          <button type="button" class="json-toolbar__view-toggle-option"
+            [class.json-toolbar__view-toggle-option--active]="vm.jsonViewMode() === 'tree'"
+            (click)="vm.setJsonViewMode('tree')" [attr.aria-pressed]="vm.jsonViewMode() === 'tree'">
+            <span class="json-toolbar__view-toggle-icon" aria-hidden="true">🌳</span>
+            <span>{{ 'controls.viewJsonTree' | t }}</span>
+          </button>
+        </div>
+        <button type="button" class="btn" (click)="vm.copyJSON()"
+          [disabled]="!vm.coords().length">{{ 'controls.copyJson' | t }}</button>
+        <button type="button" class="btn" (click)="vm.downloadJSON()"
+          [disabled]="!vm.coords().length">{{ 'controls.downloadJson' | t }}</button>
       </div>
-    </ng-template>
-  </ng-template>
-  <div class="json-toolbar">
-    <div class="json-toolbar__view-toggle-group" role="group"
-      [attr.aria-label]="'controls.jsonViewModeToggle' | t">
-      <button type="button" class="json-toolbar__view-toggle-option"
-        [class.json-toolbar__view-toggle-option--active]="vm.jsonViewMode() === 'text'"
-        (click)="vm.setJsonViewMode('text')" [attr.aria-pressed]="vm.jsonViewMode() === 'text'">
-        <span class="json-toolbar__view-toggle-icon" aria-hidden="true">📝</span>
-        <span>{{ 'controls.viewJsonText' | t }}</span>
-      </button>
-      <button type="button" class="json-toolbar__view-toggle-option"
-        [class.json-toolbar__view-toggle-option--active]="vm.jsonViewMode() === 'tree'"
-        (click)="vm.setJsonViewMode('tree')" [attr.aria-pressed]="vm.jsonViewMode() === 'tree'">
-        <span class="json-toolbar__view-toggle-icon" aria-hidden="true">🌳</span>
-        <span>{{ 'controls.viewJsonTree' | t }}</span>
-      </button>
-    </div>
-    <button type="button" class="btn" (click)="vm.copyJSON()"
-      [disabled]="!vm.coords().length">{{ 'controls.copyJson' | t }}</button>
-    <button type="button" class="btn" (click)="vm.downloadJSON()"
-      [disabled]="!vm.coords().length">{{ 'controls.downloadJson' | t }}</button>
-  </div>
-  <small class="sidebar-hint">{{ 'sidebar.jsonHint' | t }}</small>
+      <small class="sidebar-hint">{{ 'sidebar.jsonHint' | t }}</small>
+    </ng-container>
+  </section>
+
+  <button *ngIf="vm.jsonPanelCollapsed()" type="button" class="json-panel__restore"
+    (click)="vm.setJsonPanelCollapsed(false)">
+    {{ 'sidebar.jsonPanelShow' | t }}
+  </button>
 
   <section class="advanced-panel" [class.open]="vm.advancedOptionsOpen()"
     [class.active]="vm.guidesFeatureEnabled() || vm.customFontsFeatureEnabled()">

--- a/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.scss
+++ b/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.scss
@@ -107,3 +107,39 @@
 .json-panel__restore {
   margin-top: 8px;
 }
+
+.sidebar {
+  position: relative;
+}
+
+.sidebar-content {
+  min-width: 0;
+}
+
+.sidebar-minimize-toggle {
+  position: sticky;
+  top: 8px;
+  z-index: 2;
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  border: 1px solid rgba(94, 234, 212, 0.35);
+  background: rgba(94, 234, 212, 0.1);
+  color: var(--accent);
+  cursor: pointer;
+}
+
+.sidebar--minimized {
+  padding: 10px 8px;
+  overflow: hidden;
+}
+
+.sidebar--minimized .sidebar-minimize-toggle {
+  margin: 0 auto;
+  width: 36px;
+  height: 36px;
+}

--- a/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.scss
+++ b/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.scss
@@ -65,3 +65,45 @@
     max-height: clamp(140px, 28vh, 300px);
   }
 }
+
+.json-panel {
+  margin-top: 8px;
+}
+
+.json-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.json-panel__title {
+  margin: 0;
+  color: var(--accent);
+  font-size: 1rem;
+}
+
+.json-panel__toggle,
+.json-panel__restore {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid rgba(94, 234, 212, 0.35);
+  border-radius: 999px;
+  padding: 4px 10px;
+  background: rgba(94, 234, 212, 0.1);
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.json-panel__toggle-icon {
+  font-size: 0.95rem;
+  line-height: 1;
+}
+
+.json-panel__restore {
+  margin-top: 8px;
+}

--- a/src/app/pages/workspace/workspace.page.html
+++ b/src/app/pages/workspace/workspace.page.html
@@ -1,4 +1,4 @@
-<div class="app">
+<div class="app" [class.app--sidebar-minimized]="vm.sidebarMinimized()">
   <app-workspace-header [vm]="vm"></app-workspace-header>
   <app-workspace-sidebar [vm]="vm"></app-workspace-sidebar>
   <app-workspace-viewer [vm]="vm"></app-workspace-viewer>

--- a/src/app/pages/workspace/workspace.page.ts
+++ b/src/app/pages/workspace/workspace.page.ts
@@ -187,6 +187,7 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
   fileDropActive = signal(false);
   readonly jsonViewMode = signal<JsonViewMode>('text');
   readonly jsonPanelCollapsed = signal(false);
+  readonly sidebarMinimized = signal(false);
   private readonly translationService = inject(TranslationService);
   private readonly document = inject(DOCUMENT);
   private readonly templatesService = inject(AnnotationTemplatesService);
@@ -269,6 +270,14 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
 
   setJsonPanelCollapsed(collapsed: boolean): void {
     this.jsonPanelCollapsed.set(collapsed);
+  }
+
+  toggleSidebarMinimized(): void {
+    this.sidebarMinimized.update((current) => !current);
+  }
+
+  setSidebarMinimized(minimized: boolean): void {
+    this.sidebarMinimized.set(minimized);
   }
 
   get previewFontSearchRef(): ElementRef<HTMLInputElement> | undefined {

--- a/src/app/pages/workspace/workspace.page.ts
+++ b/src/app/pages/workspace/workspace.page.ts
@@ -186,6 +186,7 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
   snapPointsYText = signal('');
   fileDropActive = signal(false);
   readonly jsonViewMode = signal<JsonViewMode>('text');
+  readonly jsonPanelCollapsed = signal(false);
   private readonly translationService = inject(TranslationService);
   private readonly document = inject(DOCUMENT);
   private readonly templatesService = inject(AnnotationTemplatesService);
@@ -260,6 +261,14 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
 
   get editFontDropdownRef(): ElementRef<HTMLDivElement> | undefined {
     return this.viewerComponent?.editFontDropdownRef;
+  }
+
+  toggleJsonPanelCollapsed(): void {
+    this.jsonPanelCollapsed.update((current) => !current);
+  }
+
+  setJsonPanelCollapsed(collapsed: boolean): void {
+    this.jsonPanelCollapsed.set(collapsed);
   }
 
   get previewFontSearchRef(): ElementRef<HTMLInputElement> | undefined {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -54,6 +54,10 @@ body {
   padding: 12px;
 }
 
+.app--sidebar-minimized {
+  grid-template-columns: 72px minmax(0, 1fr);
+}
+
 .app--landing {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
### Motivation

- Permitir ocultar/guardar el área de JSON para dar más espacio y enfocarse mejor en la vista del PDF; al colapsar aparece una mini barra para volver a desplegar el panel.

### Description

- Añadido el estado `jsonPanelCollapsed` y los métodos `toggleJsonPanelCollapsed` y `setJsonPanelCollapsed` en `WorkspacePageComponent` para controlar el estado del panel JSON.
- Reestructurado el HTML del sidebar en `workspace-sidebar.component.html` para envolver el editor/preview JSON en una sección `.json-panel` con cabecera de toggle y un botón compacto de restauración cuando está colapsado.
- Añadidos estilos en `workspace-sidebar.component.scss` para la cabecera, el toggle y la mini barra de restauración (`.json-panel__*`).
- Añadidas claves de i18n `sidebar.jsonPanelHide` y `sidebar.jsonPanelShow` en los archivos de traducción para soportar los textos de ocultar/mostrar en múltiples idiomas.

### Testing

- Ejecutado `npm run build` (incluye `npm run i18n:check`) y la compilación terminó correctamente sin errores.
- Se generó una captura visual automatizada (Playwright) de la página con el panel JSON colapsado para validación visual exitosa.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b19bfb4cfc8325ba43a30c51522dde)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* The sidebar can now be minimized and expanded for a more compact view
* The JSON panel can be collapsed and expanded independently
* Added a footer section to the workspace page

**Documentation**
* Added multi-language support for new UI controls (Catalan, German, English, Spanish, French, Italian, Portuguese)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->