### PR TITLE
Export JSON: show minimal fields by default and add advanced-fields toggle

### DIFF
--- a/src/app/i18n/translations/ca.json
+++ b/src/app/i18n/translations/ca.json
@@ -87,6 +87,8 @@
     "jsonHint": "Enganxa les coordenades o importa-les des d'un fitxer JSON amb el mateix format que l'exportat.",
     "advancedTitle": "Opcions avançades",
     "advancedHint": "Activa les guies i el snapping només quan necessitis més precisió.",
+    "includeAdvancedJsonFields": "Inclou propietats avançades al JSON",
+    "includeAdvancedJsonFieldsHint": "Desactivat: només x, y, mapField, fontSize i type. Activat: també exporta color, font, opacitat, fons, bloqueig i visibilitat.",
     "jsonPanelHide": "Hide JSON",
     "jsonPanelShow": "Show JSON",
     "minimizeSidebar": "Minimize sidebar",

--- a/src/app/i18n/translations/de.json
+++ b/src/app/i18n/translations/de.json
@@ -87,6 +87,8 @@
     "jsonHint": "Fügen Sie Koordinaten ein oder importieren Sie sie aus einer JSON-Datei mit demselben Format wie die exportierten Daten.",
     "advancedTitle": "Erweiterte Optionen",
     "advancedHint": "Aktivieren Sie Hilfslinien und Einrast-Hilfen nur bei Bedarf für mehr Präzision.",
+    "includeAdvancedJsonFields": "Erweiterte Eigenschaften in JSON einschließen",
+    "includeAdvancedJsonFieldsHint": "Deaktiviert: nur x, y, mapField, fontSize und type. Aktiviert: exportiert zusätzlich Farbe, Schriftart, Deckkraft, Hintergrund, Sperre und Sichtbarkeit.",
     "jsonPanelHide": "Hide JSON",
     "jsonPanelShow": "Show JSON",
     "minimizeSidebar": "Minimize sidebar",

--- a/src/app/i18n/translations/en.json
+++ b/src/app/i18n/translations/en.json
@@ -87,6 +87,8 @@
     "jsonHint": "Paste coordinates or import them from a JSON file following the same format as the exported data.",
     "advancedTitle": "Advanced options",
     "advancedHint": "Toggle guides and snapping helpers when you need extra precision.",
+    "includeAdvancedJsonFields": "Include advanced properties in JSON",
+    "includeAdvancedJsonFieldsHint": "Disabled: only x, y, mapField, fontSize and type. Enabled: also exports color, font, opacity, background, lock and visibility.",
     "jsonPanelHide": "Hide JSON",
     "jsonPanelShow": "Show JSON",
     "minimizeSidebar": "Minimize sidebar",

--- a/src/app/i18n/translations/es-ES.json
+++ b/src/app/i18n/translations/es-ES.json
@@ -87,6 +87,8 @@
     "jsonHint": "Pega las coordenadas o impórtalas desde un JSON con el mismo formato que el archivo exportado.",
     "advancedTitle": "Opciones avanzadas",
     "advancedHint": "Activa las guías y el snapping solo cuando necesites más precisión.",
+    "includeAdvancedJsonFields": "Incluir propiedades avanzadas en el JSON",
+    "includeAdvancedJsonFieldsHint": "Desactivado: solo x, y, mapField, fontSize y type. Activado: exporta también color, fuente, opacidad, fondo, bloqueo y visibilidad.",
     "jsonPanelHide": "Ocultar JSON",
     "jsonPanelShow": "Mostrar JSON",
     "minimizeSidebar": "Minimizar barra lateral",

--- a/src/app/i18n/translations/fr.json
+++ b/src/app/i18n/translations/fr.json
@@ -87,6 +87,8 @@
     "jsonHint": "Collez les coordonnées ou importez-les depuis un JSON en suivant le même format que les données exportées.",
     "advancedTitle": "Options avancées",
     "advancedHint": "Activez les guides et les aides d'alignement uniquement lorsque vous avez besoin de plus de précision.",
+    "includeAdvancedJsonFields": "Inclure les propriétés avancées dans le JSON",
+    "includeAdvancedJsonFieldsHint": "Désactivé : uniquement x, y, mapField, fontSize et type. Activé : exporte aussi la couleur, la police, l'opacité, le fond, le verrouillage et la visibilité.",
     "jsonPanelHide": "Hide JSON",
     "jsonPanelShow": "Show JSON",
     "minimizeSidebar": "Minimize sidebar",

--- a/src/app/i18n/translations/it.json
+++ b/src/app/i18n/translations/it.json
@@ -87,6 +87,8 @@
     "jsonHint": "Incolla le coordinate o importale da un JSON seguendo lo stesso formato dei dati esportati.",
     "advancedTitle": "Opzioni avanzate",
     "advancedHint": "Attiva guide e agganci solo quando ti serve maggiore precisione.",
+    "includeAdvancedJsonFields": "Includi proprietà avanzate nel JSON",
+    "includeAdvancedJsonFieldsHint": "Disattivato: solo x, y, mapField, fontSize e type. Attivato: esporta anche colore, font, opacità, sfondo, blocco e visibilità.",
     "jsonPanelHide": "Hide JSON",
     "jsonPanelShow": "Show JSON",
     "minimizeSidebar": "Minimize sidebar",

--- a/src/app/i18n/translations/pt.json
+++ b/src/app/i18n/translations/pt.json
@@ -87,6 +87,8 @@
     "jsonHint": "Cole as coordenadas ou importe-as de um JSON com o mesmo formato dos dados exportados.",
     "advancedTitle": "Opções avançadas",
     "advancedHint": "Ative as guias e os auxiliares de alinhamento apenas quando precisar de mais precisão.",
+    "includeAdvancedJsonFields": "Incluir propriedades avançadas no JSON",
+    "includeAdvancedJsonFieldsHint": "Desativado: apenas x, y, mapField, fontSize e type. Ativado: também exporta cor, fonte, opacidade, fundo, bloqueio e visibilidade.",
     "jsonPanelHide": "Hide JSON",
     "jsonPanelShow": "Show JSON",
     "minimizeSidebar": "Minimize sidebar",

--- a/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.html
+++ b/src/app/pages/workspace/components/sidebar/workspace-sidebar.component.html
@@ -195,6 +195,13 @@
         </label>
         <small class="advanced-hint">{{ 'sidebar.advancedHint' | t }}</small>
 
+        <label class="advanced-checkbox">
+          <input type="checkbox" [checked]="vm.includeAdvancedJsonFields()"
+            (change)="vm.toggleIncludeAdvancedJsonFields($event.target.checked)" />
+          <span>{{ 'sidebar.includeAdvancedJsonFields' | t }}</span>
+        </label>
+        <small class="advanced-hint">{{ 'sidebar.includeAdvancedJsonFieldsHint' | t }}</small>
+
         <section class="guides-panel" *ngIf="vm.guidesFeatureEnabled() && vm.guideSettings() as guides">
           <h5>{{ 'guides.title' | t }}</h5>
           <div class="guides-toggles">

--- a/src/app/pages/workspace/workspace.page.ts
+++ b/src/app/pages/workspace/workspace.page.ts
@@ -174,6 +174,7 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
   guidesFeatureEnabled = signal(false);
   advancedOptionsOpen = signal(false);
   customFontsFeatureEnabled = signal(false);
+  includeAdvancedJsonFields = signal(false);
   customFonts = signal<CustomFontEntry[]>([]);
   private readonly fontDropdownState = signal<Record<EditorMode, FontDropdownUiState>>({
     preview: { open: false, query: '' },
@@ -2753,14 +2754,14 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
   }
 
   private buildPageJsonBlock(page: PageAnnotations): string {
-    return JSON.stringify(page, null, 2)
+    return JSON.stringify(this.serializePageForJson(page), null, 2)
       .split('\n')
       .map((line) => `    ${line}`)
       .join('\n');
   }
 
   private buildFieldJsonBlock(field: PageField): string {
-    return JSON.stringify(field, null, 2)
+    return JSON.stringify(this.serializeFieldForJson(field), null, 2)
       .split('\n')
       .map((line) => `        ${line}`)
       .join('\n');
@@ -3324,6 +3325,15 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
     navigator.clipboard.writeText(this.coordsTextModel).catch(() => {});
   }
 
+  toggleIncludeAdvancedJsonFields(checked: boolean) {
+    if (this.includeAdvancedJsonFields() === checked) {
+      return;
+    }
+
+    this.includeAdvancedJsonFields.set(checked);
+    this.syncCoordsTextModel(false);
+  }
+
   onCoordsTextChange(value: string) {
     this.coordsTextModel = value;
     this.refreshJsonPreview();
@@ -3384,7 +3394,7 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
         throw new Error('Formato no válido');
       }
 
-      this.replaceCoords(normalized);
+      this.replaceCoords(normalized, { preserveTextModel: true });
       return true;
     } catch (error) {
       if (!options.silent) {
@@ -3421,7 +3431,7 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
         throw new Error('Formato no válido');
       }
 
-      this.replaceCoords(normalized);
+      this.replaceCoords(normalized, { preserveTextModel: true });
     } catch (error) {
       console.error('No se pudo importar el JSON de anotaciones.', error);
       alert('No se pudo importar el archivo JSON. Comprueba que el formato sea correcto.');
@@ -3431,7 +3441,7 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
   }
 
   downloadJSON() {
-    const blob = new Blob([JSON.stringify({ pages: this.coords() }, null, 2)], {
+    const blob = new Blob([this.coordsTextModel], {
       type: 'application/json',
     });
     const url = URL.createObjectURL(blob);
@@ -3742,7 +3752,7 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
 
   private syncCoordsTextModel(persist = true) {
     const currentCoords = this.coords();
-    this.coordsTextModel = JSON.stringify({ pages: currentCoords }, null, 2);
+    this.coordsTextModel = JSON.stringify(this.buildJsonExportPayload(currentCoords), null, 2);
     this.refreshJsonPreview();
     if (persist) {
       this.templatesService.storeLastCoords(currentCoords);
@@ -3756,6 +3766,39 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
     }));
   }
 
+  private buildJsonExportPayload(pages: PageAnnotations[]): {
+    pages: Array<{ num: number; fields: Array<Record<string, unknown>> }>;
+  } {
+    return {
+      pages: pages.map((page) => this.serializePageForJson(page)),
+    };
+  }
+
+  private serializePageForJson(
+    page: PageAnnotations
+  ): { num: number; fields: Array<Record<string, unknown>> } {
+    return {
+      num: page.num,
+      fields: page.fields.map((field) => this.serializeFieldForJson(field)),
+    };
+  }
+
+  private serializeFieldForJson(field: PageField): Record<string, unknown> {
+    const sanitized = this.prepareFieldForStorage(field);
+
+    if (this.includeAdvancedJsonFields()) {
+      return { ...sanitized };
+    }
+
+    return {
+      x: sanitized.x,
+      y: sanitized.y,
+      mapField: sanitized.mapField,
+      fontSize: sanitized.fontSize,
+      type: sanitized.type,
+    };
+  }
+
   private applyCoordsChange(mutator: () => void): boolean {
     const previous = this.snapshotCoords();
     mutator();
@@ -3767,7 +3810,10 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
     return changed;
   }
 
-  private replaceCoords(newCoords: PageAnnotations[], options?: { skipHistory?: boolean }) {
+  private replaceCoords(
+    newCoords: PageAnnotations[],
+    options?: { skipHistory?: boolean; preserveTextModel?: boolean }
+  ) {
     const snapshot = this.snapshotCoords(newCoords);
     if (options?.skipHistory) {
       this.coords.set(snapshot);
@@ -3776,7 +3822,11 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
     }
     this.preview.set(null);
     this.editing.set(null);
-    this.syncCoordsTextModel();
+    if (options?.preserveTextModel) {
+      this.refreshJsonPreview();
+    } else {
+      this.syncCoordsTextModel();
+    }
     this.redrawAllForPage();
   }
 


### PR DESCRIPTION
### Motivation

- Simplificar la salida del editor JSON para que por defecto exporte solo los campos relevantes (`x`, `y`, `mapField`, `fontSize`, `type`) y dejar las propiedades adicionales en una opción avanzada.

### Description

- Añadí un flag `includeAdvancedJsonFields` y el handler `toggleIncludeAdvancedJsonFields` para controlar si se incluyen las propiedades avanzadas en la exportación JSON y un checkbox en la sección de `Opciones avanzadas` del sidebar.
- Cambié la serialización del editor para usar `buildJsonExportPayload`, `serializePageForJson` y `serializeFieldForJson` y `buildPageJsonBlock`/`buildFieldJsonBlock` ahora usan esas funciones para generar el texto mostrado en el editor; por defecto `serializeFieldForJson` devuelve solo `x`, `y`, `mapField`, `fontSize` y `type`, y si `includeAdvancedJsonFields` está activado devuelve el objeto saneado completo.
- Al aplicar JSON desde el editor o importar desde archivo ahora se llama a `replaceCoords(..., { preserveTextModel: true })` para no reescribir el contenido del editor automáticamente y preservar el formato pegado por el usuario. Además `downloadJSON()` descarga exactamente el contenido actual del editor (`coordsTextModel`) en lugar de regenerarlo desde el estado interno.
- Añadí claves i18n (`sidebar.includeAdvancedJsonFields` y `sidebar.includeAdvancedJsonFieldsHint`) en los ficheros de traducción para los idiomas del proyecto y actualicé la plantilla HTML del sidebar para mostrar la opción.

### Testing

- Ejecuté `npm run build`, que incluye `i18n` check y compilación de Angular, y la build finalizó correctamente (`Translation check passed` y bundle generado). ✅
- Intenté capturar una verificación visual con Playwright pero la prueba de interacción contra el servidor local falló por timeout en el localizador; esto no impidió la compilación. ⚠️
- Levanté un servidor estático sobre el artefacto (`dist/pdf-annotator/browser`) para comprobaciones manuales de la interfaz (servidor iniciado).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1a92d5dc4832580d228daa2448f9b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a toggle option to include or exclude advanced JSON properties in exports across all supported languages.
  * When enabled, exports now include color, font, opacity, background, lock, and visibility properties in addition to standard fields.
  * When disabled, exports contain only basic fields (x, y, mapField, fontSize, type).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->