### PR TITLE
Add global Ctrl/Cmd+C and Ctrl/Cmd+V shortcuts for annotations

### DIFF
--- a/src/app/pages/workspace/workspace.page.ts
+++ b/src/app/pages/workspace/workspace.page.ts
@@ -1812,6 +1812,24 @@ export class WorkspacePageComponent implements OnInit, AfterViewChecked, OnDestr
       return;
     }
 
+    if (this.isEditableElement(event.target)) {
+      return;
+    }
+
+    if (key === 'c') {
+      if (this.copyAnnotation()) {
+        event.preventDefault();
+      }
+      return;
+    }
+
+    if (key === 'v') {
+      if (this.pasteAnnotation()) {
+        event.preventDefault();
+      }
+      return;
+    }
+
     if (key === 's') {
       event.preventDefault();
       this.applyCoordsText();


### PR DESCRIPTION
### Motivation
- Enable keyboard copy/paste of the currently selected annotation with `Ctrl/Cmd + C` and `Ctrl/Cmd + V` so users can quickly duplicate annotations without using the UI buttons.

### Description
- Added handling in `onGlobalKeydown` to intercept `c` and `v` when the primary modifier (`ctrlKey`/`metaKey`) is held and call the existing `copyAnnotation()` / `pasteAnnotation()` logic. 
- Prevented default browser behavior only when the component successfully handled the action by calling `event.preventDefault()` after `copyAnnotation()`/`pasteAnnotation()` return true. 
- Guarded the new shortcuts with `isEditableElement(event.target)` so native copy/paste remains active when focus is inside `input`, `textarea`, `select` or `contenteditable` elements. 
- Modified file: `src/app/pages/workspace/workspace.page.ts`.

### Testing
- Ran `npm run build` which includes translation checks and a production build, and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1b920f1d48325aad6775d245d032b)